### PR TITLE
Sort events by start time

### DIFF
--- a/Domain Model/EurofurenceModel/Private/Services/Events/ConcreteEventsService.swift
+++ b/Domain Model/EurofurenceModel/Private/Services/Events/ConcreteEventsService.swift
@@ -195,7 +195,7 @@ class ConcreteEventsService: ClockDelegate, EventsService {
             self.rooms = rooms
             self.tracks = tracks
 
-            eventModels = events.compactMap(makeEventModel)
+            eventModels = events.sorted(by: { $0.startDateTime < $1.startDateTime }).compactMap(makeEventModel)
 
             dayModels = makeDays(from: days)
             eventBus.post(ConcreteEventsService.ChangedEvent())

--- a/Domain Model/EurofurenceModel/Private/Services/Events/EventsScheduleAdapter.swift
+++ b/Domain Model/EurofurenceModel/Private/Services/Events/EventsScheduleAdapter.swift
@@ -128,7 +128,7 @@ class EventsScheduleAdapter: EventsSchedule {
             allEvents = allEvents.filter(filter.shouldFilter)
         }
 
-        events = allEvents.compactMap(schedule.makeEventModel)
+        events = allEvents.sorted(by: { $0.startDateTime < $1.startDateTime }).compactMap(schedule.makeEventModel)
         delegate?.scheduleEventsDidChange(to: events)
     }
 

--- a/Domain Model/EurofurenceModelTests/Events/EventAssertion.swift
+++ b/Domain Model/EurofurenceModelTests/Events/EventAssertion.swift
@@ -21,9 +21,11 @@ class EventAssertion: Assertion {
             fail(message: "Differing amount of expected/actual events")
             return
         }
+        
+        let eventsShouldBeOrderedByStartTime = characteristics.sorted { $0.startDateTime < $1.startDateTime }
 
         for (idx, event) in events.enumerated() {
-            let characteristic = characteristics[idx]
+            let characteristic = eventsShouldBeOrderedByStartTime[idx]
             assertEvent(event, characterisedBy: characteristic)
         }
     }


### PR DESCRIPTION
Applies to all event types, so current/upcoming/favourites all get sorted by their start times. Fixes #189