### PR TITLE
Fix navigation titles pre-iOS 13

### DIFF
--- a/Eurofurence/Application/Components/Dealers/View/UIKit/Dealers.storyboard
+++ b/Eurofurence/Application/Components/Dealers/View/UIKit/Dealers.storyboard
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -18,24 +19,16 @@
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="dHW-vm-Gc3">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="618"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </tableView>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6mj-pw-eS0" customClass="NavigationBarViewExtensionContainer" customModule="Eurofurence" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                            </view>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="3wZ-bx-MNt"/>
                         <constraints>
                             <constraint firstItem="dHW-vm-Gc3" firstAttribute="top" secondItem="6ea-Oq-lts" secondAttribute="top" id="Bgh-Fb-rdp"/>
-                            <constraint firstItem="3wZ-bx-MNt" firstAttribute="trailing" secondItem="6mj-pw-eS0" secondAttribute="trailing" id="JAU-Yg-8wD"/>
                             <constraint firstItem="dHW-vm-Gc3" firstAttribute="trailing" secondItem="6ea-Oq-lts" secondAttribute="trailing" id="SvV-kT-fLY"/>
                             <constraint firstItem="3wZ-bx-MNt" firstAttribute="bottom" secondItem="dHW-vm-Gc3" secondAttribute="bottom" id="Tdj-Tt-7gL"/>
                             <constraint firstItem="dHW-vm-Gc3" firstAttribute="leading" secondItem="6ea-Oq-lts" secondAttribute="leading" id="Un9-UV-ycv"/>
-                            <constraint firstItem="6mj-pw-eS0" firstAttribute="leading" secondItem="3wZ-bx-MNt" secondAttribute="leading" id="V3N-kl-xnC"/>
-                            <constraint firstItem="3wZ-bx-MNt" firstAttribute="top" secondItem="6mj-pw-eS0" secondAttribute="bottom" id="lNw-Tf-NUa"/>
-                            <constraint firstItem="6mj-pw-eS0" firstAttribute="top" secondItem="6ea-Oq-lts" secondAttribute="top" id="m8O-vV-5su"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="3wZ-bx-MNt"/>
                     </view>
                     <extendedEdge key="edgesForExtendedLayout" top="YES"/>
                     <tabBarItem key="tabBarItem" title="Item" image="dealers" id="PPC-cq-ywk"/>
@@ -56,7 +49,6 @@
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>
-                        <outlet property="navigationBarExtension" destination="6mj-pw-eS0" id="MEY-1A-Lj6"/>
                         <outlet property="tableView" destination="dHW-vm-Gc3" id="Syc-pg-Xns"/>
                     </connections>
                 </viewController>
@@ -87,7 +79,7 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" allowsMultipleSelection="YES" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="ZrY-Ls-9Ut">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="647"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                        <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="DealerCategoryTableViewCell" editingAccessoryType="checkmark" textLabel="Vz5-Jk-iyu" style="IBUITableViewCellStyleDefault" id="nLA-i8-FW5" customClass="DealerCategoryTableViewCell" customModule="Eurofurence" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="55.5" width="375" height="43.5"/>
@@ -132,7 +124,7 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="bQR-C7-7g0">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <connections>
                             <outlet property="dataSource" destination="CFe-9I-8ah" id="Um9-6N-F6H"/>
                             <outlet property="delegate" destination="CFe-9I-8ah" id="D9U-xW-IdH"/>
@@ -147,5 +139,11 @@
     <resources>
         <image name="Filter" width="25" height="25"/>
         <image name="dealers" width="25" height="25"/>
+        <systemColor name="groupTableViewBackgroundColor">
+            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
     </resources>
 </document>

--- a/Eurofurence/Application/Components/News/View/UIKit/News.storyboard
+++ b/Eurofurence/Application/Components/News/View/UIKit/News.storyboard
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <customFonts key="customFonts">
@@ -24,7 +25,7 @@
                         <subviews>
                             <tableView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="Ogd-Bj-WFd">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="729"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <view key="tableHeaderView" contentMode="scaleToFill" id="DAO-ck-zi9">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="150"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
@@ -60,7 +61,7 @@
                                         <rect key="frame" x="0.0" y="178" width="375" height="76"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="mWN-xP-H3H" id="Fda-o9-5OR">
-                                            <rect key="frame" x="0.0" y="0.0" width="349" height="76"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="347.66666666666669" height="76"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5e7-Fs-Rfc" userLabel="Icon Container">
@@ -99,17 +100,17 @@
                                                     </constraints>
                                                 </view>
                                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="c0p-tm-neN">
