### PR TITLE
Avoid immediate Intent donation

### DIFF
--- a/Eurofurence.xcodeproj/project.pbxproj
+++ b/Eurofurence.xcodeproj/project.pbxproj
@@ -247,6 +247,7 @@
 		CA4010A12110854E0056E16C /* DefaultKnowledgeGroupViewModelFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA4010A02110854E0056E16C /* DefaultKnowledgeGroupViewModelFactory.swift */; };
 		CA456DD1258F774600E32E7B /* DuringFeedbackSubmission_EventFeedbackPresenterShould.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA456DD0258F774600E32E7B /* DuringFeedbackSubmission_EventFeedbackPresenterShould.swift */; };
 		CA456DE1258F7D1B00E32E7B /* WhenUserUpdatesFeedbackText_EventFeedbackPresenterShould.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA456DE0258F7D1B00E32E7B /* WhenUserUpdatesFeedbackText_EventFeedbackPresenterShould.swift */; };
+		CA456DF1258F9F1C00E32E7B /* ActivityDonation.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA456DF0258F9F1C00E32E7B /* ActivityDonation.swift */; };
 		CA47B1B1255812D600050890 /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = CA47B1B0255812D600050890 /* Localizable.stringsdict */; };
 		CA47B1B82558189D00050890 /* EventsWidgetStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA47B1B72558189D00050890 /* EventsWidgetStrings.swift */; };
 		CA4908C4245DADA000DB032C /* WindowContentWireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA4908C3245DADA000DB032C /* WindowContentWireframe.swift */; };
@@ -1609,6 +1610,7 @@
 		CA4010A02110854E0056E16C /* DefaultKnowledgeGroupViewModelFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultKnowledgeGroupViewModelFactory.swift; sourceTree = "<group>"; };
 		CA456DD0258F774600E32E7B /* DuringFeedbackSubmission_EventFeedbackPresenterShould.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuringFeedbackSubmission_EventFeedbackPresenterShould.swift; sourceTree = "<group>"; };
 		CA456DE0258F7D1B00E32E7B /* WhenUserUpdatesFeedbackText_EventFeedbackPresenterShould.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhenUserUpdatesFeedbackText_EventFeedbackPresenterShould.swift; sourceTree = "<group>"; };
+		CA456DF0258F9F1C00E32E7B /* ActivityDonation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityDonation.swift; sourceTree = "<group>"; };
 		CA47B1B0255812D600050890 /* Localizable.stringsdict */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; path = Localizable.stringsdict; sourceTree = "<group>"; };
 		CA47B1B72558189D00050890 /* EventsWidgetStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsWidgetStrings.swift; sourceTree = "<group>"; };
 		CA4908C3245DADA000DB032C /* WindowContentWireframe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowContentWireframe.swift; sourceTree = "<group>"; };
@@ -3788,6 +3790,7 @@
 			isa = PBXGroup;
 			children = (
 				CA987FC922E638A8006338FB /* Activity.swift */,
+				CA456DF0258F9F1C00E32E7B /* ActivityDonation.swift */,
 				CA987FC722E6389E006338FB /* ActivityFactory.swift */,
 				CA987FCD22E63A4C006338FB /* ActivityInteraction.swift */,
 				CA987FCB22E63A2C006338FB /* Interaction.swift */,
@@ -7698,6 +7701,7 @@
 				CAD4F770245C47590036ADAF /* ModalWireframe.swift in Sources */,
 				CA63A762245DCE6400E4B313 /* ExternalApplicationContentRepresentation.swift in Sources */,
 				CA36A4BE20DA70B000EE6537 /* DealersSearchTableViewController.swift in Sources */,
+				CA456DF1258F9F1C00E32E7B /* ActivityDonation.swift in Sources */,
 				CA6A8DD220E417EE007536CD /* MapDetailSceneFactory.swift in Sources */,
 				CA6375B0208E02CC00536BE2 /* DealersSceneFactory.swift in Sources */,
 				CA4D9364245EF334006FA832 /* Identifier+ExpressibleByString.swift in Sources */,

