### PR TITLE
Submit “empty” token for anonymous game requests

### DIFF
--- a/Domain Model/EurofurenceModel/Public/Default Dependency Implementations/DefaultCollectThemAllRequestFactory.swift
+++ b/Domain Model/EurofurenceModel/Public/Default Dependency Implementations/DefaultCollectThemAllRequestFactory.swift
@@ -14,10 +14,17 @@ public struct DefaultCollectThemAllRequestFactory: CollectThemAllRequestFactory 
     }
 
     private func makeGameURL(token: String? = nil) -> URL {
-        var urlString = "https://app.eurofurence.org/EF25/companion/#/login?embedded=true&returnPath=/collect"
-        if let token = token {
-            urlString.append("&token=\(token)")
-        }
+        var urlString = "https://app.eurofurence.org/EF25/companion/#/login?embedded=true&returnPath=/collect&token="
+        
+        let tokenToSend: String = {
+            if let token = token {
+                return token
+            } else {
+                return "empty"
+            }
+        }()
+        
+        urlString.append(tokenToSend)
         
         guard let url = URL(string: urlString) else {
             fatalError("Error marshalling token into url: \(urlString)")

--- a/Domain Model/EurofurenceModelTests/Collect-them-All/DefaultCollectThemAllRequestFactoryShould.swift
+++ b/Domain Model/EurofurenceModelTests/Collect-them-All/DefaultCollectThemAllRequestFactoryShould.swift
@@ -6,7 +6,7 @@ class DefaultCollectThemAllRequestFactoryShould: XCTestCase {
     func testProduceExpectedAnonymousRequest() {
         let factory = DefaultCollectThemAllRequestFactory()
         let anonymousRequest = factory.makeAnonymousGameURLRequest()
-        let expectedURL = unwrap(URL(string: "https://app.eurofurence.org/EF25/companion/#/login?embedded=true&returnPath=/collect"))
+        let expectedURL = unwrap(URL(string: "https://app.eurofurence.org/EF25/companion/#/login?embedded=true&returnPath=/collect&token=empty"))
 
         XCTAssertEqual(expectedURL, anonymousRequest.url)
     }


### PR DESCRIPTION
This lets the app show the “Please login via the app” message in the collect ‘em all tab