### PR TITLE
Patch up scroll-to-top behaviour

### DIFF
--- a/Eurofurence/Modules/Dealers/View/UIKit/Dealers.storyboard
+++ b/Eurofurence/Modules/Dealers/View/UIKit/Dealers.storyboard
@@ -52,6 +52,7 @@
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>
+                        <outlet property="navigationBarExtension" destination="6mj-pw-eS0" id="MEY-1A-Lj6"/>
                         <outlet property="tableView" destination="dHW-vm-Gc3" id="Syc-pg-Xns"/>
                     </connections>
                 </viewController>

--- a/Eurofurence/Modules/Dealers/View/UIKit/Dealers.storyboard
+++ b/Eurofurence/Modules/Dealers/View/UIKit/Dealers.storyboard
@@ -19,7 +19,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="dHW-vm-Gc3">
-                                <rect key="frame" x="0.0" y="64" width="375" height="554"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="618"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </tableView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6mj-pw-eS0" customClass="NavigationBarViewExtensionContainer" customModule="Eurofurence" customModuleProvider="target">
@@ -29,13 +29,13 @@
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="dHW-vm-Gc3" firstAttribute="top" secondItem="3wZ-bx-MNt" secondAttribute="top" id="Bgh-Fb-rdp"/>
+                            <constraint firstItem="dHW-vm-Gc3" firstAttribute="top" secondItem="6ea-Oq-lts" secondAttribute="top" id="Bgh-Fb-rdp"/>
                             <constraint firstItem="3wZ-bx-MNt" firstAttribute="trailing" secondItem="6mj-pw-eS0" secondAttribute="trailing" id="JAU-Yg-8wD"/>
                             <constraint firstItem="3wZ-bx-MNt" firstAttribute="trailing" secondItem="dHW-vm-Gc3" secondAttribute="trailing" id="SvV-kT-fLY"/>
                             <constraint firstItem="3wZ-bx-MNt" firstAttribute="bottom" secondItem="dHW-vm-Gc3" secondAttribute="bottom" id="Tdj-Tt-7gL"/>
                             <constraint firstItem="dHW-vm-Gc3" firstAttribute="leading" secondItem="3wZ-bx-MNt" secondAttribute="leading" id="Un9-UV-ycv"/>
                             <constraint firstItem="6mj-pw-eS0" firstAttribute="leading" secondItem="3wZ-bx-MNt" secondAttribute="leading" id="V3N-kl-xnC"/>
-                            <constraint firstItem="dHW-vm-Gc3" firstAttribute="top" secondItem="6mj-pw-eS0" secondAttribute="bottom" id="lNw-Tf-NUa"/>
+                            <constraint firstItem="3wZ-bx-MNt" firstAttribute="top" secondItem="6mj-pw-eS0" secondAttribute="bottom" id="lNw-Tf-NUa"/>
                             <constraint firstItem="6mj-pw-eS0" firstAttribute="top" secondItem="6ea-Oq-lts" secondAttribute="top" id="m8O-vV-5su"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="3wZ-bx-MNt"/>

--- a/Eurofurence/Modules/Dealers/View/UIKit/DealersSearchTableViewController.swift
+++ b/Eurofurence/Modules/Dealers/View/UIKit/DealersSearchTableViewController.swift
@@ -53,6 +53,7 @@ class DealersSearchTableViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
         onDidSelectSearchResultAtIndexPath?(indexPath)
     }
 

--- a/Eurofurence/Modules/Dealers/View/UIKit/DealersViewController.swift
+++ b/Eurofurence/Modules/Dealers/View/UIKit/DealersViewController.swift
@@ -39,6 +39,12 @@ class DealersViewController: UIViewController, UISearchControllerDelegate, UISea
         
         prepareSearchController()
         
+        if #available(iOS 11.0, *) {
+            extendedLayoutIncludesOpaqueBars = true
+        } else {
+            extendedLayoutIncludesOpaqueBars = false
+        }
+        
         delegate?.dealersSceneDidLoad()
     }
     
@@ -60,6 +66,11 @@ class DealersViewController: UIViewController, UISearchControllerDelegate, UISea
 
     func presentSearchController(_ searchController: UISearchController) {
         present(searchController, animated: true)
+    }
+    
+    func willDismissSearchController(_ searchController: UISearchController) {
+        if #available(iOS 11.0, *) { return }
+        adjustTableViewContentInsetsForiOS10LayoutProblems()
     }
 
     // MARK: UISearchResultsUpdating
