### PR TITLE
Fix image sizes flickering in knowledge entries

### DIFF
--- a/Eurofurence/Modules/Knowledge Detail/View/UIKit/KnowledgeDetail.storyboard
+++ b/Eurofurence/Modules/Knowledge Detail/View/UIKit/KnowledgeDetail.storyboard
@@ -36,9 +36,6 @@
                                             <subviews>
                                                 <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="TKr-4i-DdQ" customClass="AspectRatioConstrainedImageView" customModule="Eurofurence" customModuleProvider="target">
                                                     <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="height" relation="lessThanOrEqual" constant="333" id="a0J-ZN-c1X"/>
-                                                    </constraints>
                                                 </imageView>
                                             </subviews>
                                             <constraints>


### PR DESCRIPTION
Stop messing with the size of the incoming image so it’s behaving a bit more clearly