### PR TITLE
Refresh model on foreground notification

### DIFF
--- a/Eurofurence/AppNotificationDelegate.swift
+++ b/Eurofurence/AppNotificationDelegate.swift
@@ -7,6 +7,7 @@ class AppNotificationDelegate: NSObject, UNUserNotificationCenterDelegate {
     func userNotificationCenter(_ center: UNUserNotificationCenter,
                                 willPresent notification: UNNotification,
                                 withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Swift.Void) {
+        ApplicationStack.handleRemoteNotification(notification.request.content.userInfo)
         completionHandler([.alert, .badge, .sound])
     }
     

--- a/Eurofurence/ApplicationStack.swift
+++ b/Eurofurence/ApplicationStack.swift
@@ -24,7 +24,7 @@ class ApplicationStack {
     }
     
     static func handleRemoteNotification(_ payload: [AnyHashable: Any],
-                                         completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
+                                         completionHandler: @escaping (UIBackgroundFetchResult) -> Void = { (_) in }) {
         instance.notificationFetchResultAdapter.handleRemoteNotification(payload, completionHandler: completionHandler)
     }
     


### PR DESCRIPTION
Make sure while the app is running, receiving a PM starts a refresh operation so we're ready to show the incoming message