### PR TITLE
Sort dealers by name ignoring case

### DIFF
--- a/Domain Model/EurofurenceModel/Private/Services/ConcreteDealersService.swift
+++ b/Domain Model/EurofurenceModel/Private/Services/ConcreteDealersService.swift
@@ -56,7 +56,9 @@ class ConcreteDealersService: DealersService {
             alphebetisedDealers = sortedGroups.map({ (arg) -> AlphabetisedDealersGroup in
                 let (index, dealers) = arg
                 return AlphabetisedDealersGroup(indexingString: index,
-                                                dealers: dealers.sorted(by: { $0.preferredName < $1.preferredName }))
+                                                dealers: dealers.sorted(by: { (first, second) -> Bool in
+                                                    return first.preferredName.lowercased() < second.preferredName.lowercased()
+                                                }))
             })
         }
 

--- a/Domain Model/EurofurenceModelTests/Dealers/WhenDealersHaveCaseVaryingNames_ApplicationShould.swift
+++ b/Domain Model/EurofurenceModelTests/Dealers/WhenDealersHaveCaseVaryingNames_ApplicationShould.swift
@@ -21,5 +21,23 @@ class WhenDealersHaveCaseVaryingNames_ApplicationShould: XCTestCase {
         XCTAssertEqual("B", group?.indexingString)
         XCTAssertEqual(2, group?.dealers.count)
     }
+    
+    func testSortIgnoringCase() {
+        var syncResponse = ModelCharacteristics.randomWithoutDeletions
+        var firstDealer = DealerCharacteristics.random
+        firstDealer.displayName = "ANGO76"
+        var secondDealer = DealerCharacteristics.random
+        secondDealer.displayName = "Aaargh"
+        syncResponse.dealers.changed = [firstDealer, secondDealer]
+        let dataStore = InMemoryDataStore(response: syncResponse)
+        let context = EurofurenceSessionTestBuilder().with(dataStore).build()
+        let dealersIndex = context.dealersService.makeDealersIndex()
+        let delegate = CapturingDealersIndexDelegate()
+        dealersIndex.setDelegate(delegate)
+        let group = delegate.capturedAlphabetisedDealerGroups.first
+        
+        XCTAssertEqual("Aaargh", group?.dealers[0].preferredName)
+        XCTAssertEqual("ANGO76", group?.dealers[1].preferredName)
+    }
 
 }


### PR DESCRIPTION
In place of literal ASCII sorting, take casing out of the equation so they’re sorted as expected