### PR TITLE
Deep link into knowledge entries

### DIFF
--- a/Domain Model/Domain Model.xcodeproj/project.pbxproj
+++ b/Domain Model/Domain Model.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		CA2AA30522CA98BF00C0E1A1 /* DoNothingRefreshCollaboration.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA2AA30422CA98BF00C0E1A1 /* DoNothingRefreshCollaboration.swift */; };
 		CA30FB9C22F36456001C2EB3 /* KnowledgeGroupImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA30FB9B22F36456001C2EB3 /* KnowledgeGroupImpl.swift */; };
 		CA30FB9E22F365E4001C2EB3 /* KnowledgeEntryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA30FB9D22F365E4001C2EB3 /* KnowledgeEntryImpl.swift */; };
+		CA6EE99B22F401E900821E68 /* WhenDescribingKnowledgeGroupsLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6EE99A22F401E900821E68 /* WhenDescribingKnowledgeGroupsLink.swift */; };
 		CA7A2F3422B16DA3002AD939 /* EurofurenceModel.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA7A2F2B22B16DA3002AD939 /* EurofurenceModel.framework */; };
 		CA7A2FFF22B16DE4002AD939 /* EurofurenceSessionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA7A2F4322B16DE3002AD939 /* EurofurenceSessionState.swift */; };
 		CA7A300022B16DE4002AD939 /* ApplicationNotificationKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA7A2F4422B16DE3002AD939 /* ApplicationNotificationKey.swift */; };
@@ -515,6 +516,7 @@
 		CA2AA30422CA98BF00C0E1A1 /* DoNothingRefreshCollaboration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoNothingRefreshCollaboration.swift; sourceTree = "<group>"; };
 		CA30FB9B22F36456001C2EB3 /* KnowledgeGroupImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KnowledgeGroupImpl.swift; sourceTree = "<group>"; };
 		CA30FB9D22F365E4001C2EB3 /* KnowledgeEntryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KnowledgeEntryImpl.swift; sourceTree = "<group>"; };
+		CA6EE99A22F401E900821E68 /* WhenDescribingKnowledgeGroupsLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhenDescribingKnowledgeGroupsLink.swift; sourceTree = "<group>"; };
 		CA7A2F2B22B16DA3002AD939 /* EurofurenceModel.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = EurofurenceModel.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CA7A2F2E22B16DA3002AD939 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		CA7A2F3322B16DA3002AD939 /* EurofurenceModelTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = EurofurenceModelTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1065,6 +1067,14 @@
 				CA2AA2FC22CA8E0B00C0E1A1 /* WhenPerfomingSync_WithUnsuccessfulCollaboration.swift */,
 			);
 			path = Collaboration;
+			sourceTree = "<group>";
+		};
+		CA6EE99922F401D200821E68 /* Knowledge */ = {
+			isa = PBXGroup;
+			children = (
+				CA6EE99A22F401E900821E68 /* WhenDescribingKnowledgeGroupsLink.swift */,
+			);
+			path = Knowledge;
 			sourceTree = "<group>";
 		};
 		CA7A2F1122B16D70002AD939 = {
@@ -2208,6 +2218,7 @@
 			children = (
 				CA2AA2D822C941B100C0E1A1 /* Dealers */,
 				CAB0FD5F22C9128E00D4CB98 /* Events */,
+				CA6EE99922F401D200821E68 /* Knowledge */,
 			);
 			path = "App Links";
 			sourceTree = "<group>";
@@ -2781,6 +2792,7 @@
 				CA7A321922B16E26002AD939 /* WhenAddingAnnouncementsObserverBeforeLoadingAnything.swift in Sources */,
 				CA7A31B722B16E26002AD939 /* BeforeSyncInitiated_ApplicationShould.swift in Sources */,
 				CA7A31CA22B16E26002AD939 /* WhenRequestingPrivateMessagesWhileAuthenticated.swift in Sources */,
+				CA6EE99B22F401E900821E68 /* WhenDescribingKnowledgeGroupsLink.swift in Sources */,
 				CA7A31C422B16E26002AD939 /* WhenPerformingSync_AfterEnforcingFullStoreRefresh_WhenFullRefreshFailed.swift in Sources */,
 				CA7A324622B16E26002AD939 /* WhenSignificantTimeChanges_ScheduleShould.swift in Sources */,
 				CA7A31E022B16E26002AD939 /* StubConventionStartDateRepository.swift in Sources */,

--- a/Domain Model/Domain Model.xcodeproj/project.pbxproj
+++ b/Domain Model/Domain Model.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		CA30FB9C22F36456001C2EB3 /* KnowledgeGroupImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA30FB9B22F36456001C2EB3 /* KnowledgeGroupImpl.swift */; };
 		CA30FB9E22F365E4001C2EB3 /* KnowledgeEntryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA30FB9D22F365E4001C2EB3 /* KnowledgeEntryImpl.swift */; };
 		CA6EE99B22F401E900821E68 /* WhenDescribingKnowledgeGroupsLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6EE99A22F401E900821E68 /* WhenDescribingKnowledgeGroupsLink.swift */; };
+		CA6EE9A122F4B65B00821E68 /* WhenDescribingKnowledgeEntryLink_GroupHasMoreThanOneEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6EE9A022F4B65B00821E68 /* WhenDescribingKnowledgeEntryLink_GroupHasMoreThanOneEntry.swift */; };
 		CA7A2F3422B16DA3002AD939 /* EurofurenceModel.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA7A2F2B22B16DA3002AD939 /* EurofurenceModel.framework */; };
 		CA7A2FFF22B16DE4002AD939 /* EurofurenceSessionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA7A2F4322B16DE3002AD939 /* EurofurenceSessionState.swift */; };
 		CA7A300022B16DE4002AD939 /* ApplicationNotificationKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA7A2F4422B16DE3002AD939 /* ApplicationNotificationKey.swift */; };
@@ -517,6 +518,7 @@
 		CA30FB9B22F36456001C2EB3 /* KnowledgeGroupImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KnowledgeGroupImpl.swift; sourceTree = "<group>"; };
 		CA30FB9D22F365E4001C2EB3 /* KnowledgeEntryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KnowledgeEntryImpl.swift; sourceTree = "<group>"; };
 		CA6EE99A22F401E900821E68 /* WhenDescribingKnowledgeGroupsLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhenDescribingKnowledgeGroupsLink.swift; sourceTree = "<group>"; };
+		CA6EE9A022F4B65B00821E68 /* WhenDescribingKnowledgeEntryLink_GroupHasMoreThanOneEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhenDescribingKnowledgeEntryLink_GroupHasMoreThanOneEntry.swift; sourceTree = "<group>"; };
 		CA7A2F2B22B16DA3002AD939 /* EurofurenceModel.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = EurofurenceModel.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CA7A2F2E22B16DA3002AD939 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		CA7A2F3322B16DA3002AD939 /* EurofurenceModelTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = EurofurenceModelTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1073,6 +1075,7 @@
 			isa = PBXGroup;
 			children = (
 				CA6EE99A22F401E900821E68 /* WhenDescribingKnowledgeGroupsLink.swift */,
+				CA6EE9A022F4B65B00821E68 /* WhenDescribingKnowledgeEntryLink_GroupHasMoreThanOneEntry.swift */,
 			);
 			path = Knowledge;
 			sourceTree = "<group>";
@@ -2870,6 +2873,7 @@
 				CA7A321422B16E26002AD939 /* EurofurenceModelTestAssets.swift in Sources */,
 				CA7A31D122B16E26002AD939 /* WhenFullRefreshOccurs_YieldingOrphanedEntities.swift in Sources */,
 				CA7A31B022B16E26002AD939 /* WhenDataStoreAlreadyContainsMaps_ApplicationShould.swift in Sources */,
+				CA6EE9A122F4B65B00821E68 /* WhenDescribingKnowledgeEntryLink_GroupHasMoreThanOneEntry.swift in Sources */,
 				CAA7DE3922F0C75600A6984D /* WhenPerformingEventSearch_NotRestrictedToFavourites_ThenToggleEventFavouriteState.swift in Sources */,
 				CA7A319922B16E26002AD939 /* KnowledgeGroupsRemoveAllBeforeInsertTests.swift in Sources */,
 				CA8A73E522BD2429007A5201 /* HardcodedCompanionAppURLRequestFactoryTests.swift in Sources */,

--- a/Domain Model/Domain Model.xcodeproj/project.pbxproj
+++ b/Domain Model/Domain Model.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		CA30FB9E22F365E4001C2EB3 /* KnowledgeEntryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA30FB9D22F365E4001C2EB3 /* KnowledgeEntryImpl.swift */; };
 		CA6EE99B22F401E900821E68 /* WhenDescribingKnowledgeGroupsLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6EE99A22F401E900821E68 /* WhenDescribingKnowledgeGroupsLink.swift */; };
 		CA6EE9A122F4B65B00821E68 /* WhenDescribingKnowledgeEntryLink_GroupHasMoreThanOneEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6EE9A022F4B65B00821E68 /* WhenDescribingKnowledgeEntryLink_GroupHasMoreThanOneEntry.swift */; };
+		CA6EE9A722F4D41300821E68 /* WhenDescribingKnowledgeEntryLink_GroupHasOneEntryExactly.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6EE9A622F4D41300821E68 /* WhenDescribingKnowledgeEntryLink_GroupHasOneEntryExactly.swift */; };
 		CA7A2F3422B16DA3002AD939 /* EurofurenceModel.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA7A2F2B22B16DA3002AD939 /* EurofurenceModel.framework */; };
 		CA7A2FFF22B16DE4002AD939 /* EurofurenceSessionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA7A2F4322B16DE3002AD939 /* EurofurenceSessionState.swift */; };
 		CA7A300022B16DE4002AD939 /* ApplicationNotificationKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA7A2F4422B16DE3002AD939 /* ApplicationNotificationKey.swift */; };
@@ -519,6 +520,7 @@
 		CA30FB9D22F365E4001C2EB3 /* KnowledgeEntryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KnowledgeEntryImpl.swift; sourceTree = "<group>"; };
 		CA6EE99A22F401E900821E68 /* WhenDescribingKnowledgeGroupsLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhenDescribingKnowledgeGroupsLink.swift; sourceTree = "<group>"; };
 		CA6EE9A022F4B65B00821E68 /* WhenDescribingKnowledgeEntryLink_GroupHasMoreThanOneEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhenDescribingKnowledgeEntryLink_GroupHasMoreThanOneEntry.swift; sourceTree = "<group>"; };
+		CA6EE9A622F4D41300821E68 /* WhenDescribingKnowledgeEntryLink_GroupHasOneEntryExactly.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhenDescribingKnowledgeEntryLink_GroupHasOneEntryExactly.swift; sourceTree = "<group>"; };
 		CA7A2F2B22B16DA3002AD939 /* EurofurenceModel.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = EurofurenceModel.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CA7A2F2E22B16DA3002AD939 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		CA7A2F3322B16DA3002AD939 /* EurofurenceModelTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = EurofurenceModelTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1076,6 +1078,7 @@
 			children = (
 				CA6EE99A22F401E900821E68 /* WhenDescribingKnowledgeGroupsLink.swift */,
 				CA6EE9A022F4B65B00821E68 /* WhenDescribingKnowledgeEntryLink_GroupHasMoreThanOneEntry.swift */,
