### PR TITLE
Move to event based message read state changes

### DIFF
--- a/Domain Model/Domain Model.xcodeproj/project.pbxproj
+++ b/Domain Model/Domain Model.xcodeproj/project.pbxproj
@@ -474,6 +474,8 @@
 		CAF194CB2468785B005DFBBE /* StubConventionCountdownService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAF194CA2468785B005DFBBE /* StubConventionCountdownService.swift */; };
 		CAF198452468968E005DFBBE /* StubContentLinksService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAF198442468968E005DFBBE /* StubContentLinksService.swift */; };
 		CAF1984B2468AD63005DFBBE /* FakeCollectThemAllService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAF1984A2468AD63005DFBBE /* FakeCollectThemAllService.swift */; };
+		CAF25590251D1625008892ED /* WhenObservingUnreadMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAF2558F251D1625008892ED /* WhenObservingUnreadMessage.swift */; };
+		CAF2559A251D1731008892ED /* CapturingPrivateMessageObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAF25599251D1731008892ED /* CapturingPrivateMessageObserver.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -978,6 +980,8 @@
 		CAF194CA2468785B005DFBBE /* StubConventionCountdownService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubConventionCountdownService.swift; sourceTree = "<group>"; };
 		CAF198442468968E005DFBBE /* StubContentLinksService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubContentLinksService.swift; sourceTree = "<group>"; };
 		CAF1984A2468AD63005DFBBE /* FakeCollectThemAllService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeCollectThemAllService.swift; sourceTree = "<group>"; };
+		CAF2558F251D1625008892ED /* WhenObservingUnreadMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhenObservingUnreadMessage.swift; sourceTree = "<group>"; };
+		CAF25599251D1731008892ED /* CapturingPrivateMessageObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapturingPrivateMessageObserver.swift; sourceTree = "<group>"; };
 		EC85896EECB18D7881B0665A /* Pods-EurofurenceModel-metadata.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-EurofurenceModel-metadata.plist"; sourceTree = "<group>"; };
 		FFE87D86E3ECE04913805820 /* Pods_EurofurenceModelTestDoubles.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_EurofurenceModelTestDoubles.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -1649,6 +1653,7 @@
 				CA7A30EA22B16E24002AD939 /* WhenLoggingOut_PrivateMessagesShould.swift */,
 				CA7A30E622B16E24002AD939 /* WhenLoggingOut_ThenRequestingPrivateMessages.swift */,
 				CA7A30EB22B16E24002AD939 /* WhenMarkingMessageAsRead.swift */,
+				CAF2558F251D1625008892ED /* WhenObservingUnreadMessage.swift */,
 				CABCDE8524CB637500500F6B /* WhenRemovingObserver_PrivateMessagesServiceShould.swift */,
 				CA7A30E522B16E24002AD939 /* WhenRequestingPrivateMessagesWhileAuthenticated.swift */,
 				CA7A30E822B16E24002AD939 /* WhenRequestingPrivateMessagesWhileNotAuthenticated.swift */,
