### PR TITLE
Prevent gesture dismissal on feedback form until it has been processed

### DIFF
--- a/Eurofurence.xcodeproj/project.pbxproj
+++ b/Eurofurence.xcodeproj/project.pbxproj
@@ -246,6 +246,7 @@
 		CA40109C211081C80056E16C /* KnowledgeGroupEntriesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA40109B211081C80056E16C /* KnowledgeGroupEntriesViewController.swift */; };
 		CA4010A12110854E0056E16C /* DefaultKnowledgeGroupViewModelFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA4010A02110854E0056E16C /* DefaultKnowledgeGroupViewModelFactory.swift */; };
 		CA456DD1258F774600E32E7B /* DuringFeedbackSubmission_EventFeedbackPresenterShould.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA456DD0258F774600E32E7B /* DuringFeedbackSubmission_EventFeedbackPresenterShould.swift */; };
+		CA456DE1258F7D1B00E32E7B /* WhenUserUpdatesFeedbackText_EventFeedbackPresenterShould.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA456DE0258F7D1B00E32E7B /* WhenUserUpdatesFeedbackText_EventFeedbackPresenterShould.swift */; };
 		CA47B1B1255812D600050890 /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = CA47B1B0255812D600050890 /* Localizable.stringsdict */; };
 		CA47B1B82558189D00050890 /* EventsWidgetStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA47B1B72558189D00050890 /* EventsWidgetStrings.swift */; };
 		CA4908C4245DADA000DB032C /* WindowContentWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA4908C3245DADA000DB032C /* WindowContentWireframe.swift */; };
@@ -1607,6 +1608,7 @@
 		CA40109B211081C80056E16C /* KnowledgeGroupEntriesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KnowledgeGroupEntriesViewController.swift; sourceTree = "<group>"; };
 		CA4010A02110854E0056E16C /* DefaultKnowledgeGroupViewModelFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultKnowledgeGroupViewModelFactory.swift; sourceTree = "<group>"; };
 		CA456DD0258F774600E32E7B /* DuringFeedbackSubmission_EventFeedbackPresenterShould.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuringFeedbackSubmission_EventFeedbackPresenterShould.swift; sourceTree = "<group>"; };
+		CA456DE0258F7D1B00E32E7B /* WhenUserUpdatesFeedbackText_EventFeedbackPresenterShould.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhenUserUpdatesFeedbackText_EventFeedbackPresenterShould.swift; sourceTree = "<group>"; };
 		CA47B1B0255812D600050890 /* Localizable.stringsdict */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; path = Localizable.stringsdict; sourceTree = "<group>"; };
 		CA47B1B72558189D00050890 /* EventsWidgetStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsWidgetStrings.swift; sourceTree = "<group>"; };
 		CA4908C3245DADA000DB032C /* WindowContentWireframe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowContentWireframe.swift; sourceTree = "<group>"; };
@@ -6357,6 +6359,7 @@
 				CAF1963324688EA9005DFBBE /* Feedback Submitted Successfully */,
 				CAF1963924688EA9005DFBBE /* Feedback Unsuccessful */,
 				CAF1963124688EA9005DFBBE /* Submit Feedback Tapped */,
+				CA456DE0258F7D1B00E32E7B /* WhenUserUpdatesFeedbackText_EventFeedbackPresenterShould.swift */,
 			);
 			path = Presenter;
 			sourceTree = "<group>";
@@ -8186,6 +8189,7 @@
 				CAF196FE24688EAA005DFBBE /* FakeScheduleInteractor.swift in Sources */,
 				CAF1971424688EAA005DFBBE /* ScheduleViewModelFactoryTestBuilder.swift in Sources */,
 				CAF1970324688EAA005DFBBE /* WhenSearchControllerProducesNewResults_ScheduleViewModelFactoryShould.swift in Sources */,
+				CA456DE1258F7D1B00E32E7B /* WhenUserUpdatesFeedbackText_EventFeedbackPresenterShould.swift in Sources */,
 				CAF197E724688EAA005DFBBE /* CapturingKnowledgeInteractor.swift in Sources */,
 				CA6F75D4246956AE001FFB74 /* StubMainStageEventViewModel.swift in Sources */,
 				CAF1982224688EAB005DFBBE /* CapturingDealersViewModel.swift in Sources */,