+				CA6EE9A622F4D41300821E68 /* WhenDescribingKnowledgeEntryLink_GroupHasOneEntryExactly.swift */,
 			);
 			path = Knowledge;
 			sourceTree = "<group>";
@@ -2876,6 +2879,7 @@
 				CA6EE9A122F4B65B00821E68 /* WhenDescribingKnowledgeEntryLink_GroupHasMoreThanOneEntry.swift in Sources */,
 				CAA7DE3922F0C75600A6984D /* WhenPerformingEventSearch_NotRestrictedToFavourites_ThenToggleEventFavouriteState.swift in Sources */,
 				CA7A319922B16E26002AD939 /* KnowledgeGroupsRemoveAllBeforeInsertTests.swift in Sources */,
+				CA6EE9A722F4D41300821E68 /* WhenDescribingKnowledgeEntryLink_GroupHasOneEntryExactly.swift in Sources */,
 				CA8A73E522BD2429007A5201 /* HardcodedCompanionAppURLRequestFactoryTests.swift in Sources */,
 				CA08B11022EF76D100FDAAA7 /* WhenFavouritingEvent_WithScheduleAndSearchControllerActive.swift in Sources */,
 				CA7A322322B16E26002AD939 /* InOrderToSupportKageTag_ApplicationShould.swift in Sources */,

--- a/Domain Model/EurofurenceModel/Private/ConcreteSession.swift
+++ b/Domain Model/EurofurenceModel/Private/ConcreteSession.swift
@@ -127,7 +127,7 @@ class ConcreteSession: EurofurenceSession {
                                                           refreshService: refreshService,
                                                           privateMessagesService: privateMessagesService)
 
-        let urlEntityProcessor = URLEntityProcessor(eventsService: eventsService, dealersService: dealersService)
+        let urlEntityProcessor = URLEntityProcessor(eventsService: eventsService, dealersService: dealersService, dataStore: dataStore)
         contentLinksService = ConcreteContentLinksService(eventBus: eventBus, urlOpener: urlOpener, urlEntityProcessor: urlEntityProcessor)
         
         eventBus.subscribe(consumer: EventFeedbackService(api: api))

--- a/Domain Model/EurofurenceModel/Private/Services/URL/URLEntityProcessor.swift
+++ b/Domain Model/EurofurenceModel/Private/Services/URL/URLEntityProcessor.swift
@@ -24,11 +24,21 @@ struct URLEntityProcessor {
         }
         
         if url.absoluteString.localizedCaseInsensitiveContains("KnowledgeEntries") {
-            guard let entry = dataStore.fetchKnowledgeEntries()?.first(where: { $0.identifier == identifierComponent }) else { return }
+            let entries = dataStore.fetchKnowledgeEntries()
+            let groups = dataStore.fetchKnowledgeGroups()
+            guard let entry = entries?.first(where: { $0.identifier == identifierComponent }),
+                  let group = groups?.first(where: { $0.identifier == entry.groupIdentifier }),
+                  let numberOfEntriesInGroup = entries?.filter({ $0.groupIdentifier == group.identifier }).count else {
+                    return
+            }
             
             let entryIdentifier = KnowledgeEntryIdentifier(entry.identifier)
-            let groupIdentifier = KnowledgeGroupIdentifier(entry.groupIdentifier)
-            visitor.visitKnowledgeEntry(entryIdentifier, containedWithinGroup: groupIdentifier)
+            if numberOfEntriesInGroup == 1 {
+                visitor.visitKnowledgeEntry(entryIdentifier)
+            } else {
+                let groupIdentifier = KnowledgeGroupIdentifier(entry.groupIdentifier)
+                visitor.visitKnowledgeEntry(entryIdentifier, containedWithinGroup: groupIdentifier)   
+            }
         }
     }
     

--- a/Domain Model/EurofurenceModel/Private/Services/URL/URLEntityProcessor.swift
+++ b/Domain Model/EurofurenceModel/Private/Services/URL/URLEntityProcessor.swift
@@ -17,6 +17,10 @@ struct URLEntityProcessor {
         if dealersService.fetchDealer(for: dealerIdentifier) != nil {
             visitor.visit(dealerIdentifier)
         }
+        
+        if url.absoluteString.localizedCaseInsensitiveContains("KnowledgeGroups") {
+            visitor.visitKnowledgeGroups()
+        }
     }
     
 }

--- a/Domain Model/EurofurenceModel/Private/Services/URL/URLEntityProcessor.swift
+++ b/Domain Model/EurofurenceModel/Private/Services/URL/URLEntityProcessor.swift
@@ -23,7 +23,7 @@ struct URLEntityProcessor {
             visitor.visitKnowledgeGroups()
         }
         
