### PR TITLE
Explicitly specify non-excempt encryption not used in app bundle

### DIFF
--- a/Eurofurence/Info.plist
+++ b/Eurofurence/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>

--- a/EurofurenceTests/ApplicationInfoPropertyListShould.swift
+++ b/EurofurenceTests/ApplicationInfoPropertyListShould.swift
@@ -31,5 +31,11 @@ class ApplicationInfoPropertyListShould: XCTestCase {
         
         XCTAssertEqual(expected, cameraUsageDescription)
     }
+    
+    func testSpecifyNonExcemptEncryptionNotUsed() {
+        let nonStandardEncryptionUsed: Bool? = objectFromMainBundlePropertyList(forInfoDictionaryKey: "ITSAppUsesNonExemptEncryption")
+        
+        XCTAssertEqual(false, nonStandardEncryptionUsed)
+    }
 
 }


### PR DESCRIPTION
Stops TestFlight builds getting stuck as the export compliance popup keeps returning