-                                                    <rect key="frame" x="63.666666666666657" y="20" width="265.33333333333337" height="36"/>
+                                                    <rect key="frame" x="63.666666666666657" y="20" width="264" height="36"/>
                                                     <subviews>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Prompt" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ieu-8p-CWj">
-                                                            <rect key="frame" x="0.0" y="0.0" width="265.33333333333331" height="13.666666666666666"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="264" height="13.666666666666666"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Detail" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BoW-aY-Pet">
-                                                            <rect key="frame" x="0.0" y="21.666666666666664" width="265.33333333333331" height="14.333333333333336"/>
+                                                            <rect key="frame" x="0.0" y="21.666666666666664" width="264" height="14.333333333333336"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
-                                                            <color key="textColor" systemColor="secondaryLabelColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+                                                            <color key="textColor" systemColor="secondaryLabelColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                     </subviews>
@@ -158,11 +159,11 @@
                                         <rect key="frame" x="0.0" y="315" width="375" height="61"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="X2B-iE-Rxm" id="c6S-SK-nbL">
-                                            <rect key="frame" x="0.0" y="0.0" width="349" height="61"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="347.66666666666669" height="61"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DHn-Dx-5nI">
-                                                    <rect key="frame" x="20" y="11" width="309" height="39"/>
+                                                    <rect key="frame" x="20" y="11" width="307.66666666666669" height="39"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
@@ -180,22 +181,14 @@
                                     </tableViewCell>
                                 </prototypes>
                             </tableView>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Se9-cw-Plh" customClass="NavigationBarViewExtensionContainer" customModule="Eurofurence" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="88"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                            </view>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="HxA-JQ-dZ1"/>
                         <constraints>
                             <constraint firstItem="Ogd-Bj-WFd" firstAttribute="bottom" secondItem="Y7u-ae-31r" secondAttribute="bottom" id="IXW-Ey-fpB"/>
-                            <constraint firstAttribute="trailing" secondItem="Se9-cw-Plh" secondAttribute="trailing" id="Ou6-tW-wox"/>
                             <constraint firstItem="Ogd-Bj-WFd" firstAttribute="trailing" secondItem="Y7u-ae-31r" secondAttribute="trailing" id="WAM-l1-Po1"/>
-                            <constraint firstItem="Se9-cw-Plh" firstAttribute="leading" secondItem="Y7u-ae-31r" secondAttribute="leading" id="WGS-VB-RtL"/>
-                            <constraint firstItem="HxA-JQ-dZ1" firstAttribute="top" secondItem="Se9-cw-Plh" secondAttribute="bottom" id="YMN-0r-JrN"/>
-                            <constraint firstItem="Se9-cw-Plh" firstAttribute="top" secondItem="Y7u-ae-31r" secondAttribute="top" id="iF6-43-xZ4"/>
                             <constraint firstItem="Ogd-Bj-WFd" firstAttribute="top" secondItem="Y7u-ae-31r" secondAttribute="top" id="m3z-Vl-l5l"/>
                             <constraint firstItem="Ogd-Bj-WFd" firstAttribute="leading" secondItem="Y7u-ae-31r" secondAttribute="leading" id="uvQ-e8-oIv"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="HxA-JQ-dZ1"/>
                     </view>
                     <extendedEdge key="edgesForExtendedLayout" top="YES"/>
                     <tabBarItem key="tabBarItem" title="Item" image="News" id="ydj-jR-ms8"/>
@@ -214,5 +207,11 @@
         <image name="News" width="16.666666030883789" height="16.666666030883789"/>
         <image name="News Banner" width="500" height="166.66667175292969"/>
         <image name="ef" width="170.66667175292969" height="170.66667175292969"/>
+        <systemColor name="secondaryLabelColor">
+            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
     </resources>
 </document>

--- a/Eurofurence/Application/Components/Schedule/View/UIKit/Schedule.storyboard
+++ b/Eurofurence/Application/Components/Schedule/View/UIKit/Schedule.storyboard
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -18,12 +19,8 @@
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="MGV-Hg-vha">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="618"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </tableView>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="RuE-YL-zzB" customClass="NavigationBarViewExtensionContainer" customModule="Eurofurence" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                            </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3vS-0E-aVm" userLabel="Days Picker Container" customClass="NavigationBarViewExtensionContainer" customModule="Eurofurence" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="44" width="375" height="44"/>
                                 <subviews>
@@ -32,6 +29,7 @@
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     </view>
                                 </subviews>