-        if url.absoluteString.contains("KnowledgeEntries") {
+        if url.absoluteString.localizedCaseInsensitiveContains("KnowledgeEntries") {
             guard let entry = dataStore.fetchKnowledgeEntries()?.first(where: { $0.identifier == identifierComponent }) else { return }
             
             let entryIdentifier = KnowledgeEntryIdentifier(entry.identifier)

--- a/Domain Model/EurofurenceModel/Private/Services/URL/URLEntityProcessor.swift
+++ b/Domain Model/EurofurenceModel/Private/Services/URL/URLEntityProcessor.swift
@@ -4,6 +4,7 @@ struct URLEntityProcessor {
     
     var eventsService: EventsService
     var dealersService: DealersService
+    var dataStore: DataStore
     
     func process(_ url: URL, visitor: URLContentVisitor) {
         let identifierComponent = url.lastPathComponent
@@ -20,6 +21,14 @@ struct URLEntityProcessor {
         
         if url.absoluteString.localizedCaseInsensitiveContains("KnowledgeGroups") {
             visitor.visitKnowledgeGroups()
+        }
+        
+        if url.absoluteString.contains("KnowledgeEntries") {
+            guard let entry = dataStore.fetchKnowledgeEntries()?.first(where: { $0.identifier == identifierComponent }) else { return }
+            
+            let entryIdentifier = KnowledgeEntryIdentifier(entry.identifier)
+            let groupIdentifier = KnowledgeGroupIdentifier(entry.groupIdentifier)
+            visitor.visitKnowledgeEntry(entryIdentifier, containedWithinGroup: groupIdentifier)
         }
     }
     

--- a/Domain Model/EurofurenceModel/Public/Session/Services/ContentLinksService.swift
+++ b/Domain Model/EurofurenceModel/Public/Session/Services/ContentLinksService.swift
@@ -15,6 +15,7 @@ public protocol URLContentVisitor {
     
     func visit(_ event: EventIdentifier)
     func visit(_ dealer: DealerIdentifier)
+    func visitKnowledgeGroups()
     
 }
 

--- a/Domain Model/EurofurenceModel/Public/Session/Services/ContentLinksService.swift
+++ b/Domain Model/EurofurenceModel/Public/Session/Services/ContentLinksService.swift
@@ -16,6 +16,7 @@ public protocol URLContentVisitor {
     func visit(_ event: EventIdentifier)
     func visit(_ dealer: DealerIdentifier)
     func visitKnowledgeGroups()
+    func visitKnowledgeEntry(_ knowledgeEntry: KnowledgeEntryIdentifier, containedWithinGroup knowledgeGroup: KnowledgeGroupIdentifier)
     
 }
 

--- a/Domain Model/EurofurenceModel/Public/Session/Services/ContentLinksService.swift
+++ b/Domain Model/EurofurenceModel/Public/Session/Services/ContentLinksService.swift
@@ -14,9 +14,15 @@ public protocol ContentLinksService {
 public protocol URLContentVisitor {
     
     func visit(_ event: EventIdentifier)
+    
     func visit(_ dealer: DealerIdentifier)
+    
     func visitKnowledgeGroups()
-    func visitKnowledgeEntry(_ knowledgeEntry: KnowledgeEntryIdentifier, containedWithinGroup knowledgeGroup: KnowledgeGroupIdentifier)
+    
+    func visitKnowledgeEntry(
+        _ knowledgeEntry: KnowledgeEntryIdentifier,
+        containedWithinGroup knowledgeGroup: KnowledgeGroupIdentifier
+    )
     
 }
 

--- a/Domain Model/EurofurenceModel/Public/Session/Services/ContentLinksService.swift
+++ b/Domain Model/EurofurenceModel/Public/Session/Services/ContentLinksService.swift
@@ -19,6 +19,8 @@ public protocol URLContentVisitor {
     
     func visitKnowledgeGroups()
     
+    func visitKnowledgeEntry(_ knowledgeEntry: KnowledgeEntryIdentifier)
+    
     func visitKnowledgeEntry(
         _ knowledgeEntry: KnowledgeEntryIdentifier,
         containedWithinGroup knowledgeGroup: KnowledgeGroupIdentifier

--- a/Domain Model/EurofurenceModelTests/App Links/Knowledge/WhenDescribingKnowledgeEntryLink_GroupHasMoreThanOneEntry.swift
+++ b/Domain Model/EurofurenceModelTests/App Links/Knowledge/WhenDescribingKnowledgeEntryLink_GroupHasMoreThanOneEntry.swift
@@ -1,0 +1,24 @@
+import EurofurenceModel
+import EurofurenceModelTestDoubles
+import XCTest
+
+class WhenDescribingKnowledgeEntryLink_GroupHasMoreThanOneEntry: XCTestCase {
+
+    func testTheEntryAndGroupIdentifiersAreProvided() {
+        let characteristics = ModelCharacteristics.randomWithoutDeletions
+        let group = characteristics.knowledgeGroups.changed.randomElement().element
+        let entry = characteristics.knowledgeEntries.changed.filter({ $0.groupIdentifier == group.identifier }).randomElement().element
+        let dataStore = InMemoryDataStore(response: characteristics)
+        let cid = ModelCharacteristics.testConventionIdentifier
+        let context = EurofurenceSessionTestBuilder().with(dataStore).build()
+        let urlString = "https://this.bit.doesnt.matter/\(cid)/KnowledgeEntries/\(entry.identifier)"
+        guard let url = URL(string: urlString) else { fatalError("\(urlString) didn't make it into a URL") }
+        
+        let visitor = CapturingURLContentVisitor()
+        context.contentLinksService.describeContent(in: url, toVisitor: visitor)
+        
+        XCTAssertEqual(KnowledgeGroupIdentifier(group.identifier), visitor.visitedKnowledgePairing?.group)
+        XCTAssertEqual(KnowledgeEntryIdentifier(entry.identifier), visitor.visitedKnowledgePairing?.entry)
+    }
+
+}

--- a/Domain Model/EurofurenceModelTests/App Links/Knowledge/WhenDescribingKnowledgeEntryLink_GroupHasMoreThanOneEntry.swift
+++ b/Domain Model/EurofurenceModelTests/App Links/Knowledge/WhenDescribingKnowledgeEntryLink_GroupHasMoreThanOneEntry.swift
@@ -11,7 +11,7 @@ class WhenDescribingKnowledgeEntryLink_GroupHasMoreThanOneEntry: XCTestCase {
         let dataStore = InMemoryDataStore(response: characteristics)
         let cid = ModelCharacteristics.testConventionIdentifier
         let context = EurofurenceSessionTestBuilder().with(dataStore).build()
-        let urlString = "https://this.bit.doesnt.matter/\(cid)/KnowledgeEntries/\(entry.identifier)"
+        let urlString = "https://this.bit.doesnt.matter/\(cid)/KnowleDGEEntRIes/\(entry.identifier)"
         guard let url = URL(string: urlString) else { fatalError("\(urlString) didn't make it into a URL") }
         
         let visitor = CapturingURLContentVisitor()

--- a/Domain Model/EurofurenceModelTests/App Links/Knowledge/WhenDescribingKnowledgeEntryLink_GroupHasOneEntryExactly.swift
+++ b/Domain Model/EurofurenceModelTests/App Links/Knowledge/WhenDescribingKnowledgeEntryLink_GroupHasOneEntryExactly.swift
@@ -1,0 +1,28 @@
+import EurofurenceModel
+import EurofurenceModelTestDoubles
+import XCTest
+
+class WhenDescribingKnowledgeEntryLink_GroupHasOneEntryExactly: XCTestCase {
+
+    func testOnlyTheEntryIdentifierIsProvided() {
+        var characteristics = ModelCharacteristics.randomWithoutDeletions
+        var entry = KnowledgeEntryCharacteristics.random
+        let group = KnowledgeGroupCharacteristics.random
+        entry.groupIdentifier = group.identifier
+        characteristics.knowledgeGroups.changed = [group]
+        characteristics.knowledgeEntries.changed = [entry]
+        
+        let dataStore = InMemoryDataStore(response: characteristics)
+        let cid = ModelCharacteristics.testConventionIdentifier
+        let context = EurofurenceSessionTestBuilder().with(dataStore).build()
+        let urlString = "https://this.bit.doesnt.matter/\(cid)/KnowleDGEEntRIes/\(entry.identifier)"
+        guard let url = URL(string: urlString) else { fatalError("\(urlString) didn't make it into a URL") }
+        
+        let visitor = CapturingURLContentVisitor()
+        context.contentLinksService.describeContent(in: url, toVisitor: visitor)
+        
+        XCTAssertNil(visitor.visitedKnowledgePairing)
+        XCTAssertEqual(KnowledgeEntryIdentifier(entry.identifier), visitor.visitedKnowledgeEntry)
+    }
+
+}

--- a/Domain Model/EurofurenceModelTests/App Links/Knowledge/WhenDescribingKnowledgeGroupsLink.swift
+++ b/Domain Model/EurofurenceModelTests/App Links/Knowledge/WhenDescribingKnowledgeGroupsLink.swift
@@ -1,0 +1,30 @@
+import EurofurenceModel
+import XCTest
+
+class WhenDescribingKnowledgeGroupsLink: XCTestCase {
+
+    func testTheKnowledgeGroupsContentIsProvided() {
+        let cid = ModelCharacteristics.testConventionIdentifier
+        let context = EurofurenceSessionTestBuilder().build()
+        let urlString = "https://this.bit.doesnt.matter/\(cid)/App/Web/KnowledgeGroups"
+        guard let url = URL(string: urlString) else { fatalError("\(urlString) didn't make it into a URL") }
+        
+        let visitor = CapturingURLContentVisitor()
+        context.contentLinksService.describeContent(in: url, toVisitor: visitor)
+        
+        XCTAssertTrue(visitor.didVisitKnowledgeGroups)
+    }
+    
+    func testCaseSensitivityDoesNotMatter() {
+        let cid = ModelCharacteristics.testConventionIdentifier
+        let context = EurofurenceSessionTestBuilder().build()
+        let urlString = "https://this.bit.doesnt.matter/\(cid)/App/Web/kNoWlEdGeGroups"
+        guard let url = URL(string: urlString) else { fatalError("\(urlString) didn't make it into a URL") }
+        
+        let visitor = CapturingURLContentVisitor()
+        context.contentLinksService.describeContent(in: url, toVisitor: visitor)
+        
+        XCTAssertTrue(visitor.didVisitKnowledgeGroups)
+    }
+
+}

--- a/Domain Model/EurofurenceModelTests/Test Doubles/CapturingURLContentVisitor.swift
+++ b/Domain Model/EurofurenceModelTests/Test Doubles/CapturingURLContentVisitor.swift
@@ -18,8 +18,9 @@ class CapturingURLContentVisitor: URLContentVisitor {
         didVisitKnowledgeGroups = true
     }
     
+    private(set) var visitedKnowledgeEntry: KnowledgeEntryIdentifier?
     func visitKnowledgeEntry(_ knowledgeEntry: KnowledgeEntryIdentifier) {
-        
+        visitedKnowledgeEntry = knowledgeEntry
     }
     
     private(set) var visitedKnowledgePairing: (entry: KnowledgeEntryIdentifier, group: KnowledgeGroupIdentifier)?

--- a/Domain Model/EurofurenceModelTests/Test Doubles/CapturingURLContentVisitor.swift
+++ b/Domain Model/EurofurenceModelTests/Test Doubles/CapturingURLContentVisitor.swift
@@ -18,6 +18,10 @@ class CapturingURLContentVisitor: URLContentVisitor {
         didVisitKnowledgeGroups = true
     }
     
+    func visitKnowledgeEntry(_ knowledgeEntry: KnowledgeEntryIdentifier) {
+        
+    }
+    
     private(set) var visitedKnowledgePairing: (entry: KnowledgeEntryIdentifier, group: KnowledgeGroupIdentifier)?
     func visitKnowledgeEntry(
         _ knowledgeEntry: KnowledgeEntryIdentifier,

--- a/Domain Model/EurofurenceModelTests/Test Doubles/CapturingURLContentVisitor.swift
+++ b/Domain Model/EurofurenceModelTests/Test Doubles/CapturingURLContentVisitor.swift
@@ -13,4 +13,8 @@ class CapturingURLContentVisitor: URLContentVisitor {
         visitedDealer = dealer
     }
     
+    func visitKnowledgeGroups() {
+        
+    }
+    
 }

--- a/Domain Model/EurofurenceModelTests/Test Doubles/CapturingURLContentVisitor.swift
+++ b/Domain Model/EurofurenceModelTests/Test Doubles/CapturingURLContentVisitor.swift
@@ -13,8 +13,9 @@ class CapturingURLContentVisitor: URLContentVisitor {
         visitedDealer = dealer
     }
     
+    private(set) var didVisitKnowledgeGroups = false
     func visitKnowledgeGroups() {
-        
+        didVisitKnowledgeGroups = true
     }
     
 }

--- a/Domain Model/EurofurenceModelTests/Test Doubles/CapturingURLContentVisitor.swift
+++ b/Domain Model/EurofurenceModelTests/Test Doubles/CapturingURLContentVisitor.swift
@@ -18,4 +18,12 @@ class CapturingURLContentVisitor: URLContentVisitor {
         didVisitKnowledgeGroups = true
     }
     
+    private(set) var visitedKnowledgePairing: (entry: KnowledgeEntryIdentifier, group: KnowledgeGroupIdentifier)?
+    func visitKnowledgeEntry(
+        _ knowledgeEntry: KnowledgeEntryIdentifier,
+        containedWithinGroup knowledgeGroup: KnowledgeGroupIdentifier
+    ) {
+        visitedKnowledgePairing = (entry: knowledgeEntry, group: knowledgeGroup)
+    }
+    
 }

--- a/Eurofurence.xcodeproj/project.pbxproj
+++ b/Eurofurence.xcodeproj/project.pbxproj
@@ -695,6 +695,7 @@
 		CA6EE99822F4007200821E68 /* WhenResumingKnowledgeGroupsURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6EE99722F4007200821E68 /* WhenResumingKnowledgeGroupsURL.swift */; };
 		CA6EE99D22F4036F00821E68 /* WhenOpeningKnowledgeEntries_DirectorShould.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6EE99C22F4036F00821E68 /* WhenOpeningKnowledgeEntries_DirectorShould.swift */; };
 		CA6EE99F22F4B49500821E68 /* WhenResumingKnowledgeEntryURL_WithParentGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6EE99E22F4B49500821E68 /* WhenResumingKnowledgeEntryURL_WithParentGroup.swift */; };
+		CA6EE9A322F4C03200821E68 /* WhenOpeningKnowledgeEntry_WithParentGroup_DirectorShould.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6EE9A222F4C03200821E68 /* WhenOpeningKnowledgeEntry_WithParentGroup_DirectorShould.swift */; };
 		CA6F652722690DB500483EE0 /* WhenToldToLeaveFeedback_EventDetailPresenterShould.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6F652622690DB500483EE0 /* WhenToldToLeaveFeedback_EventDetailPresenterShould.swift */; };
 		CA6F652922690EF700483EE0 /* EventDetailModuleDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6F652822690EF700483EE0 /* EventDetailModuleDelegate.swift */; };
 		CA6F652B22690F0C00483EE0 /* CapturingEventDetailModuleDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6F652A22690F0C00483EE0 /* CapturingEventDetailModuleDelegate.swift */; };