@@ -1764,19 +1769,20 @@
 		CA7A311322B16E25002AD939 /* Observers */ = {
 			isa = PBXGroup;
 			children = (
+				CA8A73DB22BD198F007A5201 /* CapturingAdditionalServicesURLConsumer.swift */,
 				CA7A311622B16E25002AD939 /* CapturingAnnouncementsServiceObserver.swift */,
 				CA7A311422B16E25002AD939 /* CapturingAuthenticationStateObserver.swift */,
 				CA7A311C22B16E25002AD939 /* CapturingCollectThemAllURLObserver.swift */,
 				CA7A311A22B16E25002AD939 /* CapturingConventionCountdownServiceObserver.swift */,
+				CAC4993F22E0F6B6003E1D77 /* CapturingDealerCategoriesCollectionObserver.swift */,
+				CAC4993D22E04D11003E1D77 /* CapturingDealerCategoryObserver.swift */,
 				CA7A311B22B16E25002AD939 /* CapturingEventsServiceObserver.swift */,
 				CA7A311D22B16E25002AD939 /* CapturingKnowledgeServiceObserver.swift */,
 				CA7A311922B16E25002AD939 /* CapturingLoginObserver.swift */,
 				CA7A311722B16E25002AD939 /* CapturingLogoutObserver.swift */,
 				CA7A311822B16E25002AD939 /* CapturingMapsObserver.swift */,
+				CAF25599251D1731008892ED /* CapturingPrivateMessageObserver.swift */,
 				CA7A311522B16E25002AD939 /* CapturingPrivateMessagesObserver.swift */,
-				CA8A73DB22BD198F007A5201 /* CapturingAdditionalServicesURLConsumer.swift */,
-				CAC4993D22E04D11003E1D77 /* CapturingDealerCategoryObserver.swift */,
-				CAC4993F22E0F6B6003E1D77 /* CapturingDealerCategoriesCollectionObserver.swift */,
 			);
 			path = Observers;
 			sourceTree = "<group>";
@@ -2726,6 +2732,7 @@
 				CA7A31CC22B16E26002AD939 /* MessageAssertion.swift in Sources */,
 				CA7A31F622B16E26002AD939 /* CapturingEventsServiceObserver.swift in Sources */,
 				CA7A323C22B16E26002AD939 /* WhenSyncSuceeds_ThenObservingUpcomingEvents.swift in Sources */,
+				CAF25590251D1625008892ED /* WhenObservingUnreadMessage.swift in Sources */,
 				CA7A320022B16E26002AD939 /* WhenFetchingIconDataForDealerWithoutArtwork_ApplicationShould.swift in Sources */,
 				CA7A322822B16E26002AD939 /* InOrderToSupportMainStageTag_ApplicationShould.swift in Sources */,
 				CA7A31DF22B16E26002AD939 /* StubCollectThemAllRequestFactory.swift in Sources */,
@@ -2813,6 +2820,7 @@
 				CA7A31A422B16E26002AD939 /* WhenFetchingKnowledgeGroupsAfterSuccessfulRefresh.swift in Sources */,
 				CA7A322522B16E26002AD939 /* InOrderToSupportSponsorTag_ApplicationShould.swift in Sources */,
 				CA7A31DD22B16E26002AD939 /* Array+Equality.swift in Sources */,
+				CAF2559A251D1731008892ED /* CapturingPrivateMessageObserver.swift in Sources */,
 				CA7A319522B16E26002AD939 /* WhenDeletingKnowledgeEntry_AfterSuccessfulSync_ApplicationShould.swift in Sources */,
 				CA7A31AE22B16E26002AD939 /* WhenFetchingMapImageData_ApplicationShould.swift in Sources */,
 				CA7A325422B16E26002AD939 /* WhenObservingCountdownUntilConvention_EurofurenceApplicationShould.swift in Sources */,

--- a/Domain Model/Domain Model.xcodeproj/project.pbxproj
+++ b/Domain Model/Domain Model.xcodeproj/project.pbxproj
@@ -477,6 +477,7 @@
 		CAF25590251D1625008892ED /* WhenObservingUnreadMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAF2558F251D1625008892ED /* WhenObservingUnreadMessage.swift */; };
 		CAF2559A251D1731008892ED /* CapturingPrivateMessageObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAF25599251D1731008892ED /* CapturingPrivateMessageObserver.swift */; };
 		CAF255A4251D175B008892ED /* WhenObservingReadMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAF255A3251D175B008892ED /* WhenObservingReadMessage.swift */; };
+		CAF255B2251F772F008892ED /* WhenObservingMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAF255B1251F772F008892ED /* WhenObservingMessage.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -984,6 +985,7 @@
 		CAF2558F251D1625008892ED /* WhenObservingUnreadMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhenObservingUnreadMessage.swift; sourceTree = "<group>"; };
 		CAF25599251D1731008892ED /* CapturingPrivateMessageObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapturingPrivateMessageObserver.swift; sourceTree = "<group>"; };
 		CAF255A3251D175B008892ED /* WhenObservingReadMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhenObservingReadMessage.swift; sourceTree = "<group>"; };
+		CAF255B1251F772F008892ED /* WhenObservingMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhenObservingMessage.swift; sourceTree = "<group>"; };
 		EC85896EECB18D7881B0665A /* Pods-EurofurenceModel-metadata.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-EurofurenceModel-metadata.plist"; sourceTree = "<group>"; };
 		FFE87D86E3ECE04913805820 /* Pods_EurofurenceModelTestDoubles.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_EurofurenceModelTestDoubles.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -1655,12 +1657,13 @@
 				CA7A30EA22B16E24002AD939 /* WhenLoggingOut_PrivateMessagesShould.swift */,
 				CA7A30E622B16E24002AD939 /* WhenLoggingOut_ThenRequestingPrivateMessages.swift */,
 				CA7A30EB22B16E24002AD939 /* WhenMarkingMessageAsRead.swift */,
+				CAF255B1251F772F008892ED /* WhenObservingMessage.swift */,
+				CAF255A3251D175B008892ED /* WhenObservingReadMessage.swift */,
 				CAF2558F251D1625008892ED /* WhenObservingUnreadMessage.swift */,
 				CABCDE8524CB637500500F6B /* WhenRemovingObserver_PrivateMessagesServiceShould.swift */,
 				CA7A30E522B16E24002AD939 /* WhenRequestingPrivateMessagesWhileAuthenticated.swift */,
 				CA7A30E822B16E24002AD939 /* WhenRequestingPrivateMessagesWhileNotAuthenticated.swift */,
 				CAA10FC922C5597C00689A32 /* WhenResolvingMessageByItsIdentifier.swift */,