+                                <viewLayoutGuide key="safeArea" id="Uxr-u2-IR5"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstItem="KtS-4f-Pp1" firstAttribute="bottom" secondItem="Uxr-u2-IR5" secondAttribute="bottom" id="COd-7c-eOo"/>
@@ -40,23 +38,18 @@
                                     <constraint firstAttribute="height" constant="44" id="Ux8-mS-oFf"/>
                                     <constraint firstItem="Uxr-u2-IR5" firstAttribute="trailing" secondItem="KtS-4f-Pp1" secondAttribute="trailing" id="uES-qQ-mXF"/>
                                 </constraints>
-                                <viewLayoutGuide key="safeArea" id="Uxr-u2-IR5"/>
                             </view>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="UnK-qE-skU"/>
                         <constraints>
                             <constraint firstItem="3vS-0E-aVm" firstAttribute="leading" secondItem="Jed-Ti-sU7" secondAttribute="leading" id="5aq-41-ir1"/>
-                            <constraint firstItem="RuE-YL-zzB" firstAttribute="top" secondItem="Jed-Ti-sU7" secondAttribute="top" id="AqL-Pp-zg9"/>
-                            <constraint firstItem="UnK-qE-skU" firstAttribute="trailing" secondItem="RuE-YL-zzB" secondAttribute="trailing" id="COV-Le-O4O"/>
-                            <constraint firstItem="RuE-YL-zzB" firstAttribute="leading" secondItem="UnK-qE-skU" secondAttribute="leading" id="JFT-Ns-DqM"/>
                             <constraint firstItem="MGV-Hg-vha" firstAttribute="leading" secondItem="Jed-Ti-sU7" secondAttribute="leading" id="Qg3-1p-C3k"/>
                             <constraint firstItem="MGV-Hg-vha" firstAttribute="trailing" secondItem="Jed-Ti-sU7" secondAttribute="trailing" id="SwL-GZ-z2Z"/>
                             <constraint firstItem="MGV-Hg-vha" firstAttribute="top" secondItem="Jed-Ti-sU7" secondAttribute="top" id="j2M-nt-iFM"/>
                             <constraint firstAttribute="bottom" secondItem="MGV-Hg-vha" secondAttribute="bottom" id="k3U-3a-gt4"/>
-                            <constraint firstItem="RuE-YL-zzB" firstAttribute="bottom" secondItem="UnK-qE-skU" secondAttribute="top" id="m7M-oD-J7D"/>
                             <constraint firstItem="3vS-0E-aVm" firstAttribute="trailing" secondItem="Jed-Ti-sU7" secondAttribute="trailing" id="n3v-8z-rIx"/>
                             <constraint firstItem="3vS-0E-aVm" firstAttribute="top" secondItem="UnK-qE-skU" secondAttribute="top" id="pWh-ih-Typ"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="UnK-qE-skU"/>
                     </view>
                     <extendedEdge key="edgesForExtendedLayout" top="YES"/>
                     <tabBarItem key="tabBarItem" title="Item" image="Calendar" selectedImage="Calendar" id="YEX-4v-gXn"/>
@@ -86,7 +79,7 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" keyboardDismissMode="onDrag" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="KdN-4J-0ib">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <connections>
                             <outlet property="dataSource" destination="tcu-9T-Yzs" id="juj-XZ-yQd"/>
                             <outlet property="delegate" destination="tcu-9T-Yzs" id="XZx-x7-wp4"/>
@@ -100,5 +93,8 @@
     </scenes>
     <resources>
         <image name="Calendar" width="25" height="25"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
     </resources>
 </document>

--- a/Eurofurence/Application/Modules/Principal Content/PrincipalContentAggregator.swift
+++ b/Eurofurence/Application/Modules/Principal Content/PrincipalContentAggregator.swift
@@ -29,8 +29,11 @@ public struct PrincipalContentAggregator: PrincipalContentModuleProviding {
     private class NavigationController: UINavigationController {
         
         override func viewDidLoad() {
-            super.viewDidLoad()    
-            navigationBar.prefersLargeTitles = true
+            super.viewDidLoad()
+            
+            if #available(iOS 13.0, *) {
+                navigationBar.prefersLargeTitles = true
+            }
         }
         
     }

--- a/Eurofurence/Theme.swift
+++ b/Eurofurence/Theme.swift
@@ -69,6 +69,7 @@ struct Theme {
             navigationBar.compactAppearance = appearance
             navigationBar.scrollEdgeAppearance = appearance
         } else {
+            navigationBar.backgroundColor = .navigationBar
             navigationBar.largeTitleTextAttributes = whiteTextAttributes
         }
     }


### PR DESCRIPTION
Linking against the new SDK causes visual issues on iOS 11 and 12. Disabling large titles on these versions is the easiest fix given the likely minimal adoption on these versions