@@ -1812,6 +1813,7 @@
 		CA6EE99722F4007200821E68 /* WhenResumingKnowledgeGroupsURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhenResumingKnowledgeGroupsURL.swift; sourceTree = "<group>"; };
 		CA6EE99C22F4036F00821E68 /* WhenOpeningKnowledgeEntries_DirectorShould.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhenOpeningKnowledgeEntries_DirectorShould.swift; sourceTree = "<group>"; };
 		CA6EE99E22F4B49500821E68 /* WhenResumingKnowledgeEntryURL_WithParentGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhenResumingKnowledgeEntryURL_WithParentGroup.swift; sourceTree = "<group>"; };
+		CA6EE9A222F4C03200821E68 /* WhenOpeningKnowledgeEntry_WithParentGroup_DirectorShould.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhenOpeningKnowledgeEntry_WithParentGroup_DirectorShould.swift; sourceTree = "<group>"; };
 		CA6F652622690DB500483EE0 /* WhenToldToLeaveFeedback_EventDetailPresenterShould.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhenToldToLeaveFeedback_EventDetailPresenterShould.swift; sourceTree = "<group>"; };
 		CA6F652822690EF700483EE0 /* EventDetailModuleDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventDetailModuleDelegate.swift; sourceTree = "<group>"; };
 		CA6F652A22690F0C00483EE0 /* CapturingEventDetailModuleDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapturingEventDetailModuleDelegate.swift; sourceTree = "<group>"; };
@@ -5444,6 +5446,7 @@
 				CAA10FE122C5E29700689A32 /* WhenOpeningMessage_DirectorShould.swift */,
 				CA2AA2D622C93FBA00C0E1A1 /* WhenOpeningDealer_DirectorShould.swift */,
 				CA6EE99C22F4036F00821E68 /* WhenOpeningKnowledgeEntries_DirectorShould.swift */,
+				CA6EE9A222F4C03200821E68 /* WhenOpeningKnowledgeEntry_WithParentGroup_DirectorShould.swift */,
 			);
 			path = "Opening Content";
 			sourceTree = "<group>";
@@ -6864,6 +6867,7 @@
 				CA89CBC22085385900570D54 /* AnnouncementsViewModel.swift in Sources */,
 				CA637554208CBBC000536BE2 /* CapturingWindowWireframe.swift in Sources */,
 				CACF26C920FE258B00EDE150 /* WhenBindingFavouriteEvent_NewsPresenterShould.swift in Sources */,
+				CA6EE9A322F4C03200821E68 /* WhenOpeningKnowledgeEntry_WithParentGroup_DirectorShould.swift in Sources */,
 				CA63756C208CCB8900536BE2 /* WhenPreloadFails_DirectorShould.swift in Sources */,
 				CA6F652B22690F0C00483EE0 /* CapturingEventDetailModuleDelegate.swift in Sources */,
 				CA152EC82263CD2000212742 /* WhenEventFeedbackScenePreparesFeedback_EventFeedbackPresenterShould.swift in Sources */,

--- a/Eurofurence.xcodeproj/project.pbxproj
+++ b/Eurofurence.xcodeproj/project.pbxproj
@@ -694,6 +694,7 @@
 		CA6EE99622F36D4800821E68 /* VisitsEntryFromKnowledgeListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6EE99522F36D4800821E68 /* VisitsEntryFromKnowledgeListViewModel.swift */; };
 		CA6EE99822F4007200821E68 /* WhenResumingKnowledgeGroupsURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6EE99722F4007200821E68 /* WhenResumingKnowledgeGroupsURL.swift */; };
 		CA6EE99D22F4036F00821E68 /* WhenOpeningKnowledgeEntries_DirectorShould.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6EE99C22F4036F00821E68 /* WhenOpeningKnowledgeEntries_DirectorShould.swift */; };
+		CA6EE99F22F4B49500821E68 /* WhenResumingKnowledgeEntryURL_WithParentGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6EE99E22F4B49500821E68 /* WhenResumingKnowledgeEntryURL_WithParentGroup.swift */; };
 		CA6F652722690DB500483EE0 /* WhenToldToLeaveFeedback_EventDetailPresenterShould.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6F652622690DB500483EE0 /* WhenToldToLeaveFeedback_EventDetailPresenterShould.swift */; };
 		CA6F652922690EF700483EE0 /* EventDetailModuleDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6F652822690EF700483EE0 /* EventDetailModuleDelegate.swift */; };
 		CA6F652B22690F0C00483EE0 /* CapturingEventDetailModuleDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6F652A22690F0C00483EE0 /* CapturingEventDetailModuleDelegate.swift */; };
@@ -1810,6 +1811,7 @@
 		CA6EE99522F36D4800821E68 /* VisitsEntryFromKnowledgeListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisitsEntryFromKnowledgeListViewModel.swift; sourceTree = "<group>"; };
 		CA6EE99722F4007200821E68 /* WhenResumingKnowledgeGroupsURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhenResumingKnowledgeGroupsURL.swift; sourceTree = "<group>"; };
 		CA6EE99C22F4036F00821E68 /* WhenOpeningKnowledgeEntries_DirectorShould.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhenOpeningKnowledgeEntries_DirectorShould.swift; sourceTree = "<group>"; };
+		CA6EE99E22F4B49500821E68 /* WhenResumingKnowledgeEntryURL_WithParentGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhenResumingKnowledgeEntryURL_WithParentGroup.swift; sourceTree = "<group>"; };
 		CA6F652622690DB500483EE0 /* WhenToldToLeaveFeedback_EventDetailPresenterShould.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhenToldToLeaveFeedback_EventDetailPresenterShould.swift; sourceTree = "<group>"; };
 		CA6F652822690EF700483EE0 /* EventDetailModuleDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventDetailModuleDelegate.swift; sourceTree = "<group>"; };
 		CA6F652A22690F0C00483EE0 /* CapturingEventDetailModuleDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapturingEventDetailModuleDelegate.swift; sourceTree = "<group>"; };
@@ -5042,6 +5044,7 @@
 				CAB0FD6422C93A0B00D4CB98 /* WhenResumingDealerURL.swift */,
 				CAB0FD5A22C90D8D00D4CB98 /* WhenResumingEventURL.swift */,
 				CA6EE99722F4007200821E68 /* WhenResumingKnowledgeGroupsURL.swift */,
+				CA6EE99E22F4B49500821E68 /* WhenResumingKnowledgeEntryURL_WithParentGroup.swift */,
 			);
 			path = URL;
 			sourceTree = "<group>";
@@ -7076,6 +7079,7 @@
 				CA987FD622E64380006338FB /* DealerDetailPresenter_InteractionRecordingTests.swift in Sources */,
 				CA6A8D8920E2BBA4007536CD /* FakeMapsViewModel.swift in Sources */,
 				CA36A4C020DA74CB00EE6537 /* WhenSceneUpdatesSearchQuery_DealersPresenterShould.swift in Sources */,
+				CA6EE99F22F4B49500821E68 /* WhenResumingKnowledgeEntryURL_WithParentGroup.swift in Sources */,
 				CACEA06F2242832F00DFF26C /* CapturingNotificationScheduler.swift in Sources */,
 				CA50B1A42261105C0091E425 /* CapturingEventFeedbackScene.swift in Sources */,
 				CACF1E7620B1D0FC00D904B5 /* StubEventSummaryViewModel.swift in Sources */,

--- a/Eurofurence.xcodeproj/project.pbxproj
+++ b/Eurofurence.xcodeproj/project.pbxproj
@@ -692,6 +692,7 @@
 		CA6EC48E2051D97600402894 /* KnowledgeDetailPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6EC48D2051D97600402894 /* KnowledgeDetailPresenter.swift */; };
 		CA6EE99422F36B6900821E68 /* WhenSelectingItemInKnowledgeList_ThatRelatesToEntry_KnowledgeListPresenterShould.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6EE99322F36B6900821E68 /* WhenSelectingItemInKnowledgeList_ThatRelatesToEntry_KnowledgeListPresenterShould.swift */; };
 		CA6EE99622F36D4800821E68 /* VisitsEntryFromKnowledgeListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6EE99522F36D4800821E68 /* VisitsEntryFromKnowledgeListViewModel.swift */; };
+		CA6EE99822F4007200821E68 /* WhenResumingKnowledgeGroupsURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6EE99722F4007200821E68 /* WhenResumingKnowledgeGroupsURL.swift */; };
 		CA6F652722690DB500483EE0 /* WhenToldToLeaveFeedback_EventDetailPresenterShould.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6F652622690DB500483EE0 /* WhenToldToLeaveFeedback_EventDetailPresenterShould.swift */; };
 		CA6F652922690EF700483EE0 /* EventDetailModuleDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6F652822690EF700483EE0 /* EventDetailModuleDelegate.swift */; };
 		CA6F652B22690F0C00483EE0 /* CapturingEventDetailModuleDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6F652A22690F0C00483EE0 /* CapturingEventDetailModuleDelegate.swift */; };
@@ -1806,6 +1807,7 @@
 		CA6EC48D2051D97600402894 /* KnowledgeDetailPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KnowledgeDetailPresenter.swift; sourceTree = "<group>"; };
 		CA6EE99322F36B6900821E68 /* WhenSelectingItemInKnowledgeList_ThatRelatesToEntry_KnowledgeListPresenterShould.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhenSelectingItemInKnowledgeList_ThatRelatesToEntry_KnowledgeListPresenterShould.swift; sourceTree = "<group>"; };
 		CA6EE99522F36D4800821E68 /* VisitsEntryFromKnowledgeListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisitsEntryFromKnowledgeListViewModel.swift; sourceTree = "<group>"; };
+		CA6EE99722F4007200821E68 /* WhenResumingKnowledgeGroupsURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhenResumingKnowledgeGroupsURL.swift; sourceTree = "<group>"; };
 		CA6F652622690DB500483EE0 /* WhenToldToLeaveFeedback_EventDetailPresenterShould.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhenToldToLeaveFeedback_EventDetailPresenterShould.swift; sourceTree = "<group>"; };
 		CA6F652822690EF700483EE0 /* EventDetailModuleDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventDetailModuleDelegate.swift; sourceTree = "<group>"; };
 		CA6F652A22690F0C00483EE0 /* CapturingEventDetailModuleDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapturingEventDetailModuleDelegate.swift; sourceTree = "<group>"; };
@@ -5037,6 +5039,7 @@
 			children = (
 				CAB0FD6422C93A0B00D4CB98 /* WhenResumingDealerURL.swift */,
 				CAB0FD5A22C90D8D00D4CB98 /* WhenResumingEventURL.swift */,
+				CA6EE99722F4007200821E68 /* WhenResumingKnowledgeGroupsURL.swift */,
 			);
 			path = URL;
 			sourceTree = "<group>";
@@ -6745,6 +6748,7 @@
 				CA00AE7320D18D1E00C2FBB0 /* WhenPreparingViewModel_ScheduleInteractorShould.swift in Sources */,
 				CAF705611F82CBDE00A9FEA2 /* ApplicationDirectorTests.swift in Sources */,
 				CA250DE420D6F68700E7513C /* WhenSearchControllerProducesNewResults_ScheduleInteractorShould.swift in Sources */,
+				CA6EE99822F4007200821E68 /* WhenResumingKnowledgeGroupsURL.swift in Sources */,
 				CA89CBAB207F7FE900570D54 /* NewsViewModel+RandomValueProviding.swift in Sources */,
 				CA89CBBA2084CA8A00570D54 /* StubNewsViewModel.swift in Sources */,
 				CA1B6F2B20DB8A9C00ADF414 /* BeforeDealerDetailSceneLoads_DealerDetailPresenterShould.swift in Sources */,

