### PR TITLE
Fix placeholder content erroneously appearing

### DIFF
--- a/Eurofurence.xcodeproj/project.pbxproj
+++ b/Eurofurence.xcodeproj/project.pbxproj
@@ -593,6 +593,7 @@
 		CABA43A11FD57A78009CB5B0 /* PreloadComponentBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CABA43A01FD57A78009CB5B0 /* PreloadComponentBuilder.swift */; };
 		CABA43A31FD57C65009CB5B0 /* TutorialModuleBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CABA43A21FD57C65009CB5B0 /* TutorialModuleBuilder.swift */; };
 		CABA43AC1FD5DC68009CB5B0 /* LoginScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = CABA43AB1FD5DC68009CB5B0 /* LoginScene.swift */; };
+		CABBCA302566FE0B007A11A2 /* SplitViewDetailBugTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CABBCA2F2566FE0B007A11A2 /* SplitViewDetailBugTests.swift */; };
 		CABCDE6824C9C78000500F6B /* EmbeddedEventContentRepresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = CABCDE6724C9C78000500F6B /* EmbeddedEventContentRepresentation.swift */; };
 		CABCDE6A24C9C79300500F6B /* EmbeddedEventContentRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = CABCDE6924C9C79300500F6B /* EmbeddedEventContentRoute.swift */; };
 		CABCDE6C24C9C7BD00500F6B /* EmbeddedEventContentRouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CABCDE6B24C9C7BD00500F6B /* EmbeddedEventContentRouteTests.swift */; };
@@ -1882,6 +1883,7 @@
 		CABA43A01FD57A78009CB5B0 /* PreloadComponentBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreloadComponentBuilder.swift; sourceTree = "<group>"; };
 		CABA43A21FD57C65009CB5B0 /* TutorialModuleBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TutorialModuleBuilder.swift; sourceTree = "<group>"; };
 		CABA43AB1FD5DC68009CB5B0 /* LoginScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginScene.swift; sourceTree = "<group>"; };
+		CABBCA2F2566FE0B007A11A2 /* SplitViewDetailBugTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitViewDetailBugTests.swift; sourceTree = "<group>"; };
 		CABCDE6724C9C78000500F6B /* EmbeddedEventContentRepresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbeddedEventContentRepresentation.swift; sourceTree = "<group>"; };
 		CABCDE6924C9C79300500F6B /* EmbeddedEventContentRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbeddedEventContentRoute.swift; sourceTree = "<group>"; };
 		CABCDE6B24C9C7BD00500F6B /* EmbeddedEventContentRouteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbeddedEventContentRouteTests.swift; sourceTree = "<group>"; };
@@ -6649,6 +6651,7 @@
 				CAF255112517FE81008892ED /* DealerDetailTests.swift */,
 				CAF2552E251A6DC4008892ED /* EventDetailTests.swift */,
 				CAF254AC2517F983008892ED /* LaunchPerformanceTest.swift */,
+				CABBCA2F2566FE0B007A11A2 /* SplitViewDetailBugTests.swift */,
 				CAF254FD2517FB47008892ED /* UI Automation */,
 			);
 			path = EurofurenceUITests;
@@ -8476,6 +8479,7 @@
 				CAF2552F251A6DC4008892ED /* EventDetailTests.swift in Sources */,
 				CAF254AD2517F983008892ED /* LaunchPerformanceTest.swift in Sources */,
 				CAF255122517FE81008892ED /* DealerDetailTests.swift in Sources */,
+				CABBCA302566FE0B007A11A2 /* SplitViewDetailBugTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Eurofurence/Application/Components/No Content/NoContentPlaceholderViewController.storyboard
+++ b/Eurofurence/Application/Components/No Content/NoContentPlaceholderViewController.storyboard
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="eoY-VH-1Kp">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="eoY-VH-1Kp">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -20,20 +21,21 @@
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="No Content Placeholder" translatesAutoresizingMaskIntoConstraints="NO" id="rKt-ba-4LL">
                                 <rect key="frame" x="87" y="232.5" width="240" height="431"/>
                                 <color key="tintColor" name="No Content Fill"/>
+                                <accessibility key="accessibilityConfiguration" identifier="org.eurofurence.NoContentPlaceholder.Placeholderimage"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="lessThanOrEqual" constant="240" id="AL1-Lx-D7T"/>
                                     <constraint firstAttribute="width" secondItem="rKt-ba-4LL" secondAttribute="height" multiplier="386:693" id="Q71-RH-zrn"/>
                                 </constraints>
                             </imageView>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="g0b-we-sRw"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="rKt-ba-4LL" firstAttribute="centerY" secondItem="yIo-JB-qwN" secondAttribute="centerY" id="3nr-rq-Scq"/>
                             <constraint firstItem="rKt-ba-4LL" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="g0b-we-sRw" secondAttribute="leading" constant="14" id="Gff-eS-gce"/>
                             <constraint firstItem="rKt-ba-4LL" firstAttribute="centerX" secondItem="yIo-JB-qwN" secondAttribute="centerX" id="Ma8-Ug-ZdJ"/>
                             <constraint firstItem="g0b-we-sRw" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="rKt-ba-4LL" secondAttribute="trailing" constant="14" id="j8n-lR-ynb"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="g0b-we-sRw"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="fcq-rp-JJb" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -46,5 +48,8 @@
         <namedColor name="No Content Fill">
             <color red="0.0" green="0.34901960784313724" blue="0.32549019607843138" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
     </resources>
 </document>

--- a/Eurofurence/Application/Modules/Principal Content/PrincipalContentAggregator.swift
+++ b/Eurofurence/Application/Modules/Principal Content/PrincipalContentAggregator.swift
@@ -53,10 +53,18 @@ public struct PrincipalContentAggregator: PrincipalContentModuleProviding {
     
     private class SplitViewController: UISplitViewController, UISplitViewControllerDelegate {
         
+        init() {
+            super.init(nibName: nil, bundle: nil)
+            delegate = self
+        }
+        
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+        
         override func viewDidLoad() {
             super.viewDidLoad()
             
-            delegate = self
             extendedLayoutIncludesOpaqueBars = true
             preferredDisplayMode = .allVisible
         }

--- a/EurofurenceUITests/SplitViewDetailBugTests.swift
+++ b/EurofurenceUITests/SplitViewDetailBugTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+
+class SplitViewDetailBugTests: XCTestCase {
+
+    func testPlaceholderNotVisibleWhenTransitioningFromAppToHomeToApp_BUG() throws {
+        let controller = AutomationController()
+        try XCTSkipIf(controller.isTablet, "Does not apply to tablets")
+        
+        controller.app.launch()
+        controller.transitionToContent()
+        
+        XCUIDevice.shared.press(.home)
+        XCTAssertTrue(controller.app.wait(for: .runningBackground, timeout: 5), "App did not enter background state")
+        
+        controller.app.activate()
+        controller.tapTab(.schedule)
+        
+        let placeholderImage = controller.app.images["org.eurofurence.NoContentPlaceholder.Placeholderimage"].firstMatch
+        XCTAssertFalse(placeholderImage.exists)
+    }
+
+}


### PR DESCRIPTION
Going from active -> background -> active while in compact size class would cause the placeholder content to appear when moving to other tabs for the first time. Delegate event handling in UISplitViewController changed in iOS 13 and needs to be handled sooner, so setting the delegate in init instead of viewDidLoad does the trick