### PR TITLE
Fixing jittery refresh

### DIFF
--- a/Domain Model/Domain Model.xcodeproj/project.pbxproj
+++ b/Domain Model/Domain Model.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		BF91A447FA61C6354AB65ED6 /* Pods_EurofurenceModelAdapterTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3B0DDF6C8403F4E4C678F5B /* Pods_EurofurenceModelAdapterTests.framework */; };
 		CA17015022B183880067BCDE /* EurofurenceModelTestDoubles-Swift.h in Headers */ = {isa = PBXBuildFile; fileRef = CA17014F22B183880067BCDE /* EurofurenceModelTestDoubles-Swift.h */; };
 		CA17015122B188290067BCDE /* EurofurenceModelTestDoubles.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA7A326922B16E75002AD939 /* EurofurenceModelTestDoubles.framework */; };
+		CA25A87522C15F4F00226478 /* WhenRequestingStoreRefresh_MultipleTimes.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA25A87422C15F4F00226478 /* WhenRequestingStoreRefresh_MultipleTimes.swift */; };
 		CA7A2F3422B16DA3002AD939 /* EurofurenceModel.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA7A2F2B22B16DA3002AD939 /* EurofurenceModel.framework */; };
 		CA7A2FFF22B16DE4002AD939 /* EurofurenceSessionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA7A2F4322B16DE3002AD939 /* EurofurenceSessionState.swift */; };
 		CA7A300022B16DE4002AD939 /* ApplicationNotificationKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA7A2F4422B16DE3002AD939 /* ApplicationNotificationKey.swift */; };