--- a/Eurofurence.xcodeproj/project.pbxproj
+++ b/Eurofurence.xcodeproj/project.pbxproj
@@ -696,6 +696,7 @@
 		CA6EE99D22F4036F00821E68 /* WhenOpeningKnowledgeEntries_DirectorShould.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6EE99C22F4036F00821E68 /* WhenOpeningKnowledgeEntries_DirectorShould.swift */; };
 		CA6EE99F22F4B49500821E68 /* WhenResumingKnowledgeEntryURL_WithParentGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6EE99E22F4B49500821E68 /* WhenResumingKnowledgeEntryURL_WithParentGroup.swift */; };
 		CA6EE9A322F4C03200821E68 /* WhenOpeningKnowledgeEntry_WithParentGroup_DirectorShould.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6EE9A222F4C03200821E68 /* WhenOpeningKnowledgeEntry_WithParentGroup_DirectorShould.swift */; };
+		CA6EE9A522F4D2BD00821E68 /* WhenResumingKnowledgeEntry_WithoutParentGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6EE9A422F4D2BD00821E68 /* WhenResumingKnowledgeEntry_WithoutParentGroup.swift */; };
 		CA6F652722690DB500483EE0 /* WhenToldToLeaveFeedback_EventDetailPresenterShould.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6F652622690DB500483EE0 /* WhenToldToLeaveFeedback_EventDetailPresenterShould.swift */; };
 		CA6F652922690EF700483EE0 /* EventDetailModuleDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6F652822690EF700483EE0 /* EventDetailModuleDelegate.swift */; };
 		CA6F652B22690F0C00483EE0 /* CapturingEventDetailModuleDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6F652A22690F0C00483EE0 /* CapturingEventDetailModuleDelegate.swift */; };
@@ -1814,6 +1815,7 @@
 		CA6EE99C22F4036F00821E68 /* WhenOpeningKnowledgeEntries_DirectorShould.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhenOpeningKnowledgeEntries_DirectorShould.swift; sourceTree = "<group>"; };
 		CA6EE99E22F4B49500821E68 /* WhenResumingKnowledgeEntryURL_WithParentGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhenResumingKnowledgeEntryURL_WithParentGroup.swift; sourceTree = "<group>"; };
 		CA6EE9A222F4C03200821E68 /* WhenOpeningKnowledgeEntry_WithParentGroup_DirectorShould.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhenOpeningKnowledgeEntry_WithParentGroup_DirectorShould.swift; sourceTree = "<group>"; };
+		CA6EE9A422F4D2BD00821E68 /* WhenResumingKnowledgeEntry_WithoutParentGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhenResumingKnowledgeEntry_WithoutParentGroup.swift; sourceTree = "<group>"; };
 		CA6F652622690DB500483EE0 /* WhenToldToLeaveFeedback_EventDetailPresenterShould.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhenToldToLeaveFeedback_EventDetailPresenterShould.swift; sourceTree = "<group>"; };
 		CA6F652822690EF700483EE0 /* EventDetailModuleDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventDetailModuleDelegate.swift; sourceTree = "<group>"; };
 		CA6F652A22690F0C00483EE0 /* CapturingEventDetailModuleDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapturingEventDetailModuleDelegate.swift; sourceTree = "<group>"; };
@@ -5047,6 +5049,7 @@
 				CAB0FD5A22C90D8D00D4CB98 /* WhenResumingEventURL.swift */,
 				CA6EE99722F4007200821E68 /* WhenResumingKnowledgeGroupsURL.swift */,
 				CA6EE99E22F4B49500821E68 /* WhenResumingKnowledgeEntryURL_WithParentGroup.swift */,
+				CA6EE9A422F4D2BD00821E68 /* WhenResumingKnowledgeEntry_WithoutParentGroup.swift */,
 			);
 			path = URL;
 			sourceTree = "<group>";
@@ -6680,6 +6683,7 @@
 				CA08159720D475B500F750D4 /* FakeEventsService.swift in Sources */,
 				CA1B6F1020DB818A00ADF414 /* CapturingDealerDetailScene.swift in Sources */,
 				CA63754C208CBB7800536BE2 /* StubMessagesModuleFactory.swift in Sources */,
+				CA6EE9A522F4D2BD00821E68 /* WhenResumingKnowledgeEntry_WithoutParentGroup.swift in Sources */,
 				CA7D8B1C222DB19B003431A0 /* DefaultNewsInteractorTestBuilderContext.swift in Sources */,
 				CA6A8D7620E264C5007536CD /* StubMapsSceneFactory.swift in Sources */,
 				CA8A73D022BD14F3007A5201 /* BeforeAdditionalServicesSceneLoads_PresenterShould.swift in Sources */,

--- a/Eurofurence.xcodeproj/project.pbxproj
+++ b/Eurofurence.xcodeproj/project.pbxproj
@@ -693,6 +693,7 @@
 		CA6EE99422F36B6900821E68 /* WhenSelectingItemInKnowledgeList_ThatRelatesToEntry_KnowledgeListPresenterShould.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6EE99322F36B6900821E68 /* WhenSelectingItemInKnowledgeList_ThatRelatesToEntry_KnowledgeListPresenterShould.swift */; };
 		CA6EE99622F36D4800821E68 /* VisitsEntryFromKnowledgeListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6EE99522F36D4800821E68 /* VisitsEntryFromKnowledgeListViewModel.swift */; };
 		CA6EE99822F4007200821E68 /* WhenResumingKnowledgeGroupsURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6EE99722F4007200821E68 /* WhenResumingKnowledgeGroupsURL.swift */; };
+		CA6EE99D22F4036F00821E68 /* WhenOpeningKnowledgeEntries_DirectorShould.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6EE99C22F4036F00821E68 /* WhenOpeningKnowledgeEntries_DirectorShould.swift */; };
 		CA6F652722690DB500483EE0 /* WhenToldToLeaveFeedback_EventDetailPresenterShould.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6F652622690DB500483EE0 /* WhenToldToLeaveFeedback_EventDetailPresenterShould.swift */; };
 		CA6F652922690EF700483EE0 /* EventDetailModuleDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6F652822690EF700483EE0 /* EventDetailModuleDelegate.swift */; };
 		CA6F652B22690F0C00483EE0 /* CapturingEventDetailModuleDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6F652A22690F0C00483EE0 /* CapturingEventDetailModuleDelegate.swift */; };
@@ -1808,6 +1809,7 @@
 		CA6EE99322F36B6900821E68 /* WhenSelectingItemInKnowledgeList_ThatRelatesToEntry_KnowledgeListPresenterShould.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhenSelectingItemInKnowledgeList_ThatRelatesToEntry_KnowledgeListPresenterShould.swift; sourceTree = "<group>"; };
 		CA6EE99522F36D4800821E68 /* VisitsEntryFromKnowledgeListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisitsEntryFromKnowledgeListViewModel.swift; sourceTree = "<group>"; };
 		CA6EE99722F4007200821E68 /* WhenResumingKnowledgeGroupsURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhenResumingKnowledgeGroupsURL.swift; sourceTree = "<group>"; };
+		CA6EE99C22F4036F00821E68 /* WhenOpeningKnowledgeEntries_DirectorShould.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhenOpeningKnowledgeEntries_DirectorShould.swift; sourceTree = "<group>"; };
 		CA6F652622690DB500483EE0 /* WhenToldToLeaveFeedback_EventDetailPresenterShould.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhenToldToLeaveFeedback_EventDetailPresenterShould.swift; sourceTree = "<group>"; };
 		CA6F652822690EF700483EE0 /* EventDetailModuleDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventDetailModuleDelegate.swift; sourceTree = "<group>"; };
 		CA6F652A22690F0C00483EE0 /* CapturingEventDetailModuleDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapturingEventDetailModuleDelegate.swift; sourceTree = "<group>"; };
@@ -5438,6 +5440,7 @@
 				CAD55942229AF6C30068DD46 /* WhenShowingInvalidatedAnnouncementAlert_DirectorShould.swift */,
 				CAA10FE122C5E29700689A32 /* WhenOpeningMessage_DirectorShould.swift */,
 				CA2AA2D622C93FBA00C0E1A1 /* WhenOpeningDealer_DirectorShould.swift */,
+				CA6EE99C22F4036F00821E68 /* WhenOpeningKnowledgeEntries_DirectorShould.swift */,
 			);
 			path = "Opening Content";
 			sourceTree = "<group>";
@@ -6598,6 +6601,7 @@
 				CABA83F420CE988B00DD0795 /* WhenFavouritingEventViewModel_EventDetailInteractorShould.swift in Sources */,
 				CAD260A720C03909007E3618 /* WhenViewModelIndicatesEventIsFavourite_EventDetailPresenterShould.swift in Sources */,
 				CA27255C2112525E004C6D0A /* CapturingKnowledgeEntryImageScene.swift in Sources */,
+				CA6EE99D22F4036F00821E68 /* WhenOpeningKnowledgeEntries_DirectorShould.swift in Sources */,
 				CA6A8E0320E5048A007536CD /* WhenSceneTapsMapPosition_ThatProvidesSimpleContextualDetail_MapsPresenterShould.swift in Sources */,
 				CA630BF722A0650E00754C27 /* WhenResumingUnknownIntent.swift in Sources */,
 				CA283A7C20E91F3600F7D195 /* WhenToldToRefresh_ScheduleViewModelShould.swift in Sources */,

--- a/Eurofurence.xcodeproj/project.pbxproj
+++ b/Eurofurence.xcodeproj/project.pbxproj
@@ -697,6 +697,7 @@
 		CA6EE99F22F4B49500821E68 /* WhenResumingKnowledgeEntryURL_WithParentGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6EE99E22F4B49500821E68 /* WhenResumingKnowledgeEntryURL_WithParentGroup.swift */; };
 		CA6EE9A322F4C03200821E68 /* WhenOpeningKnowledgeEntry_WithParentGroup_DirectorShould.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6EE9A222F4C03200821E68 /* WhenOpeningKnowledgeEntry_WithParentGroup_DirectorShould.swift */; };
 		CA6EE9A522F4D2BD00821E68 /* WhenResumingKnowledgeEntry_WithoutParentGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6EE9A422F4D2BD00821E68 /* WhenResumingKnowledgeEntry_WithoutParentGroup.swift */; };
+		CA6EE9A922F4D62F00821E68 /* WhenOpeningKnowledgeEntry_WithoutParentGroup_DirectorShould.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6EE9A822F4D62F00821E68 /* WhenOpeningKnowledgeEntry_WithoutParentGroup_DirectorShould.swift */; };
 		CA6F652722690DB500483EE0 /* WhenToldToLeaveFeedback_EventDetailPresenterShould.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6F652622690DB500483EE0 /* WhenToldToLeaveFeedback_EventDetailPresenterShould.swift */; };
 		CA6F652922690EF700483EE0 /* EventDetailModuleDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6F652822690EF700483EE0 /* EventDetailModuleDelegate.swift */; };
 		CA6F652B22690F0C00483EE0 /* CapturingEventDetailModuleDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6F652A22690F0C00483EE0 /* CapturingEventDetailModuleDelegate.swift */; };
