### PR TITLE
Fix search bar presentation on iOS 11+

### DIFF
--- a/Eurofurence/Modules/Dealers/View/UIKit/DealersViewController.swift
+++ b/Eurofurence/Modules/Dealers/View/UIKit/DealersViewController.swift
@@ -84,6 +84,7 @@ class DealersViewController: UIViewController, UISearchControllerDelegate, UISea
     // MARK: UISearchControllerDelegate
     
     func presentSearchController(_ searchController: UISearchController) {
+        ensureScrolledToTopToAvoidLargeTitlesPresentationIssue()
         present(searchController, animated: true)
     }
     
@@ -168,6 +169,22 @@ class DealersViewController: UIViewController, UISearchControllerDelegate, UISea
 
     private func didSelectSearchResult(at indexPath: IndexPath) {
         delegate?.dealersSceneDidSelectDealerSearchResult(at: indexPath)
+    }
+    
+    private func scrollToTableViewTop() {
+        guard tableViewHasData() else { return }
+        
+        let firstIndex = IndexPath(row: 0, section: 0)
+        tableView.scrollToRow(at: firstIndex, at: .top, animated: true)
+    }
+    
+    private func tableViewHasData() -> Bool {
+        return tableView.numberOfSections > 0 && tableView.numberOfRows(inSection: 0) > 0
+    }
+    
+    private func ensureScrolledToTopToAvoidLargeTitlesPresentationIssue() {
+        guard #available(iOS 11.0, *) else { return }
+        scrollToTableViewTop()
     }
 
     private class TableController: NSObject, UITableViewDataSource, UITableViewDelegate {

--- a/Eurofurence/Modules/Schedule/View/UIKit/ScheduleViewController.swift
+++ b/Eurofurence/Modules/Schedule/View/UIKit/ScheduleViewController.swift
@@ -111,9 +111,10 @@ class ScheduleViewController: UIViewController,
     }
 
     // MARK: UISearchControllerDelegate
-
+    
     func presentSearchController(_ searchController: UISearchController) {
         resetSearchSceneForSearchingAllEvents()
+        ensureScrolledToTopToAvoidLargeTitlesPresentationIssue()
         present(searchController, animated: true)
     }
     
@@ -261,6 +262,11 @@ class ScheduleViewController: UIViewController,
     
     private func tableViewHasData() -> Bool {
         return tableView.numberOfSections > 0 && tableView.numberOfRows(inSection: 0) > 0
+    }
+    
+    private func ensureScrolledToTopToAvoidLargeTitlesPresentationIssue() {
+        guard #available(iOS 11.0, *) else { return }
+        scrollToTableViewTop()
     }
 
     private class TableController: NSObject, UITableViewDataSource, UITableViewDelegate {


### PR DESCRIPTION
Tapping the status bar to scroll to top then tapping search within a few moments showed huge gaps at the top of the table view. This enforces a non-animated scroll-to-top to complete the transition in time for the view controller presentation to occur, avoiding the auto-inset behaviour from iOS messing with the table view during the animation.

Fixes #287