### PR TITLE
Fix dealer categories missing on first sync

### DIFF
--- a/Domain Model/EurofurenceModel/Public/Objects/InMemoryDealerCategoriesCollection.swift
+++ b/Domain Model/EurofurenceModel/Public/Objects/InMemoryDealerCategoriesCollection.swift
@@ -4,7 +4,8 @@ public class InMemoryDealerCategoriesCollection<C>: DealerCategoriesCollection
     where C: RandomAccessCollection, C.Element: DealerCategory, C.Index == Int {
     
     private var observers = [DealerCategoriesCollectionObserver]()
-    var categories: C {
+    
+    public var categories: C {
         didSet {
             observers.forEach({ $0.categoriesCollectionDidChange(self) })
         }

--- a/Eurofurence/Modules/Dealers/Interactor/DefaultDealersInteractor.swift
+++ b/Eurofurence/Modules/Dealers/Interactor/DefaultDealersInteractor.swift
@@ -205,13 +205,15 @@ struct DefaultDealersInteractor: DealersInteractor, DealersIndexDelegate {
 
     }
     
-    private class CategoriesViewModel: DealerCategoriesViewModel {
+    private class CategoriesViewModel: DealerCategoriesViewModel, DealerCategoriesCollectionObserver {
         
         private let categoriesCollection: DealerCategoriesCollection
         private var categoryViewModels = [CategoryViewModel]()
         
         init(categoriesCollection: DealerCategoriesCollection) {
             self.categoriesCollection = categoriesCollection
+            categoriesCollection.add(self)
+            
             regenerateCategoryViewModels()
         }
         
@@ -221,6 +223,10 @@ struct DefaultDealersInteractor: DealersInteractor, DealersIndexDelegate {
         
         func categoryViewModel(at index: Int) -> DealerCategoryViewModel {
             return categoryViewModels[index]
+        }
+        
+        func categoriesCollectionDidChange(_ collection: DealerCategoriesCollection) {
+            regenerateCategoryViewModels()
         }
         
         private func regenerateCategoryViewModels() {

--- a/EurofurenceTests/Presenter Tests/Dealers/Interactor Tests/WhenProducingCategoriesViewModel_DealersInteractorShould.swift
+++ b/EurofurenceTests/Presenter Tests/Dealers/Interactor Tests/WhenProducingCategoriesViewModel_DealersInteractorShould.swift
@@ -119,6 +119,19 @@ class WhenProducingCategoriesViewModel_DealersInteractorShould: XCTestCase {
         
         XCTAssertFalse(category.isActive)
     }
+    
+    func testUpdateAvailableCategoriesWhenCollectionChanges() {
+        let categoriesCollection = InMemoryDealerCategoriesCollection(categories: [FakeDealerCategory]())
+        let index = FakeDealersIndex(availableCategories: categoriesCollection)
+        let service = FakeDealersService(index: index)
+        let context = DealerInteractorTestBuilder().with(service).build()
+        let viewModel = context.prepareCategoriesViewModel()
+        let category = FakeDealerCategory(title: "Updated Category")
+        categoriesCollection.categories = [category]
+        
+        XCTAssertEqual(1, viewModel?.numberOfCategories)
+        XCTAssertEqual("Updated Category", viewModel?.categoryViewModel(at: 0).title)
+    }
 
 }
 


### PR DESCRIPTION
When the categories updated post-launch, the view model was not hooked into the event. This adds an observation to handle category changes while the app is running, catering for the initial “create view model then sync” and “update view model from sync” scenarios in one go