@@ -1816,6 +1817,7 @@
 		CA6EE99E22F4B49500821E68 /* WhenResumingKnowledgeEntryURL_WithParentGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhenResumingKnowledgeEntryURL_WithParentGroup.swift; sourceTree = "<group>"; };
 		CA6EE9A222F4C03200821E68 /* WhenOpeningKnowledgeEntry_WithParentGroup_DirectorShould.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhenOpeningKnowledgeEntry_WithParentGroup_DirectorShould.swift; sourceTree = "<group>"; };
 		CA6EE9A422F4D2BD00821E68 /* WhenResumingKnowledgeEntry_WithoutParentGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhenResumingKnowledgeEntry_WithoutParentGroup.swift; sourceTree = "<group>"; };
+		CA6EE9A822F4D62F00821E68 /* WhenOpeningKnowledgeEntry_WithoutParentGroup_DirectorShould.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhenOpeningKnowledgeEntry_WithoutParentGroup_DirectorShould.swift; sourceTree = "<group>"; };
 		CA6F652622690DB500483EE0 /* WhenToldToLeaveFeedback_EventDetailPresenterShould.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhenToldToLeaveFeedback_EventDetailPresenterShould.swift; sourceTree = "<group>"; };
 		CA6F652822690EF700483EE0 /* EventDetailModuleDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventDetailModuleDelegate.swift; sourceTree = "<group>"; };
 		CA6F652A22690F0C00483EE0 /* CapturingEventDetailModuleDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapturingEventDetailModuleDelegate.swift; sourceTree = "<group>"; };
@@ -5450,6 +5452,7 @@
 				CA2AA2D622C93FBA00C0E1A1 /* WhenOpeningDealer_DirectorShould.swift */,
 				CA6EE99C22F4036F00821E68 /* WhenOpeningKnowledgeEntries_DirectorShould.swift */,
 				CA6EE9A222F4C03200821E68 /* WhenOpeningKnowledgeEntry_WithParentGroup_DirectorShould.swift */,
+				CA6EE9A822F4D62F00821E68 /* WhenOpeningKnowledgeEntry_WithoutParentGroup_DirectorShould.swift */,
 			);
 			path = "Opening Content";
 			sourceTree = "<group>";
@@ -7093,6 +7096,7 @@
 				CACF1E7620B1D0FC00D904B5 /* StubEventSummaryViewModel.swift in Sources */,
 				CAD3BDB520587DD800C91E6E /* WhenShowingKnowledgeEntryWithoutLinks.swift in Sources */,
 				CA637568208CC9C700536BE2 /* WhenTutorialFinished_DirectorShould.swift in Sources */,
+				CA6EE9A922F4D62F00821E68 /* WhenOpeningKnowledgeEntry_WithoutParentGroup_DirectorShould.swift in Sources */,
 				CA250DDC20D6E85700E7513C /* WhenSearching_ScheduleInteractorShould.swift in Sources */,
 				CA6A8DDB20E41844007536CD /* MapDetailPresenterTestBuilder.swift in Sources */,
 				CA152EF822666D4F00212742 /* CapturingEventDetailViewModelVisitor.swift in Sources */,

--- a/Eurofurence/Activity/Resuming/ActivityResumer.swift
+++ b/Eurofurence/Activity/Resuming/ActivityResumer.swift
@@ -101,6 +101,14 @@ struct ActivityResumer {
             handledContent = true
         }
         
+        func visitKnowledgeEntry(
+            _ knowledgeEntry: KnowledgeEntryIdentifier,
+            containedWithinGroup knowledgeGroup: KnowledgeGroupIdentifier
+        ) {
+            contentRouter.resumeViewingKnowledgeEntry(knowledgeEntry, parentGroup: knowledgeGroup)
+            handledContent = true
+        }
+        
     }
     
 }

--- a/Eurofurence/Activity/Resuming/ActivityResumer.swift
+++ b/Eurofurence/Activity/Resuming/ActivityResumer.swift
@@ -96,6 +96,11 @@ struct ActivityResumer {
             handledContent = true
         }
         
+        func visitKnowledgeGroups() {
+            contentRouter.resumeViewingKnowledgeGroups()
+            handledContent = true
+        }
+        
     }
     
 }

--- a/Eurofurence/Activity/Resuming/ActivityResumer.swift
+++ b/Eurofurence/Activity/Resuming/ActivityResumer.swift
@@ -101,6 +101,11 @@ struct ActivityResumer {
             handledContent = true
         }
         
+        func visitKnowledgeEntry(_ knowledgeEntry: KnowledgeEntryIdentifier) {
+            contentRouter.resumeViewingKnowledgeEntry(knowledgeEntry)
+            handledContent = true
+        }
+        
         func visitKnowledgeEntry(
             _ knowledgeEntry: KnowledgeEntryIdentifier,
             containedWithinGroup knowledgeGroup: KnowledgeGroupIdentifier

--- a/Eurofurence/Activity/Resuming/Content Router/ContentRouter.swift
+++ b/Eurofurence/Activity/Resuming/Content Router/ContentRouter.swift
@@ -5,5 +5,6 @@ protocol ContentRouter {
     func resumeViewingEvent(identifier: EventIdentifier)
     func resumeViewingDealer(identifier: DealerIdentifier)
     func resumeViewingKnowledgeGroups()
+    func resumeViewingKnowledgeEntry(_ knowledgeEntry: KnowledgeEntryIdentifier, parentGroup: KnowledgeGroupIdentifier)
     
 }

--- a/Eurofurence/Activity/Resuming/Content Router/ContentRouter.swift
+++ b/Eurofurence/Activity/Resuming/Content Router/ContentRouter.swift
@@ -4,5 +4,6 @@ protocol ContentRouter {
     
     func resumeViewingEvent(identifier: EventIdentifier)
     func resumeViewingDealer(identifier: DealerIdentifier)
+    func resumeViewingKnowledgeGroups()
     
 }

--- a/Eurofurence/Activity/Resuming/Content Router/ContentRouter.swift
+++ b/Eurofurence/Activity/Resuming/Content Router/ContentRouter.swift
@@ -5,6 +5,7 @@ protocol ContentRouter {
     func resumeViewingEvent(identifier: EventIdentifier)
     func resumeViewingDealer(identifier: DealerIdentifier)
     func resumeViewingKnowledgeGroups()
+    func resumeViewingKnowledgeEntry(_ knowledgeEntry: KnowledgeEntryIdentifier)
     func resumeViewingKnowledgeEntry(_ knowledgeEntry: KnowledgeEntryIdentifier, parentGroup: KnowledgeGroupIdentifier)
     
 }

--- a/Eurofurence/Activity/Resuming/Content Router/DirectorContentRouter.swift
+++ b/Eurofurence/Activity/Resuming/Content Router/DirectorContentRouter.swift
@@ -13,7 +13,7 @@ struct DirectorContentRouter: ContentRouter {
     }
     
     func resumeViewingKnowledgeGroups() {
-        
+        director.openKnowledgeGroups()
     }
     
 }

--- a/Eurofurence/Activity/Resuming/Content Router/DirectorContentRouter.swift
+++ b/Eurofurence/Activity/Resuming/Content Router/DirectorContentRouter.swift
@@ -16,6 +16,10 @@ struct DirectorContentRouter: ContentRouter {
         director.openKnowledgeGroups()
     }
     
+    func resumeViewingKnowledgeEntry(_ knowledgeEntry: KnowledgeEntryIdentifier) {
+        
+    }
+    
     func resumeViewingKnowledgeEntry(_ knowledgeEntry: KnowledgeEntryIdentifier, parentGroup: KnowledgeGroupIdentifier) {
         director.openKnowledgeEntry(knowledgeEntry, parentGroup: parentGroup)
     }

--- a/Eurofurence/Activity/Resuming/Content Router/DirectorContentRouter.swift
+++ b/Eurofurence/Activity/Resuming/Content Router/DirectorContentRouter.swift
@@ -12,4 +12,8 @@ struct DirectorContentRouter: ContentRouter {
         director.openDealer(identifier)
     }
     
+    func resumeViewingKnowledgeGroups() {
+        
+    }
+    
 }

--- a/Eurofurence/Activity/Resuming/Content Router/DirectorContentRouter.swift
+++ b/Eurofurence/Activity/Resuming/Content Router/DirectorContentRouter.swift
@@ -17,7 +17,7 @@ struct DirectorContentRouter: ContentRouter {
     }
     
     func resumeViewingKnowledgeEntry(_ knowledgeEntry: KnowledgeEntryIdentifier) {
-        
+        director.openKnowledgeEntry(knowledgeEntry)
     }
     
     func resumeViewingKnowledgeEntry(_ knowledgeEntry: KnowledgeEntryIdentifier, parentGroup: KnowledgeGroupIdentifier) {

--- a/Eurofurence/Activity/Resuming/Content Router/DirectorContentRouter.swift
+++ b/Eurofurence/Activity/Resuming/Content Router/DirectorContentRouter.swift
@@ -16,4 +16,8 @@ struct DirectorContentRouter: ContentRouter {
         director.openKnowledgeGroups()
     }
     
+    func resumeViewingKnowledgeEntry(_ knowledgeEntry: KnowledgeEntryIdentifier, parentGroup: KnowledgeGroupIdentifier) {
+        
+    }
+    
 }

--- a/Eurofurence/Activity/Resuming/Content Router/DirectorContentRouter.swift
+++ b/Eurofurence/Activity/Resuming/Content Router/DirectorContentRouter.swift
@@ -17,7 +17,7 @@ struct DirectorContentRouter: ContentRouter {
     }
     
     func resumeViewingKnowledgeEntry(_ knowledgeEntry: KnowledgeEntryIdentifier, parentGroup: KnowledgeGroupIdentifier) {
-        
+        director.openKnowledgeEntry(knowledgeEntry, parentGroup: parentGroup)
     }
     
 }

--- a/Eurofurence/Director/ApplicationDirector.swift
+++ b/Eurofurence/Director/ApplicationDirector.swift
@@ -64,6 +64,10 @@ class ApplicationDirector: RootModuleDelegate, TutorialModuleDelegate, PreloadMo
         tabBarDirector?.openMessage(message)
     }
     
+    func openKnowledgeGroups() {
+        tabBarDirector?.openKnowledgeGroups()
+    }
+    
     func showInvalidatedAnnouncementAlert() {
         tabBarDirector?.showInvalidatedAnnouncementAlert()
     }