@@ -478,6 +479,7 @@
 		A3B0DDF6C8403F4E4C678F5B /* Pods_EurofurenceModelAdapterTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_EurofurenceModelAdapterTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AD2DE387F01CB519CFFD1718 /* Pods-EurofurenceModelTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-EurofurenceModelTests.debug.xcconfig"; path = "Target Support Files/Pods-EurofurenceModelTests/Pods-EurofurenceModelTests.debug.xcconfig"; sourceTree = "<group>"; };
 		CA17014F22B183880067BCDE /* EurofurenceModelTestDoubles-Swift.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "EurofurenceModelTestDoubles-Swift.h"; sourceTree = "<group>"; };
+		CA25A87422C15F4F00226478 /* WhenRequestingStoreRefresh_MultipleTimes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhenRequestingStoreRefresh_MultipleTimes.swift; sourceTree = "<group>"; };
 		CA7A2F2B22B16DA3002AD939 /* EurofurenceModel.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = EurofurenceModel.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CA7A2F2E22B16DA3002AD939 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		CA7A2F3322B16DA3002AD939 /* EurofurenceModelTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = EurofurenceModelTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -980,6 +982,14 @@
 			path = ../Pods;
 			sourceTree = "<group>";
 		};
+		CA25A87322C15F3B00226478 /* Coalescing Refreshes */ = {
+			isa = PBXGroup;
+			children = (
+				CA25A87422C15F4F00226478 /* WhenRequestingStoreRefresh_MultipleTimes.swift */,
+			);
+			path = "Coalescing Refreshes";
+			sourceTree = "<group>";
+		};
 		CA7A2F1122B16D70002AD939 = {
 			isa = PBXGroup;
 			children = (
@@ -1025,6 +1035,7 @@
 				CA7A313E22B16E25002AD939 /* Announcements */,
 				CA7A317D22B16E26002AD939 /* Authentication */,
 				CA7A30EE22B16E24002AD939 /* Client API */,
+				CA25A87322C15F3B00226478 /* Coalescing Refreshes */,
 				CA7A30F822B16E25002AD939 /* Collect-them-All */,
 				CA7A318722B16E26002AD939 /* Countdown */,
 				CA7A313822B16E25002AD939 /* Days */,
@@ -2735,6 +2746,7 @@
 				CA7A31FE22B16E26002AD939 /* DealerAssertion.swift in Sources */,
 				CA7A31C022B16E26002AD939 /* WhenSyncingWhileLoggedIn.swift in Sources */,
 				CA8A73E922BD3035007A5201 /* Credential+Random.swift in Sources */,
+				CA25A87522C15F4F00226478 /* WhenRequestingStoreRefresh_MultipleTimes.swift in Sources */,
 				CA7A31C922B16E26002AD939 /* WhenLookingUpMailToLinks.swift in Sources */,
 				CA7A321D22B16E26002AD939 /* WhenObservingRunningEvents_ThenLoadSucceeds.swift in Sources */,
 				CA7A324922B16E26002AD939 /* WhenRestrictingSearchResultsToFavourites_ScheduleShould.swift in Sources */,

--- a/Domain Model/EurofurenceModel/Private/Services/ConcreteRefreshService.swift
+++ b/Domain Model/EurofurenceModel/Private/Services/ConcreteRefreshService.swift
@@ -49,11 +49,12 @@ class ConcreteRefreshService: RefreshService {
     @discardableResult
     func refreshLocalStore(completionHandler: @escaping (RefreshServiceError?) -> Void) -> Progress {
         notifyRefreshStarted()
-        startLongRunningTask()
         
         if let progress = ongoingProgress {
             return progress
         }
+        
+        startLongRunningTask()
         
         let progress = Progress()
         progress.totalUnitCount = -1

--- a/Domain Model/EurofurenceModel/Private/Services/ConcreteRefreshService.swift
+++ b/Domain Model/EurofurenceModel/Private/Services/ConcreteRefreshService.swift
@@ -48,13 +48,12 @@ class ConcreteRefreshService: RefreshService {
 
     @discardableResult
     func refreshLocalStore(completionHandler: @escaping (RefreshServiceError?) -> Void) -> Progress {
-        notifyRefreshStarted()
-        
         if let progress = ongoingProgress {
             return progress
         }
         
         startLongRunningTask()
+        notifyRefreshStarted()
         
         let progress = Progress()
         progress.totalUnitCount = -1

--- a/Domain Model/EurofurenceModel/Private/Services/ConcreteRefreshService.swift
+++ b/Domain Model/EurofurenceModel/Private/Services/ConcreteRefreshService.swift
@@ -43,15 +43,23 @@ class ConcreteRefreshService: RefreshService {
     func add(_ observer: RefreshServiceObserver) {
         refreshObservers.append(observer)
     }
+    
+    private var ongoingProgress: Progress?
 
     @discardableResult
     func refreshLocalStore(completionHandler: @escaping (RefreshServiceError?) -> Void) -> Progress {
         notifyRefreshStarted()
         startLongRunningTask()
         
+        if let progress = ongoingProgress {
+            return progress
+        }
+        
         let progress = Progress()
         progress.totalUnitCount = -1
         progress.completedUnitCount = -1
+        
+        ongoingProgress = progress
         
         let lastSyncTime = determineLastRefreshDate()
         api.fetchLatestData(lastSyncTime: lastSyncTime) { (response) in
@@ -86,6 +94,7 @@ class ConcreteRefreshService: RefreshService {
     }
 
     private func refreshTaskDidFinish() {
+        ongoingProgress = nil
         notifyRefreshFinished()
         finishLongRunningTask()
     }

--- a/Domain Model/EurofurenceModelTests/Coalescing Refreshes/WhenRequestingStoreRefresh_MultipleTimes.swift
+++ b/Domain Model/EurofurenceModelTests/Coalescing Refreshes/WhenRequestingStoreRefresh_MultipleTimes.swift
@@ -12,6 +12,15 @@ class WhenRequestingStoreRefresh_MultipleTimes: XCTestCase {
         XCTAssertTrue(firstProgress === secondProgress, "The same refresh task should use the same Progress")
     }
     
+    func testOnlyOneLongRunningTaskIsManaged() {
+        let longRunningTaskManager = JournallingLongRunningTaskManager()
+        let context = EurofurenceSessionTestBuilder().with(longRunningTaskManager).build()
+        context.refreshLocalStore()
+        context.refreshLocalStore()
+        
+        XCTAssertEqual(1, longRunningTaskManager.longRunningTaskCount, "Only one task should start when coalescing multiple refreshes")
+    }
+    
     func testTheAPIIsOnlyHitOnce() {
         let api = OnlyToldToRefreshOnceMockAPI()
         let context = EurofurenceSessionTestBuilder().with(api).build()

--- a/Domain Model/EurofurenceModelTests/Coalescing Refreshes/WhenRequestingStoreRefresh_MultipleTimes.swift
+++ b/Domain Model/EurofurenceModelTests/Coalescing Refreshes/WhenRequestingStoreRefresh_MultipleTimes.swift
@@ -21,6 +21,16 @@ class WhenRequestingStoreRefresh_MultipleTimes: XCTestCase {
         XCTAssertEqual(1, longRunningTaskManager.longRunningTaskCount, "Only one task should start when coalescing multiple refreshes")
     }
     
+    func testObserversAreOnlyToldAboutTheRefreshStartingOnce() {
+        let context = EurofurenceSessionTestBuilder().build()
+        let observer = JournallingRefreshServiceObserver()
+        context.refreshService.add(observer)
+        context.refreshLocalStore()
+        context.refreshLocalStore()
+        
+        XCTAssertEqual(1, observer.numberOfTimesToldDidBeginRefreshing, "Observers should not be told about refreshes that are coalesced")
+    }
+    
     func testTheAPIIsOnlyHitOnce() {
         let api = OnlyToldToRefreshOnceMockAPI()
         let context = EurofurenceSessionTestBuilder().with(api).build()

--- a/Domain Model/EurofurenceModelTests/Coalescing Refreshes/WhenRequestingStoreRefresh_MultipleTimes.swift
+++ b/Domain Model/EurofurenceModelTests/Coalescing Refreshes/WhenRequestingStoreRefresh_MultipleTimes.swift
@@ -1,0 +1,46 @@
+import EurofurenceModel
+import EurofurenceModelTestDoubles
+import XCTest
+
+class WhenRequestingStoreRefresh_MultipleTimes: XCTestCase {
+
+    func testTheSameProgressIsReturned() {
+        let context = EurofurenceSessionTestBuilder().build()
+        let firstProgress = context.refreshLocalStore()
+        let secondProgress = context.refreshLocalStore()
+        
+        XCTAssertTrue(firstProgress === secondProgress, "The same refresh task should use the same Progress")
+    }
+    
+    func testTheAPIIsOnlyHitOnce() {
+        let api = OnlyToldToRefreshOnceMockAPI()
+        let context = EurofurenceSessionTestBuilder().with(api).build()
+        context.refreshLocalStore()
+        context.refreshLocalStore()
+        
+        XCTAssertTrue(api.toldToRefreshOnlyOnce, "Trying to refresh while already refreshing should coalesce the requests")
+    }
+    
+    func testEncounteringAPIErrorShouldPermitNewRequests() {
+        let context = EurofurenceSessionTestBuilder().build()
+        let firstProgress = context.refreshLocalStore()
+        context.simulateSyncAPIError()
+        let secondProgress = context.refreshLocalStore()
+        
+        XCTAssertFalse(firstProgress === secondProgress, "API errors during a sync should stop coalescing sync requests")
+    }
+    
+    func testConventionIdentifierMismatchesShouldPermitNewRequests() {
+        let initialCharacteristics = ModelCharacteristics.randomWithoutDeletions
+        let store = InMemoryDataStore(response: initialCharacteristics)
+        let context = EurofurenceSessionTestBuilder().with(store).build()
+        let firstProgress = context.refreshLocalStore()
+        var mismatchedConventionIdentifierCharacteristics = ModelCharacteristics.randomWithoutDeletions
+        mismatchedConventionIdentifierCharacteristics.conventionIdentifier = .random
+        context.simulateSyncSuccess(mismatchedConventionIdentifierCharacteristics)
+        let secondProgress = context.refreshLocalStore()
+        
+        XCTAssertFalse(firstProgress === secondProgress, "CID mismatches should stop coalescing sync requests")
+    }
+
+}

--- a/Domain Model/EurofurenceModelTests/EurofurenceSessionTestBuilder.swift
+++ b/Domain Model/EurofurenceModelTests/EurofurenceSessionTestBuilder.swift
@@ -180,6 +180,7 @@ class EurofurenceSessionTestBuilder {
     private var collectThemAllRequestFactory: CollectThemAllRequestFactory = StubCollectThemAllRequestFactory()
     private var companionAppURLRequestFactory: CompanionAppURLRequestFactory = StubCompanionAppURLRequestFactory()
     private var forceUpgradeRequired: ForceRefreshRequired = StubForceRefreshRequired(isForceRefreshRequired: false)
+    private var longRunningTaskManager: FakeLongRunningTaskManager = FakeLongRunningTaskManager()
 
     func with(_ currentDate: Date) -> EurofurenceSessionTestBuilder {
         clock = StubClock(currentDate: currentDate)
@@ -238,6 +239,12 @@ class EurofurenceSessionTestBuilder {
         self.companionAppURLRequestFactory = companionAppURLRequestFactory
         return self
     }
+    
+    @discardableResult
+    func with(_ longRunningTaskManager: FakeLongRunningTaskManager) -> EurofurenceSessionTestBuilder {
+        self.longRunningTaskManager = longRunningTaskManager
+        return self
+    }
 
     func loggedInWithValidCredential() -> EurofurenceSessionTestBuilder {
         let credential = Credential(username: "User",
@@ -261,7 +268,6 @@ class EurofurenceSessionTestBuilder {
         let dateDistanceCalculator = StubDateDistanceCalculator()
         let conventionStartDateRepository = StubConventionStartDateRepository()
         let significantTimeChangeAdapter = CapturingSignificantTimeChangeAdapter()
-        let longRunningTaskManager = FakeLongRunningTaskManager()
         let mapCoordinateRender = CapturingMapCoordinateRender()
         
         let session = EurofurenceSessionBuilder(conventionIdentifier: conventionIdentifier)

--- a/Domain Model/EurofurenceModelTests/EurofurenceSessionTestBuilder.swift
+++ b/Domain Model/EurofurenceModelTests/EurofurenceSessionTestBuilder.swift
@@ -149,10 +149,18 @@ class EurofurenceSessionTestBuilder {
                 completionHandler?(error)
             }
         }
-
+        
         func performSuccessfulSync(response: ModelCharacteristics) {
             refreshLocalStore()
+            simulateSyncSuccess(response)
+        }
+        
+        func simulateSyncSuccess(_ response: ModelCharacteristics) {
             api.simulateSuccessfulSync(response)
+        }
+        
+        func simulateSyncAPIError() {
+            api.simulateUnsuccessfulSync()
         }
 
         func simulateSignificantTimeChange() {

--- a/Domain Model/EurofurenceModelTests/Sync/CapturingRefreshServiceObserver.swift
+++ b/Domain Model/EurofurenceModelTests/Sync/CapturingRefreshServiceObserver.swift
@@ -20,3 +20,14 @@ class CapturingRefreshServiceObserver: RefreshServiceObserver {
     }
 
 }
+
+class JournallingRefreshServiceObserver: CapturingRefreshServiceObserver {
+    
+    private(set) var numberOfTimesToldDidBeginRefreshing = 0
+    
+    override func refreshServiceDidBeginRefreshing() {
+        super.refreshServiceDidBeginRefreshing()
+        numberOfTimesToldDidBeginRefreshing += 1
+    }
+    
+}

--- a/Domain Model/EurofurenceModelTests/Test Doubles/API/FakeAPI.swift
+++ b/Domain Model/EurofurenceModelTests/Test Doubles/API/FakeAPI.swift
@@ -143,3 +143,17 @@ extension SlowFakeImageAPI {
     }
 
 }
+
+class OnlyToldToRefreshOnceMockAPI: FakeAPI {
+    
+    private var refreshCount = 0
+    var toldToRefreshOnlyOnce: Bool {
+        return refreshCount == 1
+    }
+    
+    override func fetchLatestData(lastSyncTime: Date?, completionHandler: @escaping (ModelCharacteristics?) -> Void) {
+        refreshCount += 1
+        super.fetchLatestData(lastSyncTime: lastSyncTime, completionHandler: completionHandler)
+    }
+    
+}

--- a/Domain Model/EurofurenceModelTests/Test Doubles/Configurable Dependencies/FakeLongRunningTaskManager.swift
+++ b/Domain Model/EurofurenceModelTests/Test Doubles/Configurable Dependencies/FakeLongRunningTaskManager.swift
@@ -31,3 +31,19 @@ class FakeLongRunningTaskManager: LongRunningTaskManager {
     }
 
 }
+
+class JournallingLongRunningTaskManager: FakeLongRunningTaskManager {
+    
+    private(set) var longRunningTaskCount = 0
+    
+    override func beginLongRunningTask() -> AnyHashable {
+        longRunningTaskCount += 1
+        return super.beginLongRunningTask()
+    }
+    
+    override func finishLongRunningTask(token: AnyHashable) {
+        super.finishLongRunningTask(token: token)
+        longRunningTaskCount -= 1
+    }
+    
+}

--- a/Eurofurence/Modules/Dealers/View/UIKit/DealersViewController.swift
+++ b/Eurofurence/Modules/Dealers/View/UIKit/DealersViewController.swift
@@ -115,7 +115,8 @@ class DealersViewController: UIViewController, UISearchControllerDelegate, UISea
         tableController = TableController(numberOfDealersPerSection: numberOfDealersPerSection,
                                           sectionIndexTitles: sectionIndexTitles,
                                           binder: binder,
-                                          onDidSelectRowAtIndexPath: didSelectDealer)
+                                          onDidSelectRowAtIndexPath: didSelectDealer,
+                                          onDidEndDragging: scrollViewDidEndDragging)
     }
 
     func bindSearchResults(numberOfDealersPerSection: [Int], sectionIndexTitles: [String], using binder: DealersSearchResultsBinder) {
@@ -131,7 +132,15 @@ class DealersViewController: UIViewController, UISearchControllerDelegate, UISea
     }
 
     @objc private func refreshControlValueDidChange() {
-        delegate?.dealersSceneDidPerformRefreshAction()
+        if tableView.isDragging == false {        
+            delegate?.dealersSceneDidPerformRefreshAction()
+        }
+    }
+    
+    private func scrollViewDidEndDragging() {
+        if refreshControl.isRefreshing {
+            delegate?.dealersSceneDidPerformRefreshAction()
+        }
     }
 
     private func didSelectDealer(at indexPath: IndexPath) {
@@ -148,15 +157,18 @@ class DealersViewController: UIViewController, UISearchControllerDelegate, UISea
         private let sectionIndexTitles: [String]
         private let binder: DealersBinder
         private let onDidSelectRowAtIndexPath: (IndexPath) -> Void
+        private let onDidEndDragging: () -> Void
 
         init(numberOfDealersPerSection: [Int],
              sectionIndexTitles: [String],
              binder: DealersBinder,
-             onDidSelectRowAtIndexPath: @escaping (IndexPath) -> Void) {
+             onDidSelectRowAtIndexPath: @escaping (IndexPath) -> Void,
+             onDidEndDragging: @escaping () -> Void) {
             self.numberOfDealersPerSection = numberOfDealersPerSection
             self.sectionIndexTitles = sectionIndexTitles
             self.binder = binder
             self.onDidSelectRowAtIndexPath = onDidSelectRowAtIndexPath
+            self.onDidEndDragging = onDidEndDragging
         }
 
         func numberOfSections(in tableView: UITableView) -> Int {
@@ -186,6 +198,10 @@ class DealersViewController: UIViewController, UISearchControllerDelegate, UISea
 
         func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
             onDidSelectRowAtIndexPath(indexPath)
+        }
+        
+        func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+            onDidEndDragging()
         }
 
     }

--- a/Eurofurence/Modules/News/View/UIKit/NewsViewController.swift
+++ b/Eurofurence/Modules/News/View/UIKit/NewsViewController.swift
@@ -43,6 +43,7 @@ class NewsViewController: UIViewController, NewsScene {
     func bind(numberOfItemsPerComponent: [Int], using binder: NewsComponentsBinder) {
         tableController = TableController(tableView: tableView, numberOfItemsPerComponent: numberOfItemsPerComponent, binder: binder)
         tableController?.onDidSelectRowAtIndexPath = tableViewDidSelectRow
+        tableController?.onDidEndDragging = scrollViewDidEndDragging
         tableView.dataSource = tableController
         tableView.delegate = tableController
         tableView.reloadData()
@@ -51,10 +52,22 @@ class NewsViewController: UIViewController, NewsScene {
     // MARK: Private
 
     @objc private func refreshControlDidChangeValue() {
+        if tableView.isDragging == false {        
+            notifyDidPerformRefreshAction()
+        }
+    }
+    
+    private func scrollViewDidEndDragging() {
+        if refreshControl.isRefreshing {
+            notifyDidPerformRefreshAction()
+        }
+    }
+    
+    private func notifyDidPerformRefreshAction() {
         delegate?.newsSceneDidPerformRefreshAction()
     }
 
-    func tableViewDidSelectRow(at indexPath: IndexPath) {
+    private func tableViewDidSelectRow(at indexPath: IndexPath) {
         delegate?.newsSceneDidSelectComponent(at: indexPath)
     }
 
@@ -64,6 +77,7 @@ class NewsViewController: UIViewController, NewsScene {
         private let numberOfItemsPerComponent: [Int]
         private let binder: NewsComponentsBinder
         var onDidSelectRowAtIndexPath: ((IndexPath) -> Void)?
+        var onDidEndDragging: (() -> Void)?
 
         init(tableView: UITableView, numberOfItemsPerComponent: [Int], binder: NewsComponentsBinder) {
             self.tableView = tableView
@@ -123,6 +137,10 @@ class NewsViewController: UIViewController, NewsScene {
             let header = tableView.dequeueConventionBrandedHeader()
             binder.bindTitleForSection(at: section, scene: header)
             return header
+        }
+        
+        func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+            onDidEndDragging?()
         }
 
         // MARK: Functions

--- a/Eurofurence/Modules/Schedule/View/UIKit/ScheduleViewController.swift
+++ b/Eurofurence/Modules/Schedule/View/UIKit/ScheduleViewController.swift
@@ -152,7 +152,8 @@ class ScheduleViewController: UIViewController,
         tableController = TableController(numberOfItemsPerSection: numberOfItemsPerSection,
                                           binder: binder,
                                           onDidSelectRow: scheduleTableViewDidSelectRow,
-                                          onTableViewDidScroll: tableViewDidScroll)
+                                          onTableViewDidScroll: tableViewDidScroll,
+                                          onDidEndDragging: scrollViewDidEndDragging)
     }
 
     func bindSearchResults(numberOfItemsPerSection: [Int], using binder: ScheduleSceneBinder) {
@@ -199,6 +200,18 @@ class ScheduleViewController: UIViewController,
     }
 
     @objc private func refreshControlDidChangeValue() {
+        if tableView.isDragging == false {
+            notifyDidPerformRefreshAction()
+        }
+    }
+    
+    private func scrollViewDidEndDragging() {
+        if refreshControl.isRefreshing {
+            notifyDidPerformRefreshAction()
+        }
+    }
+    
+    private func notifyDidPerformRefreshAction() {
         delegate?.scheduleSceneDidPerformRefreshAction()
     }
 
@@ -239,15 +252,18 @@ class ScheduleViewController: UIViewController,
         private let binder: ScheduleSceneBinder
         private let onDidSelectRow: (IndexPath) -> Void
         private let onTableViewDidScroll: (CGPoint) -> Void
+        private let onDidEndDragging: () -> Void
 
         init(numberOfItemsPerSection: [Int],
              binder: ScheduleSceneBinder,
              onDidSelectRow: @escaping (IndexPath) -> Void,
-             onTableViewDidScroll: @escaping (CGPoint) -> Void) {
+             onTableViewDidScroll: @escaping (CGPoint) -> Void,
+             onDidEndDragging: @escaping () -> Void) {
             self.numberOfItemsPerSection = numberOfItemsPerSection
             self.binder = binder
             self.onDidSelectRow = onDidSelectRow
             self.onTableViewDidScroll = onTableViewDidScroll
+            self.onDidEndDragging = onDidEndDragging
         }
 
         func numberOfSections(in tableView: UITableView) -> Int {
@@ -295,6 +311,10 @@ class ScheduleViewController: UIViewController,
         
         func scrollViewDidScroll(_ scrollView: UIScrollView) {
             onTableViewDidScroll(scrollView.contentOffset)
+        }
+        
+        func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+            onDidEndDragging()
         }
 
     }


### PR DESCRIPTION
Pulling to refresh and holding it in place would cause the navigtion bar to flicker around wildly. This PR avoids refreshing until the user has lifted their finger, and coalesces multiple refresh requests into one should they get through