### PR TITLE
Feature/map entry links

### DIFF
--- a/Eurofurence/Modules/Map Detail/Interactor/DefaultMapDetailInteractor.swift
+++ b/Eurofurence/Modules/Map Detail/Interactor/DefaultMapDetailInteractor.swift
@@ -71,6 +71,9 @@ class DefaultMapDetailInteractor: MapDetailInteractor, MapsObserver {
                 case .dealer(let dealer):
                     return dealer.preferredName
 
+                case .location(_, _, let name):
+                    return name
+
                 default:
                     return nil
                 }

--- a/EurofurenceTests/Presenter Tests/Map Detail/Interactor Tests/WhenShowingMapContents_ForPositionWithMultipleOptions_MapDetailInteractorShould.swift
+++ b/EurofurenceTests/Presenter Tests/Map Detail/Interactor Tests/WhenShowingMapContents_ForPositionWithMultipleOptions_MapDetailInteractorShould.swift
@@ -11,7 +11,8 @@ class WhenShowingMapContents_ForPositionWithMultipleOptions_MapDetailInteractorS
         let (x, y) = (Float.random, Float.random)
         let dealer = FakeDealer.random
         let room = Room.random
-        let content: MapContent = .multiple([.dealer(dealer), .room(room)])
+		let locationName = String.random
+        let content: MapContent = .multiple([.dealer(dealer), .room(room), .location(x: .random, y: .random, name: locationName)])
         randomMap.element.stub(content: content, atX: Int(x), y: Int(y))
         
         let interactor = DefaultMapDetailInteractor(mapsService: mapsService)
@@ -19,7 +20,7 @@ class WhenShowingMapContents_ForPositionWithMultipleOptions_MapDetailInteractorS
         interactor.makeViewModelForMap(identifier: randomMap.element.identifier) { viewModel = $0 }
         let visitor = CapturingMapContentVisitor()
         viewModel?.showContentsAtPosition(x: x, y: y, describingTo: visitor)
-        let expectedOptions = [dealer.preferredName, room.name]
+        let expectedOptions = [dealer.preferredName, room.name, locationName]
 
         XCTAssertEqual(expectedOptions, visitor.capturedMapContents?.options)
     }
@@ -30,7 +31,8 @@ class WhenShowingMapContents_ForPositionWithMultipleOptions_MapDetailInteractorS
         let (x, y) = (Float.random, Float.random)
         let dealer = FakeDealer.random
         let room = Room.random
-        let content: MapContent = .multiple([.dealer(dealer), .room(room)])
+        let locationName = String.random
+        let content: MapContent = .multiple([.dealer(dealer), .room(room), .location(x: .random, y: .random, name: locationName)])
         randomMap.element.stub(content: content, atX: Int(x), y: Int(y))
         let interactor = DefaultMapDetailInteractor(mapsService: mapsService)
         var viewModel: MapDetailViewModel?
@@ -48,7 +50,8 @@ class WhenShowingMapContents_ForPositionWithMultipleOptions_MapDetailInteractorS
         let (x, y) = (Float.random, Float.random)
         let dealer = FakeDealer.random
         let room = Room.random
-        let contents: [MapContent] = [.dealer(dealer), .room(room)]
+        let locationName = String.random
+        let contents: [MapContent] = [.dealer(dealer), .room(room), .location(x: .random, y: .random, name: locationName)]
         let content: MapContent = .multiple(contents)
         randomMap.element.stub(content: content, atX: Int(x), y: Int(y))
         let interactor = DefaultMapDetailInteractor(mapsService: mapsService)


### PR DESCRIPTION
A map entry may contain multiple links to dealers, rooms and also to other map entries, which should therefore also be shown in the action sheets presented upon tapping an entry with multiple links.