### PR TITLE
Fix Danger mis marking comments in SwiftPM files

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -76,7 +76,7 @@ def perform_swift_code_review_on_file(file)
             warn("Override methods which only call super can be removed", file: file, line: index+1)
         end
 
-        if line =~ /^\/\/([^\/]|$)/ and !line.include?("MARK:") and !line.include?("swiftlint")
+        if line =~ /^\/\/([^\/]|$)/ and !line.include?("MARK:") and !line.include?("swift")
             warn("Comments should be avoided in favour of expressing intent in code", file: file, line: index + 1)
         end
 


### PR DESCRIPTION
The header starts with a comment to designate the tools version, so Danger shouldn’t include this in the checks