### PR TITLE
Improve speed of recreating snapshots

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,5 +1,4 @@
 lane :screenshots do
-  reset_simulator_contents
   capture_screenshots(stop_after_first_error: true)
 end
 

--- a/fastlane/Snapfile
+++ b/fastlane/Snapfile
@@ -1,12 +1,7 @@
 devices([
-   "iPhone 5s",
-   "iPhone 6",
-   "iPhone 6 Plus",
-   "iPhone X",
+   "iPhone 8 Plus",
    "iPhone XS Max",
    "iPad Pro (12.9-inch)",
-   "iPad Pro (9.7-inch)",
-   "iPad Pro (11-inch)",
    "iPad Pro (12.9-inch) (3rd generation)"
 ])
 


### PR DESCRIPTION
While it'd be ideal to take screenshots for every size we support, Bitrise times out after 45 minutes. The App Store Connect configuration will now downscale the larger sizes, so we'll only generate those for now instead. We also don't need to reset the simulators on Bitrise, as they'll be fresh ones every time anyway.