@@ -107,6 +118,10 @@ class DealersViewController: UIViewController, UISearchControllerDelegate, UISea
     }
 
     // MARK: Private
+    
+    private func adjustTableViewContentInsetsForiOS10LayoutProblems() {
+        tableView.contentInset = .zero
+    }
 
     @objc private func refreshControlValueDidChange() {
         delegate?.dealersSceneDidPerformRefreshAction()

--- a/Eurofurence/Modules/Dealers/View/UIKit/DealersViewController.swift
+++ b/Eurofurence/Modules/Dealers/View/UIKit/DealersViewController.swift
@@ -5,6 +5,7 @@ class DealersViewController: UIViewController, UISearchControllerDelegate, UISea
     // MARK: Properties
 
     @IBOutlet private weak var tableView: UITableView!
+    @IBOutlet private weak var navigationBarExtension: NavigationBarViewExtensionContainer!
     private var tableController: TableController? {
         didSet {
             tableView.dataSource = tableController
@@ -63,14 +64,20 @@ class DealersViewController: UIViewController, UISearchControllerDelegate, UISea
     }
 
     // MARK: UISearchControllerDelegate
-
+    
     func presentSearchController(_ searchController: UISearchController) {
         present(searchController, animated: true)
     }
     
     func willDismissSearchController(_ searchController: UISearchController) {
+        navigationBarExtension.isHidden = true
+        
         if #available(iOS 11.0, *) { return }
         adjustTableViewContentInsetsForiOS10LayoutProblems()
+    }
+    
+    func didDismissSearchController(_ searchController: UISearchController) {
+        navigationBarExtension.isHidden = false
     }
 
     // MARK: UISearchResultsUpdating

--- a/Eurofurence/Modules/News/View/UIKit/News.storyboard
+++ b/Eurofurence/Modules/News/View/UIKit/News.storyboard
@@ -25,7 +25,7 @@
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="Ogd-Bj-WFd">
-                                <rect key="frame" x="0.0" y="88" width="375" height="641"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="729"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <view key="tableHeaderView" contentMode="scaleToFill" id="DAO-ck-zi9">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="175"/>
@@ -66,10 +66,10 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5e7-Fs-Rfc" userLabel="Icon Container">
-                                                    <rect key="frame" x="19.999999999999996" y="17" width="35.666666666666657" height="42"/>
+                                                    <rect key="frame" x="19.999999999999996" y="13.333333333333336" width="35.666666666666657" height="49"/>
                                                     <subviews>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DyR-dZ-fn1">
-                                                            <rect key="frame" x="0.0" y="0.0" width="35.666666666666664" height="42"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="35.666666666666664" height="49"/>
                                                             <accessibility key="accessibilityConfiguration">
                                                                 <bool key="isElement" value="NO"/>
                                                             </accessibility>
@@ -78,7 +78,7 @@
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Nxz-qR-aoc">
-                                                            <rect key="frame" x="0.0" y="0.0" width="35.666666666666664" height="42"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="35.666666666666664" height="49"/>
                                                             <accessibility key="accessibilityConfiguration">
                                                                 <bool key="isElement" value="NO"/>
                                                             </accessibility>
@@ -192,13 +192,13 @@
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="Ogd-Bj-WFd" firstAttribute="bottom" secondItem="HxA-JQ-dZ1" secondAttribute="bottom" id="IXW-Ey-fpB"/>
+                            <constraint firstItem="Ogd-Bj-WFd" firstAttribute="bottom" secondItem="Y7u-ae-31r" secondAttribute="bottom" id="IXW-Ey-fpB"/>
                             <constraint firstAttribute="trailing" secondItem="Se9-cw-Plh" secondAttribute="trailing" id="Ou6-tW-wox"/>
                             <constraint firstItem="Ogd-Bj-WFd" firstAttribute="trailing" secondItem="HxA-JQ-dZ1" secondAttribute="trailing" id="WAM-l1-Po1"/>
                             <constraint firstItem="Se9-cw-Plh" firstAttribute="leading" secondItem="Y7u-ae-31r" secondAttribute="leading" id="WGS-VB-RtL"/>
-                            <constraint firstItem="Ogd-Bj-WFd" firstAttribute="top" secondItem="Se9-cw-Plh" secondAttribute="bottom" id="YMN-0r-JrN"/>
+                            <constraint firstItem="HxA-JQ-dZ1" firstAttribute="top" secondItem="Se9-cw-Plh" secondAttribute="bottom" id="YMN-0r-JrN"/>
                             <constraint firstItem="Se9-cw-Plh" firstAttribute="top" secondItem="Y7u-ae-31r" secondAttribute="top" id="iF6-43-xZ4"/>
-                            <constraint firstItem="Ogd-Bj-WFd" firstAttribute="top" secondItem="HxA-JQ-dZ1" secondAttribute="top" id="m3z-Vl-l5l"/>
+                            <constraint firstItem="Ogd-Bj-WFd" firstAttribute="top" secondItem="Y7u-ae-31r" secondAttribute="top" id="m3z-Vl-l5l"/>
                             <constraint firstItem="Ogd-Bj-WFd" firstAttribute="leading" secondItem="HxA-JQ-dZ1" secondAttribute="leading" id="uvQ-e8-oIv"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="HxA-JQ-dZ1"/>

--- a/Eurofurence/Modules/Schedule/View/UIKit/Schedule.storyboard
+++ b/Eurofurence/Modules/Schedule/View/UIKit/Schedule.storyboard
@@ -19,26 +19,24 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="MGV-Hg-vha">
-                                <rect key="frame" x="0.0" y="108" width="375" height="510"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="618"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </tableView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="RuE-YL-zzB" customClass="NavigationBarViewExtensionContainer" customModule="Eurofurence" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="108"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="64"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3vS-0E-aVm" customClass="NavigationBarViewExtensionContainer" customModule="Eurofurence" customModuleProvider="target">
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3vS-0E-aVm" userLabel="Days Picker Container" customClass="NavigationBarViewExtensionContainer" customModule="Eurofurence" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="64" width="375" height="44"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KtS-4f-Pp1" customClass="DaysHorizontalPickerView" customModule="Eurofurence" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="44" id="HmB-zb-5TD"/>
-                                        </constraints>
                                     </view>
                                 </subviews>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
+                                    <constraint firstItem="KtS-4f-Pp1" firstAttribute="bottom" secondItem="Uxr-u2-IR5" secondAttribute="bottom" id="COd-7c-eOo"/>
                                     <constraint firstItem="KtS-4f-Pp1" firstAttribute="top" secondItem="3vS-0E-aVm" secondAttribute="top" id="PMt-eD-wTa"/>
                                     <constraint firstItem="KtS-4f-Pp1" firstAttribute="leading" secondItem="Uxr-u2-IR5" secondAttribute="leading" id="Pvk-E4-G4O"/>
                                     <constraint firstAttribute="height" constant="44" id="Ux8-mS-oFf"/>
@@ -55,9 +53,9 @@
                             <constraint firstItem="RuE-YL-zzB" firstAttribute="leading" secondItem="UnK-qE-skU" secondAttribute="leading" id="JFT-Ns-DqM"/>
                             <constraint firstItem="MGV-Hg-vha" firstAttribute="leading" secondItem="UnK-qE-skU" secondAttribute="leading" id="Qg3-1p-C3k"/>
                             <constraint firstItem="UnK-qE-skU" firstAttribute="trailing" secondItem="MGV-Hg-vha" secondAttribute="trailing" id="SwL-GZ-z2Z"/>
-                            <constraint firstItem="MGV-Hg-vha" firstAttribute="top" secondItem="UnK-qE-skU" secondAttribute="top" constant="44" id="j2M-nt-iFM"/>
+                            <constraint firstItem="MGV-Hg-vha" firstAttribute="top" secondItem="Jed-Ti-sU7" secondAttribute="top" id="j2M-nt-iFM"/>
                             <constraint firstAttribute="bottom" secondItem="MGV-Hg-vha" secondAttribute="bottom" id="k3U-3a-gt4"/>
-                            <constraint firstItem="RuE-YL-zzB" firstAttribute="bottom" secondItem="KtS-4f-Pp1" secondAttribute="bottom" id="m7M-oD-J7D"/>
+                            <constraint firstItem="RuE-YL-zzB" firstAttribute="bottom" secondItem="UnK-qE-skU" secondAttribute="top" id="m7M-oD-J7D"/>
                             <constraint firstItem="3vS-0E-aVm" firstAttribute="trailing" secondItem="Jed-Ti-sU7" secondAttribute="trailing" id="n3v-8z-rIx"/>
                             <constraint firstItem="3vS-0E-aVm" firstAttribute="top" secondItem="UnK-qE-skU" secondAttribute="top" id="pWh-ih-Typ"/>
                         </constraints>
@@ -76,7 +74,7 @@
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>
                         <outlet property="daysHorizontalPickerView" destination="KtS-4f-Pp1" id="YUn-aY-EU6"/>
-                        <outlet property="daysPickerTopConstraint" destination="pWh-ih-Typ" id="GjP-Q2-dHh"/>
+                        <outlet property="daysPickerTopConstraint" destination="pWh-ih-Typ" id="xfb-aQ-tSQ"/>
                         <outlet property="tableView" destination="MGV-Hg-vha" id="yqL-H1-aBt"/>
                     </connections>
                 </viewController>

--- a/Eurofurence/Modules/Schedule/View/UIKit/ScheduleViewController.swift
+++ b/Eurofurence/Modules/Schedule/View/UIKit/ScheduleViewController.swift
@@ -45,8 +45,15 @@ class ScheduleViewController: UIViewController,
         searchViewController?.onDidSelectSearchResultAtIndexPath = didSelectSearchResult
         
         var insets = tableView.contentInset
-        insets.top = 44.0
+        insets.top = daysHorizontalPickerView.bounds.height
         tableView.contentInset = insets
+        tableView.scrollIndicatorInsets = insets
+        
+        if #available(iOS 11.0, *) {
+            extendedLayoutIncludesOpaqueBars = true
+        } else {
+            extendedLayoutIncludesOpaqueBars = false
+        }
         
         tableView.refreshControl = refreshControl
         refreshControl.addTarget(self, action: #selector(refreshControlDidChangeValue), for: .valueChanged)
@@ -103,6 +110,11 @@ class ScheduleViewController: UIViewController,
     func presentSearchController(_ searchController: UISearchController) {
         resetSearchSceneForSearchingAllEvents()
         present(searchController, animated: true)
+    }
+    
+    func willDismissSearchController(_ searchController: UISearchController) {
+        if #available(iOS 11.0, *) { return }
+        adjustTableViewContentInsetsForiOS10LayoutProblems()
     }
 
     // MARK: UISearchResultsUpdating
@@ -174,6 +186,17 @@ class ScheduleViewController: UIViewController,
     }
 
     // MARK: Private
+    
+    private func adjustTableViewContentInsetsForiOS10LayoutProblems() {
+        var insets = tableView.contentInset
+        var topInsets = daysHorizontalPickerView.bounds.height
+        if let navigationBar = navigationController?.navigationBar {
+            topInsets += navigationBar.bounds.height
+        }
+        
+        insets.top = topInsets
+        tableView.contentInset = insets
+    }
 
     @objc private func refreshControlDidChangeValue() {
         delegate?.scheduleSceneDidPerformRefreshAction()

--- a/Eurofurence/Modules/Schedule/View/UIKit/ScheduleViewController.swift
+++ b/Eurofurence/Modules/Schedule/View/UIKit/ScheduleViewController.swift
@@ -44,6 +44,10 @@ class ScheduleViewController: UIViewController,
         searchViewController = storyboard?.instantiate(ScheduleSearchTableViewController.self)
         searchViewController?.onDidSelectSearchResultAtIndexPath = didSelectSearchResult
         
+        var insets = tableView.contentInset
+        insets.top = 44.0
+        tableView.contentInset = insets
+        
         tableView.refreshControl = refreshControl
         refreshControl.addTarget(self, action: #selector(refreshControlDidChangeValue), for: .valueChanged)
         
@@ -197,15 +201,12 @@ class ScheduleViewController: UIViewController,
     }
     
     private func tableViewDidScroll(to offset: CGPoint) {
-        if #available(iOS 11.0, *) {        
-            let verticalOffset: CGFloat
-            if offset.y >= 0 {
-                verticalOffset = 0
-            } else {
-                verticalOffset = abs(offset.y)
-            }
+        if #available(iOS 11.0, *) {
+            guard offset.y < 0 else { return }
             
-            daysPickerTopConstraint.constant = verticalOffset
+            let safeAreaApplyingScrollViewContentInsets = view.safeAreaLayoutGuide.layoutFrame.origin.y + tableView.contentInset.top
+            let distance = max(0, abs(offset.y) - safeAreaApplyingScrollViewContentInsets)
+            daysPickerTopConstraint.constant = distance
         }
     }
 


### PR DESCRIPTION
Some major version specific issues (10 in particular) induced from the large title changes.

Still a couple of visual annoyances left when using scroll-to-top, then tapping on search bars in iOS 11+ when the animation hasn't quite finished - can deal with later.