### PR TITLE
FCM registration fix

### DIFF
--- a/Eurofurence/AppDelegate.swift
+++ b/Eurofurence/AppDelegate.swift
@@ -15,6 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         prepareNotificationDelegate()
         installDebugModule()
         showApplicationWindow()
+        requestRemoteNotificationsDeviceToken()
 
 		return true
 	}
@@ -45,6 +46,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         ApplicationStack.assemble()
         Theme.apply()
         ReviewPromptController.initialize()
+    }
+    
+    private func requestRemoteNotificationsDeviceToken() {
+        UIApplication.shared.registerForRemoteNotifications()
     }
     
     private func prepareNotificationDelegate() {

--- a/Eurofurence/Modules/Debug/DebugTableViewController.swift
+++ b/Eurofurence/Modules/Debug/DebugTableViewController.swift
@@ -33,7 +33,7 @@ class DebugTableViewController: UITableViewController {
 
     private func copyFCMToPasteBoard() {
         guard let value = Messaging.messaging().fcmToken else { return }
-        UIPasteboard.general.setValue(value, forPasteboardType: kUTTypeRTF as String)
+        UIPasteboard.general.setValue(value, forPasteboardType: kUTTypePlainText as String)
 
         let alert = UIAlertController(title: "FCM Copied", message: nil, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "OK", style: .cancel))

--- a/Eurofurence/Notifications/Firebase Notification Registration/EurofurenceFCMDeviceRegistration.swift
+++ b/Eurofurence/Notifications/Firebase Notification Registration/EurofurenceFCMDeviceRegistration.swift
@@ -20,7 +20,7 @@ public struct EurofurenceFCMDeviceRegistration: FCMDeviceRegistration {
         let registrationRequest = Request(DeviceId: fcm, Topics: topics.map({ $0.description }))
         guard let jsonData = try? jsonEncoder.encode(registrationRequest) else { return }
 
-        let registrationURL = urlProviding.url + "PushNotifications/FcmDeviceRegistration"
+        let registrationURL = urlProviding.url + "/PushNotifications/FcmDeviceRegistration"
         var request = JSONRequest(url: registrationURL, body: jsonData)
 
         if let token = authenticationToken {

--- a/EurofurenceTests/Firebase Notification Registration/EurofurenceFCMDeviceRegistrationTests.swift
+++ b/EurofurenceTests/Firebase Notification Registration/EurofurenceFCMDeviceRegistrationTests.swift
@@ -25,7 +25,7 @@ class EurofurenceFCMDeviceRegistrationTests: XCTestCase {
 
     func testRegisteringTheFCMTokenSubmitsRequestToFCMRegistrationURL() {
         performRegistration()
-        let expectedURL = urlProviding.url + "PushNotifications/FcmDeviceRegistration"
+        let expectedURL = urlProviding.url + "/PushNotifications/FcmDeviceRegistration"
 
         XCTAssertEqual(expectedURL, capturingJSONSession.postedURL)
     }


### PR DESCRIPTION
Missing a trailing slash in the URL