### PR TITLE
Stop indexing user activies into local spotlight index

### DIFF
--- a/Eurofurence/Activity/Dealers/Intents/DonateIntentDealerInteractionRecorder.swift
+++ b/Eurofurence/Activity/Dealers/Intents/DonateIntentDealerInteractionRecorder.swift
@@ -15,7 +15,6 @@ struct DonateIntentDealerInteractionRecorder: DealerInteractionRecorder {
         let activityTitle = String.viewDealer(named: entity.preferredName)
         let url = entity.makeContentURL()
         let activity = activityFactory.makeActivity(type: "org.eurofurence.activity.view-dealer", title: activityTitle, url: url)
-        activity.markEligibleForLocalIndexing()
         activity.markEligibleForPublicIndexing()
         
         return ActivityInteraction(activity: activity)

--- a/Eurofurence/Activity/Events/Intents/SystemEventInteractionsRecorder.swift
+++ b/Eurofurence/Activity/Events/Intents/SystemEventInteractionsRecorder.swift
@@ -16,7 +16,6 @@ struct SystemEventInteractionsRecorder: EventInteractionRecorder {
         let activityTitle = String.viewEvent(named: entity.title)
         let url = entity.makeContentURL()
         let activity = activityFactory.makeActivity(type: "org.eurofurence.activity.view-event", title: activityTitle, url: url)
-        activity.markEligibleForLocalIndexing()
         activity.markEligibleForPublicIndexing()
         
         return ActivityInteraction(activity: activity)

--- a/EurofurenceTests/Activity/Intent Donation/Dealers/WhenRecordingDealerInteraction.swift
+++ b/EurofurenceTests/Activity/Intent Donation/Dealers/WhenRecordingDealerInteraction.swift
@@ -35,7 +35,7 @@ class WhenRecordingDealerInteraction: XCTestCase {
         XCTAssertEqual(expectedTitle, producedActivity?.title)
         XCTAssertEqual(dealer.shareableURL, producedActivity?.url)
         XCTAssertEqual(true, producedActivity?.supportsPublicIndexing)
-        XCTAssertEqual(true, producedActivity?.supportsLocalIndexing)
+        XCTAssertEqual(false, producedActivity?.supportsLocalIndexing)
     }
     
     func testTogglingInteractionActivationChangesCurrentStateOfActivity() {

--- a/EurofurenceTests/Activity/Intent Donation/Events/WhenRecordingEventInteraction.swift
+++ b/EurofurenceTests/Activity/Intent Donation/Events/WhenRecordingEventInteraction.swift
@@ -35,7 +35,7 @@ class WhenRecordingEventInteraction: XCTestCase {
         XCTAssertEqual(expectedTitle, producedActivity?.title)
         XCTAssertEqual(event.shareableURL, producedActivity?.url)
         XCTAssertEqual(true, producedActivity?.supportsPublicIndexing)
-        XCTAssertEqual(true, producedActivity?.supportsLocalIndexing)
+        XCTAssertEqual(false, producedActivity?.supportsLocalIndexing)
     }
     
     func testTogglingInteractionActivationChangesCurrentStateOfActivity() {


### PR DESCRIPTION
Events and dealers are donated as intents already, so this avoids duplicate entries being present