--- a/Eurofurence.xcodeproj/project.pbxproj
+++ b/Eurofurence.xcodeproj/project.pbxproj
@@ -245,6 +245,7 @@
 		CA40109A211081A40056E16C /* KnowledgeGroupEntries.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CA401099211081A40056E16C /* KnowledgeGroupEntries.storyboard */; };
 		CA40109C211081C80056E16C /* KnowledgeGroupEntriesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA40109B211081C80056E16C /* KnowledgeGroupEntriesViewController.swift */; };
 		CA4010A12110854E0056E16C /* DefaultKnowledgeGroupViewModelFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA4010A02110854E0056E16C /* DefaultKnowledgeGroupViewModelFactory.swift */; };
+		CA456DD1258F774600E32E7B /* DuringFeedbackSubmission_EventFeedbackPresenterShould.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA456DD0258F774600E32E7B /* DuringFeedbackSubmission_EventFeedbackPresenterShould.swift */; };
 		CA47B1B1255812D600050890 /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = CA47B1B0255812D600050890 /* Localizable.stringsdict */; };
 		CA47B1B82558189D00050890 /* EventsWidgetStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA47B1B72558189D00050890 /* EventsWidgetStrings.swift */; };
 		CA4908C4245DADA000DB032C /* WindowContentWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA4908C3245DADA000DB032C /* WindowContentWireframe.swift */; };