--- a/Eurofurence/Director/ApplicationDirector.swift
+++ b/Eurofurence/Director/ApplicationDirector.swift
@@ -71,6 +71,10 @@ class ApplicationDirector: RootModuleDelegate, TutorialModuleDelegate, PreloadMo
     func showInvalidatedAnnouncementAlert() {
         tabBarDirector?.showInvalidatedAnnouncementAlert()
     }
+    
+    func openKnowledgeEntry(_ knowledgeEntry: KnowledgeEntryIdentifier, parentGroup: KnowledgeGroupIdentifier) {
+        tabBarDirector?.openKnowledgeEntry(knowledgeEntry, parentGroup: parentGroup)
+    }
 
     // MARK: RootModuleDelegate
 

--- a/Eurofurence/Director/ApplicationDirector.swift
+++ b/Eurofurence/Director/ApplicationDirector.swift
@@ -72,6 +72,10 @@ class ApplicationDirector: RootModuleDelegate, TutorialModuleDelegate, PreloadMo
         tabBarDirector?.showInvalidatedAnnouncementAlert()
     }
     
+    func openKnowledgeEntry(_ knowledgeEntry: KnowledgeEntryIdentifier) {
+        tabBarDirector?.openKnowledgeEntry(knowledgeEntry)
+    }
+    
     func openKnowledgeEntry(_ knowledgeEntry: KnowledgeEntryIdentifier, parentGroup: KnowledgeGroupIdentifier) {
         tabBarDirector?.openKnowledgeEntry(knowledgeEntry, parentGroup: parentGroup)
     }

--- a/Eurofurence/Director/TabBarDirector.swift
+++ b/Eurofurence/Director/TabBarDirector.swift
@@ -129,8 +129,14 @@ class TabBarDirector: NewsModuleDelegate, ScheduleModuleDelegate,
             let knowledgeGroupModule = moduleRepository.makeKnowledgeGroupEntriesModule(parentGroup, delegate: self)
             let knowledgeEntryModule = moduleRepository.makeKnowledgeDetailModule(knowledgeEntry, delegate: self)
             let viewControllers = [knowledgeListController, knowledgeGroupModule, knowledgeEntryModule]
+            makeSureViewControllersLoadTheirNavigationItems(viewControllers)
+            
             knowledgeNavigationController.setViewControllers(viewControllers, animated: animate)
         }
+    }
+    
+    private func makeSureViewControllersLoadTheirNavigationItems(_ viewControllers: [UIViewController]) {
+        viewControllers.forEach({ $0.loadViewIfNeeded() })
     }
     
     // MARK: NewsModuleDelegate

--- a/Eurofurence/Director/TabBarDirector.swift
+++ b/Eurofurence/Director/TabBarDirector.swift
@@ -119,6 +119,20 @@ class TabBarDirector: NewsModuleDelegate, ScheduleModuleDelegate,
         tabController?.present(alert, animated: performAnimations, completion: nil)
     }
     
+    func openKnowledgeEntry(_ knowledgeEntry: KnowledgeEntryIdentifier, parentGroup: KnowledgeGroupIdentifier) {
+        guard let knowledgeNavigationController = knowledgeListController?.navigationController else { return }
+        
+        if let index = tabController?.viewControllers?.firstIndex(of: knowledgeNavigationController),
+            let knowledgeListController = knowledgeListController {
+            tabController?.selectedIndex = index
+            
+            let knowledgeGroupModule = moduleRepository.makeKnowledgeGroupEntriesModule(parentGroup, delegate: self)
+            let knowledgeEntryModule = moduleRepository.makeKnowledgeDetailModule(knowledgeEntry, delegate: self)
+            let viewControllers = [knowledgeListController, knowledgeGroupModule, knowledgeEntryModule]
+            knowledgeNavigationController.setViewControllers(viewControllers, animated: animate)
+        }
+    }
+    
     // MARK: NewsModuleDelegate
     
     func newsModuleDidRequestShowingPrivateMessages() {

--- a/Eurofurence/Director/TabBarDirector.swift
+++ b/Eurofurence/Director/TabBarDirector.swift
@@ -131,7 +131,7 @@ class TabBarDirector: NewsModuleDelegate, ScheduleModuleDelegate,
             let viewControllers = [knowledgeListController, knowledgeGroupModule, knowledgeEntryModule]
             makeSureViewControllersLoadTheirNavigationItems(viewControllers)
             
-            knowledgeNavigationController.setViewControllers(viewControllers, animated: animate)
+            knowledgeNavigationController.setViewControllers(viewControllers, animated: false)
         }
     }
     

--- a/Eurofurence/Director/TabBarDirector.swift
+++ b/Eurofurence/Director/TabBarDirector.swift
@@ -109,12 +109,13 @@ class TabBarDirector: NewsModuleDelegate, ScheduleModuleDelegate,
     func openKnowledgeEntry(_ knowledgeEntry: KnowledgeEntryIdentifier) {
         guard let knowledgeNavigationController = knowledgeListController?.navigationController else { return }
         
-        if let index = tabController?.viewControllers?.firstIndex(of: knowledgeNavigationController) {
+        if let index = tabController?.viewControllers?.firstIndex(of: knowledgeNavigationController),
+           let knowledgeListController = knowledgeListController {
             tabController?.selectedIndex = index
+            
+            let knowledgeDetailModule = moduleRepository.makeKnowledgeDetailModule(knowledgeEntry, delegate: self)
+            knowledgeNavigationController.setViewControllers([knowledgeListController, knowledgeDetailModule], animated: animate)
         }
-        
-        let knowledgeDetailModule = moduleRepository.makeKnowledgeDetailModule(knowledgeEntry, delegate: self)
-        knowledgeListController?.navigationController?.pushViewController(knowledgeDetailModule, animated: animate)
     }
     
     func showInvalidatedAnnouncementAlert() {

--- a/Eurofurence/Director/TabBarDirector.swift
+++ b/Eurofurence/Director/TabBarDirector.swift
@@ -96,6 +96,16 @@ class TabBarDirector: NewsModuleDelegate, ScheduleModuleDelegate,
         openMessage(message, revealStyle: .replace)
     }
     
+    func openKnowledgeGroups() {
+        guard let knowledgeNavigationController = knowledgeListController?.navigationController else { return }
+        
+        if let index = tabController?.viewControllers?.firstIndex(of: knowledgeNavigationController),
+           let knowledgeListController = knowledgeListController {        
+            tabController?.selectedIndex = index
+            knowledgeNavigationController.setViewControllers([knowledgeListController], animated: false)
+        }
+    }
+    
     func openKnowledgeEntry(_ knowledgeEntry: KnowledgeEntryIdentifier) {
         let knowledgeDetailModule = moduleRepository.makeKnowledgeDetailModule(knowledgeEntry, delegate: self)
         knowledgeListController?.navigationController?.pushViewController(knowledgeDetailModule, animated: animate)

--- a/Eurofurence/Director/TabBarDirector.swift
+++ b/Eurofurence/Director/TabBarDirector.swift
@@ -107,6 +107,12 @@ class TabBarDirector: NewsModuleDelegate, ScheduleModuleDelegate,
     }
     
     func openKnowledgeEntry(_ knowledgeEntry: KnowledgeEntryIdentifier) {
+        guard let knowledgeNavigationController = knowledgeListController?.navigationController else { return }
+        
+        if let index = tabController?.viewControllers?.firstIndex(of: knowledgeNavigationController) {
+            tabController?.selectedIndex = index
+        }
+        
         let knowledgeDetailModule = moduleRepository.makeKnowledgeDetailModule(knowledgeEntry, delegate: self)
         knowledgeListController?.navigationController?.pushViewController(knowledgeDetailModule, animated: animate)
     }

--- a/EurofurenceTests/Activity/Resuming/Test Doubles/CapturingContentRouter.swift
+++ b/EurofurenceTests/Activity/Resuming/Test Doubles/CapturingContentRouter.swift
@@ -18,4 +18,9 @@ class CapturingContentRouter: ContentRouter {
         didResumeViewingKnowledgeGroups = true
     }
     
+    private(set) var resumedKnowledgePairing: (entry: KnowledgeEntryIdentifier, group: KnowledgeGroupIdentifier)?
+    func resumeViewingKnowledgeEntry(_ knowledgeEntry: KnowledgeEntryIdentifier, parentGroup: KnowledgeGroupIdentifier) {
+        resumedKnowledgePairing = (entry: knowledgeEntry, group: parentGroup)
+    }
+    
 }

--- a/EurofurenceTests/Activity/Resuming/Test Doubles/CapturingContentRouter.swift
+++ b/EurofurenceTests/Activity/Resuming/Test Doubles/CapturingContentRouter.swift
@@ -13,4 +13,9 @@ class CapturingContentRouter: ContentRouter {
         resumedDealer = identifier
     }
     
+    private(set) var didResumeViewingKnowledgeGroups = false
+    func resumeViewingKnowledgeGroups() {
+        didResumeViewingKnowledgeGroups = true
+    }
+    
 }

--- a/EurofurenceTests/Activity/Resuming/Test Doubles/CapturingContentRouter.swift
+++ b/EurofurenceTests/Activity/Resuming/Test Doubles/CapturingContentRouter.swift
@@ -18,6 +18,11 @@ class CapturingContentRouter: ContentRouter {
         didResumeViewingKnowledgeGroups = true
     }
     