--- a/Eurofurence/Activity/ActivityDonation.swift
+++ b/Eurofurence/Activity/ActivityDonation.swift
@@ -1,0 +1,5 @@
+protocol ActivityDonation {
+    
+    func donate()
+    
+}

--- a/Eurofurence/Activity/ActivityInteraction.swift
+++ b/Eurofurence/Activity/ActivityInteraction.swift
@@ -1,6 +1,11 @@
 struct ActivityInteraction: Interaction {
     
     var activity: Activity
+    var donation: ActivityDonation
+    
+    func donate() {
+        donation.donate()
+    }
     
     func activate() {
         activity.becomeCurrent()

--- a/Eurofurence/Activity/Dealers/Intents/DonateIntentDealerInteractionRecorder.swift
+++ b/Eurofurence/Activity/Dealers/Intents/DonateIntentDealerInteractionRecorder.swift
@@ -19,9 +19,6 @@ public struct DonateIntentDealerInteractionRecorder: DealerInteractionRecorder {
     public func makeInteraction(for dealer: DealerIdentifier) -> Interaction? {
         guard let entity = dealersService.fetchDealer(for: dealer) else { return nil }
         
-        let intentDefinition = ViewDealerIntentDefinition(identifier: dealer, dealerName: entity.preferredName)
-        viewDealerIntentDonor.donate(intentDefinition)
-        
         let activityTitle = String.viewDealer(named: entity.preferredName)
         let url = entity.contentURL
         let activity = activityFactory.makeActivity(
@@ -32,7 +29,21 @@ public struct DonateIntentDealerInteractionRecorder: DealerInteractionRecorder {
         
         activity.markEligibleForPublicIndexing()
         
-        return ActivityInteraction(activity: activity)
+        let intentDefinition = ViewDealerIntentDefinition(identifier: dealer, dealerName: entity.preferredName)
+        let donation = DealerDonation(intentDefinition: intentDefinition, donor: viewDealerIntentDonor)
+        
+        return ActivityInteraction(activity: activity, donation: donation)
+    }
+    
+    private struct DealerDonation: ActivityDonation {
+        
+        var intentDefinition: ViewDealerIntentDefinition
+        var donor: ViewDealerIntentDonor
+        
+        func donate() {
+            donor.donate(intentDefinition)
+        }
+        
     }
     
 }

--- a/Eurofurence/Activity/Events/Intents/SystemEventInteractionsRecorder.swift
+++ b/Eurofurence/Activity/Events/Intents/SystemEventInteractionsRecorder.swift
@@ -20,9 +20,6 @@ public struct SystemEventInteractionsRecorder: EventInteractionRecorder {
     public func makeInteraction(for event: EventIdentifier) -> Interaction? {
         guard let entity = eventsService.fetchEvent(identifier: event) else { return nil }
         
-        let intentDefinition = ViewEventIntentDefinition(identifier: event, eventName: entity.title)
-        eventIntentDonor.donateEventIntent(definition: intentDefinition)
-        
         let activityTitle = String.viewEvent(named: entity.title)
         let url = entity.contentURL
         let activity = activityFactory.makeActivity(
@@ -33,7 +30,21 @@ public struct SystemEventInteractionsRecorder: EventInteractionRecorder {
         
         activity.markEligibleForPublicIndexing()
         
-        return ActivityInteraction(activity: activity)
+        let intentDefinition = ViewEventIntentDefinition(identifier: event, eventName: entity.title)
+        let donation = EventDonation(intentDefinition: intentDefinition, donor: eventIntentDonor)
+        
+        return ActivityInteraction(activity: activity, donation: donation)
+    }
+    
+    private struct EventDonation: ActivityDonation {
+        
+        var intentDefinition: ViewEventIntentDefinition
+        var donor: EventIntentDonor
+        
+        func donate() {
+            donor.donateEventIntent(definition: intentDefinition)
+        }
+        
     }
     
 }

--- a/Eurofurence/Activity/Interaction.swift
+++ b/Eurofurence/Activity/Interaction.swift
@@ -1,5 +1,6 @@
 public protocol Interaction {
     
+    func donate()
     func activate()
     func deactivate()
     

--- a/Eurofurence/Application/Components/Dealer Detail/Presenter/DealerDetailPresenter.swift
+++ b/Eurofurence/Application/Components/Dealer Detail/Presenter/DealerDetailPresenter.swift
@@ -148,6 +148,7 @@ class DealerDetailPresenter: DealerDetailSceneDelegate {
 
     func dealerDetailSceneDidLoad() {
         dealerInteraction = dealerInteractionRecorder.makeInteraction(for: dealer)
+        dealerInteraction?.donate()
         
         dealerDetailViewModelFactory.makeDealerDetailViewModel(for: dealer) { (viewModel) in
             self.viewModel = viewModel

--- a/Eurofurence/Application/Components/Event Detail/Presenter/EventDetailPresenter.swift
+++ b/Eurofurence/Application/Components/Event Detail/Presenter/EventDetailPresenter.swift
@@ -144,6 +144,7 @@ class EventDetailPresenter: EventDetailSceneDelegate, EventDetailViewModelDelega
 
     func eventDetailSceneDidLoad() {
         eventInteraction = interactionRecorder.makeInteraction(for: event)
+        eventInteraction?.donate()
         eventDetailViewModelFactory.makeViewModel(for: event, completionHandler: eventDetailViewModelReady)
     }
     

--- a/EurofurenceTests/Application/Components/Dealers/Presenter Tests/Interaction Recording/DealerDetailPresenter_InteractionRecordingTests.swift
+++ b/EurofurenceTests/Application/Components/Dealers/Presenter Tests/Interaction Recording/DealerDetailPresenter_InteractionRecordingTests.swift
@@ -9,11 +9,12 @@ class DealerDetailPresenter_InteractionRecordingTests: XCTestCase {
         let identifier: DealerIdentifier = .random
         let context = DealerDetailPresenterTestBuilder().build(for: identifier)
         
-        XCTAssertNil(context.dealerInteractionRecorder.witnessedDealer)
+        XCTAssertNil(context.dealerInteractionRecorder.currentInteraction)
         
         context.simulateSceneDidLoad()
         
         XCTAssertEqual(context.dealerInteractionRecorder.witnessedDealer, identifier)
+        XCTAssertEqual(context.dealerInteractionRecorder.currentInteraction?.donated, true)
     }
     
     func testSceneAppearingMakesInteractionActive() {

--- a/EurofurenceTests/Application/Components/Event Detail/Presenter Tests/Interaction Recording/EventDetailPresenter_InteractionRecordingTests.swift
+++ b/EurofurenceTests/Application/Components/Event Detail/Presenter Tests/Interaction Recording/EventDetailPresenter_InteractionRecordingTests.swift
@@ -9,11 +9,12 @@ class EventDetailPresenter_InteractionRecordingTests: XCTestCase {
         let event = FakeEvent.random
         let context = EventDetailPresenterTestBuilder().build(for: event)
         
-        XCTAssertNil(context.eventInteractionRecorder.witnessedEvent)
+        XCTAssertNil(context.eventInteractionRecorder.currentInteraction)
         
         context.simulateSceneDidLoad()
         
         XCTAssertEqual(context.eventInteractionRecorder.witnessedEvent, event.identifier)
+        XCTAssertEqual(context.eventInteractionRecorder.currentInteraction?.donated, true)
     }
     
     func testSceneAppearingMakesInteractionActive() {

--- a/EurofurenceTests/Application/Components/Event Detail/Presenter Tests/Test Doubles/CapturingInteraction.swift
+++ b/EurofurenceTests/Application/Components/Event Detail/Presenter Tests/Test Doubles/CapturingInteraction.swift
@@ -9,6 +9,11 @@ class CapturingInteraction: Interaction {
     }
     
     private(set) var state: State = .unset
+    private(set) var donated = false
+    
+    func donate() {
+        donated = true
+    }
     
     func activate() {
         state = .active


### PR DESCRIPTION
Prework ahead of exposing activities to system drag and drop scenarios. Permits interactions to be reused elsewhere without donating the corresponding intent to Siri