@@ -1605,6 +1606,7 @@
 		CA401099211081A40056E16C /* KnowledgeGroupEntries.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = KnowledgeGroupEntries.storyboard; sourceTree = "<group>"; };
 		CA40109B211081C80056E16C /* KnowledgeGroupEntriesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KnowledgeGroupEntriesViewController.swift; sourceTree = "<group>"; };
 		CA4010A02110854E0056E16C /* DefaultKnowledgeGroupViewModelFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultKnowledgeGroupViewModelFactory.swift; sourceTree = "<group>"; };
+		CA456DD0258F774600E32E7B /* DuringFeedbackSubmission_EventFeedbackPresenterShould.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuringFeedbackSubmission_EventFeedbackPresenterShould.swift; sourceTree = "<group>"; };
 		CA47B1B0255812D600050890 /* Localizable.stringsdict */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; path = Localizable.stringsdict; sourceTree = "<group>"; };
 		CA47B1B72558189D00050890 /* EventsWidgetStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsWidgetStrings.swift; sourceTree = "<group>"; };
 		CA4908C3245DADA000DB032C /* WindowContentWireframe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowContentWireframe.swift; sourceTree = "<group>"; };
@@ -6372,6 +6374,7 @@
 		CAF1963124688EA9005DFBBE /* Submit Feedback Tapped */ = {
 			isa = PBXGroup;
 			children = (
+				CA456DD0258F774600E32E7B /* DuringFeedbackSubmission_EventFeedbackPresenterShould.swift */,
 				CAF1963224688EA9005DFBBE /* WhenEventFeedbackScenePreparesFeedback_EventFeedbackPresenterShould.swift */,
 			);
 			path = "Submit Feedback Tapped";
@@ -8492,6 +8495,7 @@
 				CAF196F724688EAA005DFBBE /* CapturingScheduleEventComponent.swift in Sources */,
 				CAF1981F24688EAB005DFBBE /* StubDealersSceneFactory.swift in Sources */,
 				CAF196D924688EAA005DFBBE /* WhenInstigatingPullToRefreshAction_SchedulePresenterShould.swift in Sources */,
+				CA456DD1258F774600E32E7B /* DuringFeedbackSubmission_EventFeedbackPresenterShould.swift in Sources */,
 				CAF197E524688EAA005DFBBE /* VisitsEntryFromKnowledgeListViewModel.swift in Sources */,
 				CAD4F769245C45B90036ADAF /* EventFeedbackContentRouteTests.swift in Sources */,
 				CAF1973B24688EAA005DFBBE /* WhenSceneSelectsKnowledgeEntry_KnowledgeGroupEntriesPresenterShould.swift in Sources */,

--- a/Eurofurence/Application/Components/Event Feedback/Presenter/EventFeedbackPresenter.swift
+++ b/Eurofurence/Application/Components/Event Feedback/Presenter/EventFeedbackPresenter.swift
@@ -37,11 +37,15 @@ class EventFeedbackPresenter: EventFeedbackSceneDelegate, EventFeedbackDelegate 
     }
     
     func eventFeedbackSceneDidLoad() {
-        let viewModel = ViewModel(event: event,
-                                  eventFeedback: eventFeedback,
-                                  submitFeedback: { [weak self] in self?.submitFeedback() },
-                                  cancelFeedback: { [weak self] in self?.cancelFeedback() },
-                                  dayAndTimeFormatter: dayAndTimeFormatter)
+        let viewModel = ViewModel(
+            event: event,
+            eventFeedback: eventFeedback,
+            submitFeedback: { [weak self] in self?.submitFeedback() },
+            cancelFeedback: { [weak self] in self?.cancelFeedback() },
+            dayAndTimeFormatter: dayAndTimeFormatter,
+            scene: scene
+        )
+        
         scene?.bind(viewModel)
         scene?.showFeedbackForm()
         scene?.enableDismissal()
@@ -120,18 +124,23 @@ class EventFeedbackPresenter: EventFeedbackSceneDelegate, EventFeedbackDelegate 
         var eventLocation: String
         var eventHosts: String
         var defaultEventStarRating: Int = 0
-
-        init(event: Event,
-             eventFeedback: EventFeedback,
-             submitFeedback: @escaping () -> Void,
-             cancelFeedback: @escaping () -> Void,
-             dayAndTimeFormatter: EventDayAndTimeFormatter) {
+        weak var scene: EventFeedbackScene?
+        
+        init(
+            event: Event,
+            eventFeedback: EventFeedback,
+            submitFeedback: @escaping () -> Void,
+            cancelFeedback: @escaping () -> Void,
+            dayAndTimeFormatter: EventDayAndTimeFormatter,
+            scene: EventFeedbackScene?
+        ) {
             let hosts: String = {
                 let formatString = String.eventHostedByFormat
                 return String.localizedStringWithFormat(formatString, event.hosts)
             }()
             
             self.eventFeedback = eventFeedback
+            self.scene = scene
             submit = submitFeedback
             cancel = cancelFeedback
             eventTitle = event.title
@@ -143,6 +152,12 @@ class EventFeedbackPresenter: EventFeedbackSceneDelegate, EventFeedbackDelegate 
         
         func feedbackChanged(_ feedback: String) {
             eventFeedback.feedback = feedback
+            
+            if feedback.isEmpty {
+                scene?.enableDismissal()
+            } else {
+                scene?.disableDismissal()
+            }
         }
         
         func ratingPercentageChanged(_ ratingPercentage: Float) {

--- a/Eurofurence/Application/Components/Event Feedback/Presenter/EventFeedbackPresenter.swift
+++ b/Eurofurence/Application/Components/Event Feedback/Presenter/EventFeedbackPresenter.swift
@@ -44,16 +44,19 @@ class EventFeedbackPresenter: EventFeedbackSceneDelegate, EventFeedbackDelegate 
                                   dayAndTimeFormatter: dayAndTimeFormatter)
         scene?.bind(viewModel)
         scene?.showFeedbackForm()
+        scene?.enableDismissal()
     }
     
     func eventFeedbackSubmissionDidFinish(_ feedback: EventFeedback) {
         scene?.showFeedbackSubmissionSuccessful()
+        scene?.enableDismissal()
         successHaptic.play()
         successWaitingRule.evaluateRule(handler: delegate.eventFeedbackCancelled)
     }
     
     func eventFeedbackSubmissionDidFail(_ feedback: EventFeedback) {
         scene?.showFeedbackForm()
+        scene?.enableDismissal()
         scene?.showFeedbackSubmissionFailedPrompt()
         scene?.enableNavigationControls()
         failureHaptic.play()
@@ -63,6 +66,7 @@ class EventFeedbackPresenter: EventFeedbackSceneDelegate, EventFeedbackDelegate 
         eventFeedback.submit(self)
         scene?.showFeedbackSubmissionInProgress()
         scene?.disableNavigationControls()
+        scene?.disableDismissal()
     }
     
     private var userHasEnteredFeedback: Bool {

--- a/Eurofurence/Application/Components/Event Feedback/Scene/EventFeedbackScene.swift
+++ b/Eurofurence/Application/Components/Event Feedback/Scene/EventFeedbackScene.swift
@@ -10,6 +10,8 @@ public protocol EventFeedbackScene: AnyObject {
     func showFeedbackSubmissionFailedPrompt()
     func disableNavigationControls()
     func enableNavigationControls()
+    func disableDismissal()
+    func enableDismissal()
     func showDiscardFeedbackPrompt(discardHandler: @escaping () -> Void)
     
 }

--- a/Eurofurence/Application/Components/Event Feedback/Scene/EventFeedbackViewController.swift
+++ b/Eurofurence/Application/Components/Event Feedback/Scene/EventFeedbackViewController.swift
@@ -23,6 +23,11 @@ public class EventFeedbackViewController: UIViewController, EventFeedbackScene {
         delegate?.eventFeedbackSceneDidLoad()
     }
     
+    override public func didMove(toParent parent: UIViewController?) {
+        super.didMove(toParent: parent)
+        parent?.presentationController?.delegate = self
+    }
+    
     private func swapEmbeddedViewController(to newChild: UIViewController) {
         newChild.willMove(toParent: self)
         embedChildView(newChild.view)
@@ -162,6 +167,16 @@ public class EventFeedbackViewController: UIViewController, EventFeedbackScene {
         let rightBarButtonItems = navigationItem.rightBarButtonItems ?? []
         
         return leftBarButtonItems + rightBarButtonItems
+    }
+    
+}
+
+// MARK: - UIAdaptivePresentationControllerDelegate
+
+extension EventFeedbackViewController: UIAdaptivePresentationControllerDelegate {
+    
+    public func presentationControllerDidAttemptToDismiss(_ presentationController: UIPresentationController) {
+        viewModel?.cancelFeedback()
     }
     
 }

--- a/Eurofurence/Application/Components/Event Feedback/Scene/EventFeedbackViewController.swift
+++ b/Eurofurence/Application/Components/Event Feedback/Scene/EventFeedbackViewController.swift
@@ -125,6 +125,18 @@ public class EventFeedbackViewController: UIViewController, EventFeedbackScene {
         barButtonItems.forEach({ $0.isEnabled = true })
     }
     
+    public func disableDismissal() {
+        if #available(iOS 13.0, *) {
+            isModalInPresentation = true
+        }
+    }
+    
+    public func enableDismissal() {
+        if #available(iOS 13.0, *) {
+            isModalInPresentation = false
+        }
+    }
+    
     public func showDiscardFeedbackPrompt(discardHandler: @escaping () -> Void) {
         let alert = UIAlertController(title: .confirmDiscardEventFeedbackTitle, message: "", preferredStyle: .alert)
         let cancelAction = UIAlertAction(title: .cancel, style: .cancel)

--- a/EurofurenceTests/Application/Components/Event Feedback/Presenter/Submit Feedback Tapped/DuringFeedbackSubmission_EventFeedbackPresenterShould.swift
+++ b/EurofurenceTests/Application/Components/Event Feedback/Presenter/Submit Feedback Tapped/DuringFeedbackSubmission_EventFeedbackPresenterShould.swift
@@ -1,0 +1,51 @@
+import Eurofurence
+import EurofurenceModelTestDoubles
+import XCTest
+
+class DuringFeedbackSubmission_EventFeedbackPresenterShould: XCTestCase {
+    
+    func testDisallowFeedbackDismissalUntilTheFeedbackHasBeenSubmittedSuccessfully() {
+        assertFeedbackCannotBeDismissed(feedbackResultHandler: { $0?.simulateSuccess() })
+    }
+    
+    func testDisallowFeedbackDismissalUntilTheFeedbackHasBeenSubmittedUnsuccessfully() {
+        assertFeedbackCannotBeDismissed(feedbackResultHandler: { $0?.simulateFailure() })
+    }
+    
+    private func assertFeedbackCannotBeDismissed(
+        feedbackResultHandler: (FakeEventFeedback?) -> Void,
+        line: UInt = #line
+    ) {
+        let context = EventFeedbackPresenterTestBuilder().build()
+        context.simulateSceneDidLoad()
+        
+        XCTAssertEqual(
+            .dismissalPermitted,
+            context.scene.dismissalState,
+            "Feedback should be dismissable once the form has loaded",
+            line: line
+        )
+        
+        context.scene.simulateFeedbackTextDidChange(.random)
+        context.scene.simulateFeedbackRatioDidChange(.random)
+        context.scene.simulateSubmitFeedbackTapped()
+        
+        XCTAssertEqual(
+            .dismissalDenied,
+            context.scene.dismissalState,
+            "Feedback should not be dismissable until it has finished processing",
+            line: line
+        )
+        
+        let feedback = context.event.lastGeneratedFeedback
+        feedbackResultHandler(feedback)
+        
+        XCTAssertEqual(
+            .dismissalPermitted,
+            context.scene.dismissalState,
+            "Feedback should be dismissable once it has finished processing",
+            line: line
+        )
+    }
+
+}

--- a/EurofurenceTests/Application/Components/Event Feedback/Presenter/WhenUserUpdatesFeedbackText_EventFeedbackPresenterShould.swift
+++ b/EurofurenceTests/Application/Components/Event Feedback/Presenter/WhenUserUpdatesFeedbackText_EventFeedbackPresenterShould.swift
@@ -1,0 +1,26 @@
+import Eurofurence
+import XCTest
+
+class WhenUserUpdatesFeedbackText_EventFeedbackPresenterShould: XCTestCase {
+    
+    func testPreventDismissalWhenTextIsNonEmpty() {
+        let context = EventFeedbackPresenterTestBuilder().build()
+        context.simulateSceneDidLoad()
+        
+        let feedback = "This event is very cool and good"
+        context.scene.simulateFeedbackTextDidChange(feedback)
+        
+        XCTAssertEqual(.dismissalDenied, context.scene.dismissalState)
+    }
+    
+    func testPermitDissmisalWhenTextIsEmpty() {
+        let context = EventFeedbackPresenterTestBuilder().build()
+        context.simulateSceneDidLoad()
+        
+        context.scene.simulateFeedbackTextDidChange("This event is very cool and good")
+        context.scene.simulateFeedbackTextDidChange("")
+        
+        XCTAssertEqual(.dismissalPermitted, context.scene.dismissalState)
+    }
+
+}

--- a/EurofurenceTests/Application/Components/Event Feedback/Test Doubles/CapturingEventFeedbackScene.swift
+++ b/EurofurenceTests/Application/Components/Event Feedback/Test Doubles/CapturingEventFeedbackScene.swift
@@ -17,6 +17,12 @@ class CapturingEventFeedbackScene: UIViewController, EventFeedbackScene {
         case enabled
     }
     
+    enum DismissalState {
+        case unset
+        case dismissalPermitted
+        case dismissalDenied
+    }
+    
     private var delegate: EventFeedbackSceneDelegate?
     func setDelegate(_ delegate: EventFeedbackSceneDelegate) {
         self.delegate = delegate
@@ -52,6 +58,15 @@ class CapturingEventFeedbackScene: UIViewController, EventFeedbackScene {
     
     func enableNavigationControls() {
         navigationControlsState = .enabled
+    }
+    
+    private(set) var dismissalState: DismissalState = .unset
+    func disableDismissal() {
+        dismissalState = .dismissalDenied
+    }
+    
+    func enableDismissal() {
+        dismissalState = .dismissalPermitted
     }
     
     private(set) var confirmCancellationAlertPresented = false


### PR DESCRIPTION
Disables the swipe-to-dismiss gesture on the feedback form while feedback is being submitted, then renables dismissal once it’s done. Also shows the discard alert when attempting to dismiss the form with text entered