+    private(set) var resumedKnowledgeEntry: KnowledgeEntryIdentifier?
+    func resumeViewingKnowledgeEntry(_ knowledgeEntry: KnowledgeEntryIdentifier) {
+        resumedKnowledgeEntry = knowledgeEntry
+    }
+    
     private(set) var resumedKnowledgePairing: (entry: KnowledgeEntryIdentifier, group: KnowledgeGroupIdentifier)?
     func resumeViewingKnowledgeEntry(_ knowledgeEntry: KnowledgeEntryIdentifier, parentGroup: KnowledgeGroupIdentifier) {
         resumedKnowledgePairing = (entry: knowledgeEntry, group: parentGroup)

--- a/EurofurenceTests/Activity/Resuming/URL/WhenResumingKnowledgeEntryURL_WithParentGroup.swift
+++ b/EurofurenceTests/Activity/Resuming/URL/WhenResumingKnowledgeEntryURL_WithParentGroup.swift
@@ -1,0 +1,26 @@
+@testable import Eurofurence
+import EurofurenceModel
+import EurofurenceModelTestDoubles
+import XCTest
+
+class WhenResumingKnowledgeEntryURL_WithParentGroup: XCTestCase {
+
+    func testTheActivityIsResumed() {
+        let contentLinksService = StubContentLinksService()
+        let contentRouter = CapturingContentRouter()
+        let intentResumer = ActivityResumer(contentLinksService: contentLinksService, contentRouter: contentRouter)
+        let knowledgeEntry = KnowledgeEntryIdentifier.random
+        let knowledgeGroup = KnowledgeGroupIdentifier.random
+        let url = URL.random
+        contentLinksService.stub(.knowledge(knowledgeEntry, knowledgeGroup), for: url)
+        let activity = URLActivityDescription(url: url)
+        let handled = intentResumer.resume(activity: activity)
+        
+        let resumedKnowledgePairing = contentRouter.resumedKnowledgePairing
+        
+        XCTAssertTrue(handled)
+        XCTAssertEqual(knowledgeEntry, resumedKnowledgePairing?.entry)
+        XCTAssertEqual(knowledgeGroup, resumedKnowledgePairing?.group)
+    }
+
+}

--- a/EurofurenceTests/Activity/Resuming/URL/WhenResumingKnowledgeEntry_WithoutParentGroup.swift
+++ b/EurofurenceTests/Activity/Resuming/URL/WhenResumingKnowledgeEntry_WithoutParentGroup.swift
@@ -1,0 +1,22 @@
+@testable import Eurofurence
+import EurofurenceModel
+import EurofurenceModelTestDoubles
+import XCTest
+
+class WhenResumingKnowledgeEntry_WithoutParentGroup: XCTestCase {
+
+    func testTheActivityIsResumed() {
+        let contentLinksService = StubContentLinksService()
+        let contentRouter = CapturingContentRouter()
+        let intentResumer = ActivityResumer(contentLinksService: contentLinksService, contentRouter: contentRouter)
+        let knowledgeEntry = KnowledgeEntryIdentifier.random
+        let url = URL.random
+        contentLinksService.stub(.knowledgeEntry(knowledgeEntry), for: url)
+        let activity = URLActivityDescription(url: url)
+        let handled = intentResumer.resume(activity: activity)
+                
+        XCTAssertTrue(handled)
+        XCTAssertEqual(knowledgeEntry, contentRouter.resumedKnowledgeEntry)
+    }
+
+}

--- a/EurofurenceTests/Activity/Resuming/URL/WhenResumingKnowledgeGroupsURL.swift
+++ b/EurofurenceTests/Activity/Resuming/URL/WhenResumingKnowledgeGroupsURL.swift
@@ -1,0 +1,21 @@
+@testable import Eurofurence
+import EurofurenceModel
+import EurofurenceModelTestDoubles
+import XCTest
+
+class WhenResumingKnowledgeGroupsURL: XCTestCase {
+
+    func testTheActivityIsResumed() {
+        let contentLinksService = StubContentLinksService()
+        let contentRouter = CapturingContentRouter()
+        let intentResumer = ActivityResumer(contentLinksService: contentLinksService, contentRouter: contentRouter)
+        let url = URL.random
+        contentLinksService.stub(.knowledgeGroups, for: url)
+        let activity = URLActivityDescription(url: url)
+        let handled = intentResumer.resume(activity: activity)
+        
+        XCTAssertTrue(handled)
+        XCTAssertTrue(contentRouter.didResumeViewingKnowledgeGroups)
+    }
+
+}

--- a/EurofurenceTests/Director/Opening Content/WhenOpeningKnowledgeEntries_DirectorShould.swift
+++ b/EurofurenceTests/Director/Opening Content/WhenOpeningKnowledgeEntries_DirectorShould.swift
@@ -1,0 +1,31 @@
+@testable import Eurofurence
+import EurofurenceModel
+import EurofurenceModelTestDoubles
+import XCTest
+
+class WhenOpeningKnowledgeEntries_DirectorShould: XCTestCase {
+
+    func testSwapToTheCorrectTab() {
+        let context = ApplicationDirectorTestBuilder().build()
+        context.navigateToTabController()
+        let knowledgeNavigationController = unwrap(context.navigationController(for: context.knowledgeListModule.stubInterface))
+        context.director.openKnowledgeGroups()
+        
+        let index = context.tabModule.capturedTabModules.firstIndex(of: knowledgeNavigationController)
+        
+        XCTAssertEqual(index, context.tabModule.stubInterface.selectedIndex)
+    }
+    
+    func testDisposeOfAnyPushedControllers() {
+        let context = ApplicationDirectorTestBuilder().build()
+        context.navigateToTabController()
+        context.knowledgeListModule.simulateKnowledgeGroupSelected(.random)
+        context.knowledgeGroupEntriesModule.simulateKnowledgeEntrySelected(.random)
+        context.director.openKnowledgeGroups()
+        
+        let knowledgeNavigationController = unwrap(context.navigationController(for: context.knowledgeListModule.stubInterface))
+        
+        XCTAssertEqual(knowledgeNavigationController.viewControllers, [context.knowledgeListModule.stubInterface])
+    }
+
+}

--- a/EurofurenceTests/Director/Opening Content/WhenOpeningKnowledgeEntry_WithParentGroup_DirectorShould.swift
+++ b/EurofurenceTests/Director/Opening Content/WhenOpeningKnowledgeEntry_WithParentGroup_DirectorShould.swift
@@ -1,0 +1,29 @@
+@testable import Eurofurence
+import EurofurenceModel
+import EurofurenceModelTestDoubles
+import XCTest
+
+class WhenOpeningKnowledgeEntry_WithParentGroup_DirectorShould: XCTestCase {
+
+    func testShowTheKnowledgeList_Group_AndEntry() {
+        let context = ApplicationDirectorTestBuilder().build()
+        context.navigateToTabController()
+        let knowledgeNavigationController = unwrap(context.navigationController(for: context.knowledgeListModule.stubInterface))
+        let knowledgeEntry = KnowledgeEntryIdentifier.random
+        let knowledgeGroup = KnowledgeGroupIdentifier.random
+        context.director.openKnowledgeEntry(knowledgeEntry, parentGroup: knowledgeGroup)
+        
+        let index = context.tabModule.capturedTabModules.firstIndex(of: knowledgeNavigationController)
+        
+        XCTAssertEqual(index, context.tabModule.stubInterface.selectedIndex)
+        XCTAssertEqual(knowledgeEntry, context.knowledgeDetailModule.capturedModel)
+        XCTAssertEqual(knowledgeGroup, context.knowledgeGroupEntriesModule.capturedModel)
+        XCTAssertEqual(
+            [context.knowledgeListModule.stubInterface,
+             context.knowledgeGroupEntriesModule.stubInterface,
+             context.knowledgeDetailModule.stubInterface],
+            knowledgeNavigationController.viewControllers
+        )
+    }
+
+}

--- a/EurofurenceTests/Director/Opening Content/WhenOpeningKnowledgeEntry_WithoutParentGroup_DirectorShould.swift
+++ b/EurofurenceTests/Director/Opening Content/WhenOpeningKnowledgeEntry_WithoutParentGroup_DirectorShould.swift
@@ -1,0 +1,26 @@
+@testable import Eurofurence
+import EurofurenceModel
+import EurofurenceModelTestDoubles
+import XCTest
+
+class WhenOpeningKnowledgeEntry_WithoutParentGroup_DirectorShould: XCTestCase {
+
+    func testShowTheKnowledgeList_AndEntry() {
+        let context = ApplicationDirectorTestBuilder().build()
+        context.navigateToTabController()
+        let knowledgeNavigationController = unwrap(context.navigationController(for: context.knowledgeListModule.stubInterface))
+        let knowledgeEntry = KnowledgeEntryIdentifier.random
+        context.director.openKnowledgeEntry(knowledgeEntry)
+        
+        let index = context.tabModule.capturedTabModules.firstIndex(of: knowledgeNavigationController)
+        
+        XCTAssertEqual(index, context.tabModule.stubInterface.selectedIndex)
+        XCTAssertEqual(knowledgeEntry, context.knowledgeDetailModule.capturedModel)
+        XCTAssertEqual(
+            [context.knowledgeListModule.stubInterface,
+             context.knowledgeDetailModule.stubInterface],
+            knowledgeNavigationController.viewControllers
+        )
+    }
+
+}

--- a/EurofurenceTests/Director/Test Doubles/StubContentLinksService.swift
+++ b/EurofurenceTests/Director/Test Doubles/StubContentLinksService.swift
@@ -17,6 +17,7 @@ class StubContentLinksService: ContentLinksService {
         case event(EventIdentifier)
         case dealer(DealerIdentifier)
         case knowledgeGroups
+        case knowledge(KnowledgeEntryIdentifier, KnowledgeGroupIdentifier)
     }
     
     private var urlContent = [URL: URLContent]()
@@ -36,6 +37,9 @@ class StubContentLinksService: ContentLinksService {
             
         case .knowledgeGroups:
             visitor.visitKnowledgeGroups()
+            
+        case .knowledge(let entry, let group):
+            visitor.visitKnowledgeEntry(entry, containedWithinGroup: group)
         }
     }
 

--- a/EurofurenceTests/Director/Test Doubles/StubContentLinksService.swift
+++ b/EurofurenceTests/Director/Test Doubles/StubContentLinksService.swift
@@ -16,6 +16,7 @@ class StubContentLinksService: ContentLinksService {
     enum URLContent {
         case event(EventIdentifier)
         case dealer(DealerIdentifier)
+        case knowledgeGroups
     }
     
     private var urlContent = [URL: URLContent]()
@@ -32,6 +33,9 @@ class StubContentLinksService: ContentLinksService {
             
         case .dealer(let dealer):
             visitor.visit(dealer)
+            
+        case .knowledgeGroups:
+            visitor.visitKnowledgeGroups()
         }
     }
 

--- a/EurofurenceTests/Director/Test Doubles/StubContentLinksService.swift
+++ b/EurofurenceTests/Director/Test Doubles/StubContentLinksService.swift
@@ -18,6 +18,7 @@ class StubContentLinksService: ContentLinksService {
         case dealer(DealerIdentifier)
         case knowledgeGroups
         case knowledge(KnowledgeEntryIdentifier, KnowledgeGroupIdentifier)
+        case knowledgeEntry(KnowledgeEntryIdentifier)
     }
     
     private var urlContent = [URL: URLContent]()
@@ -40,6 +41,9 @@ class StubContentLinksService: ContentLinksService {
             
         case .knowledge(let entry, let group):
             visitor.visitKnowledgeEntry(entry, containedWithinGroup: group)
+            
+        case .knowledgeEntry(let entry):
+            visitor.visitKnowledgeEntry(entry)
         }
     }
 


### PR DESCRIPTION
- `/Web/KnowledgeGroups` -> Knowledge tab
- `/Web/KnowledgeEntries/<Identifier>` -> Knowledge Entry, with additional caveats:
  - If it's the only entry in the group (i.e. GoH), the tab becomes knowledge groups and the entry
  - If there's more than one entry in the group, the tab becomes knowledge groups -> knowledge group entries -> knowledge entry