### PR TITLE
Fix styling of certain elements with iOS 10

### DIFF
--- a/Eurofurence/Modules/Dealers/View/UIKit/DealersViewController.swift
+++ b/Eurofurence/Modules/Dealers/View/UIKit/DealersViewController.swift
@@ -71,11 +71,11 @@ class DealersViewController: UIViewController, UISearchControllerDelegate, UISea
         let searchController = UISearchController(searchResultsController: searchViewController)
         searchController.delegate = self
         searchController.searchResultsUpdater = self
+        Theme.performUnsafeSearchControllerStyling(searchController: searchController)
         
         if #available(iOS 11.0, *) {
             navigationItem.searchController = searchController
             navigationItem.rightBarButtonItem = nil
-            Theme.performUnsafeSearchControllerStyling(searchController: searchController)
         }
         
         self.searchController = searchController

--- a/Eurofurence/Modules/Schedule/View/UIKit/ScheduleViewController.swift
+++ b/Eurofurence/Modules/Schedule/View/UIKit/ScheduleViewController.swift
@@ -88,11 +88,11 @@ class ScheduleViewController: UIViewController,
         searchController.searchBar.delegate = self
         searchController.searchBar.scopeButtonTitles = [.allEvents, .favourites]
         searchController.searchResultsUpdater = self
+        Theme.performUnsafeSearchControllerStyling(searchController: searchController)
         
         if #available(iOS 11.0, *) {
             navigationItem.searchController = searchController
             navigationItem.rightBarButtonItem = nil
-            Theme.performUnsafeSearchControllerStyling(searchController: searchController)
         }
         
         self.searchController = searchController

--- a/Eurofurence/Theme.swift
+++ b/Eurofurence/Theme.swift
@@ -23,6 +23,8 @@ struct Theme {
     static func performUnsafeSearchControllerStyling(searchController: UISearchController) {
         styleSearchBar(searchController.searchBar)
         
+        guard #available(iOS 11.0, *) else { return }
+        
         guard let backgroundview = resolveStylableBackgroundFromPrivateViewHiearchy(searchBar: searchController.searchBar) else { return }
         
         backgroundview.backgroundColor = .white
@@ -78,6 +80,9 @@ struct Theme {
         let buttonInsideTableView = UIButton.appearance(whenContainedInInstancesOf: [UITableViewCell.self])
         buttonInsideTableView.setTitleColor(.pantone330U, for: .normal)
         buttonInsideTableView.setTitleColor(.conferenceGrey, for: .disabled)
+        
+        let buttonInsideEventCell = UIButton.appearance(whenContainedInInstancesOf: [EventTableViewCell.self])
+        buttonInsideEventCell.setTitleColor(.white, for: .normal)
     }
 
     private static func styleButtonsWithinNavigationBars() {


### PR DESCRIPTION
- Scope bar buttons were still invisible, as we were checking to apply styles for 11+ on certain elements
- Table view row actions were invisible