-				CAF255A3251D175B008892ED /* WhenObservingReadMessage.swift */,
 			);
 			path = "Private Messages";
 			sourceTree = "<group>";
@@ -2721,6 +2724,7 @@
 				CA7A31FC22B16E26002AD939 /* UserDefaultsForceRefreshRequired.swift in Sources */,
 				CA2AA2DC22C942AB00C0E1A1 /* WhenDescribingAppLink_WithInvalidDealerIdentifier.swift in Sources */,
 				CA7A31D422B16E26002AD939 /* ImageAPITests.swift in Sources */,
+				CAF255B2251F772F008892ED /* WhenObservingMessage.swift in Sources */,
 				CAC4993E22E04D11003E1D77 /* CapturingDealerCategoryObserver.swift in Sources */,
 				CA7A323722B16E26002AD939 /* WhenSubmittingFeedback_ForEventNotAcceptingFeedback.swift in Sources */,
 				CA7A319822B16E26002AD939 /* DealersRemoveAllBeforeInsertTests.swift in Sources */,

--- a/Domain Model/Domain Model.xcodeproj/project.pbxproj
+++ b/Domain Model/Domain Model.xcodeproj/project.pbxproj
@@ -476,6 +476,7 @@
 		CAF1984B2468AD63005DFBBE /* FakeCollectThemAllService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAF1984A2468AD63005DFBBE /* FakeCollectThemAllService.swift */; };
 		CAF25590251D1625008892ED /* WhenObservingUnreadMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAF2558F251D1625008892ED /* WhenObservingUnreadMessage.swift */; };
 		CAF2559A251D1731008892ED /* CapturingPrivateMessageObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAF25599251D1731008892ED /* CapturingPrivateMessageObserver.swift */; };
+		CAF255A4251D175B008892ED /* WhenObservingReadMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAF255A3251D175B008892ED /* WhenObservingReadMessage.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -982,6 +983,7 @@
 		CAF1984A2468AD63005DFBBE /* FakeCollectThemAllService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeCollectThemAllService.swift; sourceTree = "<group>"; };
 		CAF2558F251D1625008892ED /* WhenObservingUnreadMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhenObservingUnreadMessage.swift; sourceTree = "<group>"; };
 		CAF25599251D1731008892ED /* CapturingPrivateMessageObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapturingPrivateMessageObserver.swift; sourceTree = "<group>"; };
+		CAF255A3251D175B008892ED /* WhenObservingReadMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhenObservingReadMessage.swift; sourceTree = "<group>"; };
 		EC85896EECB18D7881B0665A /* Pods-EurofurenceModel-metadata.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-EurofurenceModel-metadata.plist"; sourceTree = "<group>"; };
 		FFE87D86E3ECE04913805820 /* Pods_EurofurenceModelTestDoubles.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_EurofurenceModelTestDoubles.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -1658,6 +1660,7 @@
 				CA7A30E522B16E24002AD939 /* WhenRequestingPrivateMessagesWhileAuthenticated.swift */,
 				CA7A30E822B16E24002AD939 /* WhenRequestingPrivateMessagesWhileNotAuthenticated.swift */,
 				CAA10FC922C5597C00689A32 /* WhenResolvingMessageByItsIdentifier.swift */,
+				CAF255A3251D175B008892ED /* WhenObservingReadMessage.swift */,
 			);
 			path = "Private Messages";
 			sourceTree = "<group>";
@@ -2804,6 +2807,7 @@
 				CA7A31C422B16E26002AD939 /* WhenPerformingSync_AfterEnforcingFullStoreRefresh_WhenFullRefreshFailed.swift in Sources */,
 				CA7A324622B16E26002AD939 /* WhenSignificantTimeChanges_ScheduleShould.swift in Sources */,
 				CA7A31E022B16E26002AD939 /* StubConventionStartDateRepository.swift in Sources */,
+				CAF255A4251D175B008892ED /* WhenObservingReadMessage.swift in Sources */,
 				CA7A318F22B16E26002AD939 /* WhenDeletingEvent_AfterSuccessfulSync_ApplicationShould.swift in Sources */,
 				CA7A320322B16E26002AD939 /* WhenTellingDealersIndexToSearch_ApplicationShould.swift in Sources */,
 				CA7A323F22B16E26002AD939 /* WhenResolvingEventByIdentifier_ForEventThatExists_ApplicationShould.swift in Sources */,

--- a/Domain Model/EurofurenceModel/Private/Objects/Entities/MessageImpl.swift
+++ b/Domain Model/EurofurenceModel/Private/Objects/Entities/MessageImpl.swift
@@ -46,6 +46,10 @@ class MessageImpl: Message, Comparable {
         }
     }
     
+    func remove(_ observer: PrivateMessageObserver) {
+        observers.removeAll(where: { $0 === observer })
+    }
+    
     func markAsRead() {
         isRead = true
         eventBus.post(ReadEvent(message: self))

--- a/Domain Model/EurofurenceModel/Private/Objects/Entities/MessageImpl.swift
+++ b/Domain Model/EurofurenceModel/Private/Objects/Entities/MessageImpl.swift
@@ -16,6 +16,7 @@ class MessageImpl: Message, Comparable {
     }
     
     private let eventBus: EventBus
+    private var observers: [PrivateMessageObserver] = []
 
     var identifier: MessageIdentifier
     var authorName: String
@@ -36,6 +37,8 @@ class MessageImpl: Message, Comparable {
     }
     
     func add(_ observer: PrivateMessageObserver) {
+        observers.append(observer)
+        
         if isRead {
             observer.messageMarkedRead()
         } else {
@@ -46,6 +49,10 @@ class MessageImpl: Message, Comparable {
     func markAsRead() {
         isRead = true
         eventBus.post(ReadEvent(message: self))
+        
+        for observer in observers {
+            observer.messageMarkedRead()
+        }
     }
 
 }

--- a/Domain Model/EurofurenceModel/Private/Objects/Entities/MessageImpl.swift
+++ b/Domain Model/EurofurenceModel/Private/Objects/Entities/MessageImpl.swift
@@ -36,7 +36,11 @@ class MessageImpl: Message, Comparable {
     }
     
     func add(_ observer: PrivateMessageObserver) {
-        observer.messageMarkedUnread()
+        if isRead {
+            observer.messageMarkedRead()
+        } else {
+            observer.messageMarkedUnread()
+        }
     }
     
     func markAsRead() {

--- a/Domain Model/EurofurenceModel/Private/Objects/Entities/MessageImpl.swift
+++ b/Domain Model/EurofurenceModel/Private/Objects/Entities/MessageImpl.swift
@@ -35,6 +35,10 @@ class MessageImpl: Message, Comparable {
         self.isRead = characteristics.isRead
     }
     
+    func add(_ observer: PrivateMessageObserver) {
+        observer.messageMarkedUnread()
+    }
+    
     func markAsRead() {
         isRead = true
         eventBus.post(ReadEvent(message: self))

--- a/Domain Model/EurofurenceModel/Public/Objects/Entities/Message.swift
+++ b/Domain Model/EurofurenceModel/Public/Objects/Entities/Message.swift
@@ -20,5 +20,6 @@ public protocol Message {
 public protocol PrivateMessageObserver {
     
     func messageMarkedUnread()
+    func messageMarkedRead()
     
 }

--- a/Domain Model/EurofurenceModel/Public/Objects/Entities/Message.swift
+++ b/Domain Model/EurofurenceModel/Public/Objects/Entities/Message.swift
@@ -11,12 +11,13 @@ public protocol Message {
     var contents: String { get }
     
     func add(_ observer: PrivateMessageObserver)
+    func remove(_ observer: PrivateMessageObserver)
     
     func markAsRead()
 
 }
 
-public protocol PrivateMessageObserver {
+public protocol PrivateMessageObserver: AnyObject {
     
     func messageMarkedUnread()
     func messageMarkedRead()

--- a/Domain Model/EurofurenceModel/Public/Objects/Entities/Message.swift
+++ b/Domain Model/EurofurenceModel/Public/Objects/Entities/Message.swift
@@ -9,7 +9,6 @@ public protocol Message {
     var receivedDateTime: Date { get }
     var subject: String { get }
     var contents: String { get }
-    var isRead: Bool { get }
     
     func add(_ observer: PrivateMessageObserver)
     

--- a/Domain Model/EurofurenceModel/Public/Objects/Entities/Message.swift
+++ b/Domain Model/EurofurenceModel/Public/Objects/Entities/Message.swift
@@ -11,6 +11,14 @@ public protocol Message {
     var contents: String { get }
     var isRead: Bool { get }
     
+    func add(_ observer: PrivateMessageObserver)
+    
     func markAsRead()
 
+}
+
+public protocol PrivateMessageObserver {
+    
+    func messageMarkedUnread()
+    
 }

--- a/Domain Model/EurofurenceModelTestDoubles/Entity Test Doubles/StubMessage.swift
+++ b/Domain Model/EurofurenceModelTestDoubles/Entity Test Doubles/StubMessage.swift
@@ -28,6 +28,12 @@ public final class StubMessage: Message {
     
     public func add(_ observer: PrivateMessageObserver) {
         observers.append(observer)
+        
+        if isRead {
+            observer.messageMarkedRead()
+        } else {
+            observer.messageMarkedUnread()
+        }
     }
     
     public private(set) var markedRead = false

--- a/Domain Model/EurofurenceModelTestDoubles/Entity Test Doubles/StubMessage.swift
+++ b/Domain Model/EurofurenceModelTestDoubles/Entity Test Doubles/StubMessage.swift
@@ -36,6 +36,10 @@ public final class StubMessage: Message {
         }
     }
     
+    public func remove(_ observer: PrivateMessageObserver) {
+        observers.removeAll(where: { $0 === observer })
+    }
+    
     public private(set) var markedRead = false
     public func markAsRead() {
         markedRead = true

--- a/Domain Model/EurofurenceModelTestDoubles/Entity Test Doubles/StubMessage.swift
+++ b/Domain Model/EurofurenceModelTestDoubles/Entity Test Doubles/StubMessage.swift
@@ -24,6 +24,10 @@ public final class StubMessage: Message {
         self.isRead = isRead
     }
     
+    public func add(_ observer: PrivateMessageObserver) {
+        
+    }
+    
     public private(set) var markedRead = false
     public func markAsRead() {
         markedRead = true

--- a/Domain Model/EurofurenceModelTestDoubles/Entity Test Doubles/StubMessage.swift
+++ b/Domain Model/EurofurenceModelTestDoubles/Entity Test Doubles/StubMessage.swift
@@ -9,6 +9,8 @@ public final class StubMessage: Message {
     public var subject: String
     public var contents: String
     public var isRead: Bool
+    
+    private var observers: [PrivateMessageObserver] = []
 
     public init(identifier: MessageIdentifier,
                 authorName: String,
@@ -25,12 +27,26 @@ public final class StubMessage: Message {
     }
     
     public func add(_ observer: PrivateMessageObserver) {
-        
+        observers.append(observer)
     }
     
     public private(set) var markedRead = false
     public func markAsRead() {
         markedRead = true
+    }
+    
+    public func transitionToUnreadState() {
+        isRead = false
+        for observer in observers {
+            observer.messageMarkedUnread()
+        }
+    }
+    
+    public func transitionToReadState() {
+        isRead = true
+        for observer in observers {
+            observer.messageMarkedRead()
+        }
     }
 
 }

--- a/Domain Model/EurofurenceModelTests/Private Messages/MessageAssertion.swift
+++ b/Domain Model/EurofurenceModelTests/Private Messages/MessageAssertion.swift
@@ -25,12 +25,17 @@ class MessageAssertion: Assertion {
             return
         }
         
+        let observer = CapturingPrivateMessageObserver()
+        message.add(observer)
+        
+        let expectedReadState: CapturingPrivateMessageObserver.ReadState = characteristic.isRead ? .read : .unread
+        
         assert(message.identifier.rawValue, isEqualTo: characteristic.identifier)
         assert(message.authorName, isEqualTo: characteristic.authorName)
         assert(message.receivedDateTime, isEqualTo: characteristic.receivedDateTime)
         assert(message.subject, isEqualTo: characteristic.subject)
         assert(message.contents, isEqualTo: characteristic.contents)
-        assert(message.isRead, isEqualTo: characteristic.isRead)
+        assert(expectedReadState, isEqualTo: observer.currentReadState)
     }
 
 }

--- a/Domain Model/EurofurenceModelTests/Private Messages/WhenLaunchingApplication_PrivateMessagesShould.swift
+++ b/Domain Model/EurofurenceModelTests/Private Messages/WhenLaunchingApplication_PrivateMessagesShould.swift
@@ -15,7 +15,6 @@ class WhenLaunchingApplication_PrivateMessagesShould: XCTestCase {
         XCTAssertEqual(message.receivedDateTime, observedMessage?.receivedDateTime)
         XCTAssertEqual(message.subject, observedMessage?.subject)
         XCTAssertEqual(message.contents, observedMessage?.contents)
-        XCTAssertEqual(message.isRead, observedMessage?.isRead)
     }
 
     func testProvideZeroCountForNumberOfUnreadPrivateMessages() {

--- a/Domain Model/EurofurenceModelTests/Private Messages/WhenMarkingMessageAsRead.swift
+++ b/Domain Model/EurofurenceModelTests/Private Messages/WhenMarkingMessageAsRead.swift
@@ -46,5 +46,23 @@ class WhenMarkingMessageAsRead: XCTestCase {
 
         XCTAssertEqual(0, observer.observedUnreadMessageCount)
     }
+    
+    func testItShouldTellTheObserver() throws {
+        let context = EurofurenceSessionTestBuilder().loggedInWithValidCredential().build()
+        let messagesObserver = CapturingPrivateMessagesObserver()
+        context.privateMessagesService.add(messagesObserver)
+        context.privateMessagesService.refreshMessages()
+        let identifier = "Message ID"
+        var message = MessageCharacteristics.random
+        message.identifier = identifier
+        message.isRead = false
+        context.api.simulateMessagesResponse(response: [message])
+        let receivedMessage = try XCTUnwrap(messagesObserver.observedMessages.first)
+        let messageObserver = CapturingPrivateMessageObserver()
+        receivedMessage.add(messageObserver)
+        receivedMessage.markAsRead()
+        
+        XCTAssertEqual(.read, messageObserver.currentReadState)
+    }
 
 }

--- a/Domain Model/EurofurenceModelTests/Private Messages/WhenMarkingMessageAsRead.swift
+++ b/Domain Model/EurofurenceModelTests/Private Messages/WhenMarkingMessageAsRead.swift
@@ -64,5 +64,25 @@ class WhenMarkingMessageAsRead: XCTestCase {
         
         XCTAssertEqual(.read, messageObserver.currentReadState)
     }
+    
+    func testItShouldNotTellUnregisteredObservers() throws {
+        let context = EurofurenceSessionTestBuilder().loggedInWithValidCredential().build()
+        let messagesObserver = CapturingPrivateMessagesObserver()
+        context.privateMessagesService.add(messagesObserver)
+        context.privateMessagesService.refreshMessages()
+        let identifier = "Message ID"
+        var message = MessageCharacteristics.random
+        message.identifier = identifier
+        message.isRead = false
+        context.api.simulateMessagesResponse(response: [message])
+        let receivedMessage = try XCTUnwrap(messagesObserver.observedMessages.first)
+        let messageObserver = CapturingPrivateMessageObserver()
+        receivedMessage.add(messageObserver)
+        receivedMessage.remove(messageObserver)
+        
+        receivedMessage.markAsRead()
+        
+        XCTAssertEqual(.unread, messageObserver.currentReadState)
+    }
 
 }

--- a/Domain Model/EurofurenceModelTests/Private Messages/WhenObservingMessage.swift
+++ b/Domain Model/EurofurenceModelTests/Private Messages/WhenObservingMessage.swift
@@ -1,0 +1,20 @@
+import XCTest
+
+class WhenObservingMessage: XCTestCase {
+
+    func testTheObserverIsWeaklyHeld() throws {
+        let context = EurofurenceSessionTestBuilder().loggedInWithValidCredential().build()
+        let messagesObserver = CapturingPrivateMessagesObserver()
+        context.privateMessagesService.add(messagesObserver)
+        context.privateMessagesService.refreshMessages()
+        context.api.simulateMessagesResponse(response: [.random])
+        let receivedMessage = try XCTUnwrap(messagesObserver.observedMessages.first)
+        var messageObserver: CapturingPrivateMessageObserver? = CapturingPrivateMessageObserver()
+        weak var weakMessageObserver = messageObserver
+        receivedMessage.add(messageObserver.unsafelyUnwrapped)
+        messageObserver = nil
+        
+        XCTAssertNil(weakMessageObserver)
+    }
+
+}

--- a/Domain Model/EurofurenceModelTests/Private Messages/WhenObservingReadMessage.swift
+++ b/Domain Model/EurofurenceModelTests/Private Messages/WhenObservingReadMessage.swift
@@ -1,0 +1,24 @@
+import EurofurenceModel
+import EurofurenceModelTestDoubles
+import XCTest
+
+class WhenObservingReadMessage: XCTestCase {
+
+    func testTheObserverShouldBeToldTheMessageIsRead() throws {
+        let context = EurofurenceSessionTestBuilder().loggedInWithValidCredential().build()
+        let messagesObserver = CapturingPrivateMessagesObserver()
+        context.privateMessagesService.add(messagesObserver)
+        context.privateMessagesService.refreshMessages()
+        let identifier = "Message ID"
+        var message = MessageCharacteristics.random
+        message.identifier = identifier
+        message.isRead = true
+        context.api.simulateMessagesResponse(response: [message])
+        let receivedMessage = try XCTUnwrap(messagesObserver.observedMessages.first)
+        let messageObserver = CapturingPrivateMessageObserver()
+        receivedMessage.add(messageObserver)
+        
+        XCTAssertEqual(.read, messageObserver.currentReadState)
+    }
+
+}

--- a/Domain Model/EurofurenceModelTests/Private Messages/WhenObservingUnreadMessage.swift
+++ b/Domain Model/EurofurenceModelTests/Private Messages/WhenObservingUnreadMessage.swift
@@ -1,0 +1,24 @@
+import EurofurenceModel
+import EurofurenceModelTestDoubles
+import XCTest
+
+class WhenObservingUnreadMessage: XCTestCase {
+
+    func testTheObserverShouldBeToldTheMessageIsUnread() throws {
+        let context = EurofurenceSessionTestBuilder().loggedInWithValidCredential().build()
+        let messagesObserver = CapturingPrivateMessagesObserver()
+        context.privateMessagesService.add(messagesObserver)
+        context.privateMessagesService.refreshMessages()
+        let identifier = "Message ID"
+        var message = MessageCharacteristics.random
+        message.identifier = identifier
+        message.isRead = false
+        context.api.simulateMessagesResponse(response: [message])
+        let receivedMessage = try XCTUnwrap(messagesObserver.observedMessages.first)
+        let messageObserver = CapturingPrivateMessageObserver()
+        receivedMessage.add(messageObserver)
+        
+        XCTAssertEqual(.unread, messageObserver.currentReadState)
+    }
+
+}

--- a/Domain Model/EurofurenceModelTests/Test Doubles/Observers/CapturingPrivateMessageObserver.swift
+++ b/Domain Model/EurofurenceModelTests/Test Doubles/Observers/CapturingPrivateMessageObserver.swift
@@ -5,12 +5,17 @@ class CapturingPrivateMessageObserver: PrivateMessageObserver {
     enum ReadState {
         case unset
         case unread
+        case read
     }
     
     private(set) var currentReadState: ReadState = .unset
     
     func messageMarkedUnread() {
         currentReadState = .unread
+    }
+    
+    func messageMarkedRead() {
+        currentReadState = .read
     }
     
 }

--- a/Domain Model/EurofurenceModelTests/Test Doubles/Observers/CapturingPrivateMessageObserver.swift
+++ b/Domain Model/EurofurenceModelTests/Test Doubles/Observers/CapturingPrivateMessageObserver.swift
@@ -1,0 +1,16 @@
+import EurofurenceModel
+
+class CapturingPrivateMessageObserver: PrivateMessageObserver {
+    
+    enum ReadState {
+        case unset
+        case unread
+    }
+    
+    private(set) var currentReadState: ReadState = .unset
+    
+    func messageMarkedUnread() {
+        currentReadState = .unread
+    }
+    
+}

--- a/Eurofurence/Application/Components/Messages/Presenter/MessagesPresenter.swift
+++ b/Eurofurence/Application/Components/Messages/Presenter/MessagesPresenter.swift
@@ -144,12 +144,6 @@ class MessagesPresenter: MessagesSceneDelegate, PrivateMessagesObserver {
             scene.setSubject(message.subject)
             scene.setContents(message.contents)
 
-            if message.isRead {
-                scene.hideUnreadIndicator()
-            } else {
-                scene.showUnreadIndicator()
-            }
-
             let formattedDateTime = dateFormatter.string(from: message.receivedDateTime)
             scene.setReceivedDateTime(formattedDateTime)
             
@@ -157,7 +151,7 @@ class MessagesPresenter: MessagesSceneDelegate, PrivateMessagesObserver {
         }
         
         func messageMarkedUnread() {
-            
+            scene.showUnreadIndicator()
         }
         
         func messageMarkedRead() {

--- a/Eurofurence/Application/Components/Messages/Presenter/MessagesPresenter.swift
+++ b/Eurofurence/Application/Components/Messages/Presenter/MessagesPresenter.swift
@@ -11,6 +11,7 @@ class MessagesPresenter: MessagesSceneDelegate, PrivateMessagesObserver {
     private let dateFormatter: DateFormatterProtocol
     private let delegate: MessagesComponentDelegate
     private var presentedMessages = [Message]()
+    private var currentBinder: MessagesBinder?
 
     // MARK: Initialization
 
@@ -38,6 +39,7 @@ class MessagesPresenter: MessagesSceneDelegate, PrivateMessagesObserver {
     
     func messagesSceneFinalizing() {
         privateMessagesService.removeObserver(self)
+        currentBinder?.teardown()
     }
 
     func messagesSceneDidSelectMessage(at indexPath: IndexPath) {
@@ -99,6 +101,7 @@ class MessagesPresenter: MessagesSceneDelegate, PrivateMessagesObserver {
         presentedMessages = messages
 
         let binder = MessagesBinder(messages: messages, dateFormatter: dateFormatter)
+        currentBinder = binder
         scene?.bindMessages(count: messages.count, with: binder)
 
         if messages.isEmpty {
@@ -125,6 +128,12 @@ class MessagesPresenter: MessagesSceneDelegate, PrivateMessagesObserver {
             let message = messages[indexPath[1]]
             let binder = MessageBinder(message: message, scene: scene, dateFormatter: dateFormatter)
             messageBinders[indexPath] = binder
+        }
+        
+        func teardown() {
+            for binder in messageBinders.values {
+                binder.teardown()
+            }
         }
 
     }
@@ -156,6 +165,10 @@ class MessagesPresenter: MessagesSceneDelegate, PrivateMessagesObserver {
         
         func messageMarkedRead() {
             scene.hideUnreadIndicator()
+        }
+        
+        func teardown() {
+            message.remove(self)
         }
         
     }

--- a/Eurofurence/Application/Components/Messages/Presenter/MessagesPresenter.swift
+++ b/Eurofurence/Application/Components/Messages/Presenter/MessagesPresenter.swift
@@ -129,7 +129,7 @@ class MessagesPresenter: MessagesSceneDelegate, PrivateMessagesObserver {
 
     }
     
-    private struct MessageBinder: PrivateMessageObserver {
+    private class MessageBinder: PrivateMessageObserver {
         
         private let message: Message
         private let scene: MessageItemScene

--- a/EurofurenceTests/Application/Components/Messages/WhenBindingMessage_MessagesPresenterShould.swift
+++ b/EurofurenceTests/Application/Components/Messages/WhenBindingMessage_MessagesPresenterShould.swift
@@ -53,6 +53,27 @@ class MessagesPresenterTestsWhenBindingMessages: XCTestCase {
         XCTAssertEqual(.hidden, capturingMessageScene.unreadIndicatorVisibility)
     }
     
+    func testStopUpdatingSceneAfterUnbinding() {
+        let allMessages = [StubMessage].random
+        let randomIndex = Int.random(upperLimit: UInt32(allMessages.count))
+        let randomIndexPath = IndexPath(row: randomIndex, section: 0)
+        let message = allMessages[randomIndex]
+        message.transitionToUnreadState()
+        
+        let service = CapturingPrivateMessagesService(localMessages: allMessages)
+        let context = MessagesPresenterTestContext.makeTestCaseForAuthenticatedUser(privateMessagesService: service)
+        context.scene.delegate?.messagesSceneReady()
+        context.privateMessagesService.succeedLastRefresh(messages: allMessages)
+        
+        let capturingMessageScene = CapturingMessageItemScene()
+        context.scene.capturedMessageItemBinder?.bind(capturingMessageScene, toMessageAt: randomIndexPath)
+        
+        context.scene.delegate?.messagesSceneFinalizing()
+        message.transitionToReadState()
+        
+        XCTAssertEqual(.visible, capturingMessageScene.unreadIndicatorVisibility)
+    }
+    
     private func assertBindingMessage(
         isRead: Bool,
         setsUnreadIndicatorVisibilityTo expected: VisibilityState,

--- a/EurofurenceTests/Application/Components/Messages/WhenBindingMessage_MessagesPresenterShould.swift
+++ b/EurofurenceTests/Application/Components/Messages/WhenBindingMessage_MessagesPresenterShould.swift
@@ -31,6 +31,28 @@ class MessagesPresenterTestsWhenBindingMessages: XCTestCase {
         assertBindingMessage(isRead: true, setsUnreadIndicatorVisibilityTo: .hidden)
     }
     
+    func testMessageTransitionsFromUnreadToRead() {
+        let allMessages = [StubMessage].random
+        let randomIndex = Int.random(upperLimit: UInt32(allMessages.count))
+        let randomIndexPath = IndexPath(row: randomIndex, section: 0)
+        let message = allMessages[randomIndex]
+        message.transitionToUnreadState()
+        
+        let service = CapturingPrivateMessagesService(localMessages: allMessages)
+        let context = MessagesPresenterTestContext.makeTestCaseForAuthenticatedUser(privateMessagesService: service)
+        context.scene.delegate?.messagesSceneReady()
+        context.privateMessagesService.succeedLastRefresh(messages: allMessages)
+        
+        let capturingMessageScene = CapturingMessageItemScene()
+        context.scene.capturedMessageItemBinder?.bind(capturingMessageScene, toMessageAt: randomIndexPath)
+        
+        XCTAssertEqual(.visible, capturingMessageScene.unreadIndicatorVisibility)
+        
+        message.transitionToReadState()
+        
+        XCTAssertEqual(.hidden, capturingMessageScene.unreadIndicatorVisibility)
+    }
+    
     private func assertBindingMessage(
         isRead: Bool,
         setsUnreadIndicatorVisibilityTo expected: VisibilityState,


### PR DESCRIPTION
Observe the read state of a message to update the unread indicator in place of updating on scene appearance/refresh. Fixes #320