### PR TITLE
Fix app clip routing

### DIFF
--- a/Eurofurence.xcodeproj/project.pbxproj
+++ b/Eurofurence.xcodeproj/project.pbxproj
@@ -14,6 +14,9 @@
 		CA02910221F4D6020007F350 /* UIWindow+Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA02910121F4D6020007F350 /* UIWindow+Debug.swift */; };
 		CA03124026793F32004E47B0 /* EurofurenceClipLogic in Frameworks */ = {isa = PBXBuildFile; productRef = CA03123F26793F32004E47B0 /* EurofurenceClipLogic */; };
 		CA031249267BA020004E47B0 /* AppClipInfoPropertyListShould.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA031248267BA020004E47B0 /* AppClipInfoPropertyListShould.swift */; };
+		CA04437A26DEBC63008CC04F /* AutomationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAF254FE2517FB65008892ED /* AutomationController.swift */; };
+		CA04437B26DEBC63008CC04F /* UIAutomationTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAF25567251A8774008892ED /* UIAutomationTestCase.swift */; };
+		CA04437D26DEBC7E008CC04F /* EurofurenceClip_EventDetailTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA04437C26DEBC7E008CC04F /* EurofurenceClip_EventDetailTests.swift */; };
 		CA08861F25FE997E0044DD53 /* fontawesome-webfont.ttf in Resources */ = {isa = PBXBuildFile; fileRef = CA08861B25FE997E0044DD53 /* fontawesome-webfont.ttf */; };
 		CA08862025FE997E0044DD53 /* personal_notification.caf in Resources */ = {isa = PBXBuildFile; fileRef = CA08861D25FE997E0044DD53 /* personal_notification.caf */; };
 		CA08862125FE997E0044DD53 /* generic_notification.caf in Resources */ = {isa = PBXBuildFile; fileRef = CA08861E25FE997E0044DD53 /* generic_notification.caf */; };
@@ -113,6 +116,13 @@
 			remoteInfo = Eurofurence;
 		};
 		9ACF99491EBE172D006FC958 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9ACF992C1EBE172D006FC958 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9ACF99331EBE172D006FC958;
+			remoteInfo = Eurofurence;
+		};
+		CA04437E26DEBD57008CC04F /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 9ACF992C1EBE172D006FC958 /* Project object */;
 			proxyType = 1;
@@ -238,6 +248,7 @@
 		9ACF994E1EBE172D006FC958 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		CA02910121F4D6020007F350 /* UIWindow+Debug.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIWindow+Debug.swift"; sourceTree = "<group>"; };
 		CA031248267BA020004E47B0 /* AppClipInfoPropertyListShould.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppClipInfoPropertyListShould.swift; sourceTree = "<group>"; };
+		CA04437C26DEBC7E008CC04F /* EurofurenceClip_EventDetailTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EurofurenceClip_EventDetailTests.swift; sourceTree = "<group>"; };
 		CA08861B25FE997E0044DD53 /* fontawesome-webfont.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "fontawesome-webfont.ttf"; sourceTree = "<group>"; };
 		CA08861D25FE997E0044DD53 /* personal_notification.caf */ = {isa = PBXFileReference; lastKnownFileType = file; path = personal_notification.caf; sourceTree = "<group>"; };
 		CA08861E25FE997E0044DD53 /* generic_notification.caf */ = {isa = PBXFileReference; lastKnownFileType = file; path = generic_notification.caf; sourceTree = "<group>"; };
@@ -640,8 +651,9 @@
 		CA7A2F132606BCB400919DA0 /* EurofurenceClip UITests */ = {
 			isa = PBXGroup;
 			children = (
-				CA7A2F142606BCB400919DA0 /* Eurofurence_Clip_UITests.swift */,
 				CA7A2F162606BCB400919DA0 /* Info.plist */,
+				CA7A2F142606BCB400919DA0 /* Eurofurence_Clip_UITests.swift */,
+				CA04437C26DEBC7E008CC04F /* EurofurenceClip_EventDetailTests.swift */,
 			);
 			path = "EurofurenceClip UITests";
 			sourceTree = "<group>";
@@ -907,6 +919,7 @@
 			);
 			dependencies = (
 				CA7A2F272606BCB800919DA0 /* PBXTargetDependency */,
+				CA04437F26DEBD57008CC04F /* PBXTargetDependency */,
 			);
 			name = "Eurofurence Clip UITests";
 			productName = "Eurofurence Clip UITests";
@@ -1313,7 +1326,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CA04437B26DEBC63008CC04F /* UIAutomationTestCase.swift in Sources */,
+				CA04437A26DEBC63008CC04F /* AutomationController.swift in Sources */,
 				CA7A2F152606BCB400919DA0 /* Eurofurence_Clip_UITests.swift in Sources */,
+				CA04437D26DEBC7E008CC04F /* EurofurenceClip_EventDetailTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1360,6 +1376,11 @@
 			isa = PBXTargetDependency;
 			target = 9ACF99331EBE172D006FC958 /* Eurofurence */;
 			targetProxy = 9ACF99491EBE172D006FC958 /* PBXContainerItemProxy */;
+		};
+		CA04437F26DEBD57008CC04F /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 9ACF99331EBE172D006FC958 /* Eurofurence */;
+			targetProxy = CA04437E26DEBD57008CC04F /* PBXContainerItemProxy */;
 		};
 		CA3ADD532677DC28007064AF /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -2156,7 +2177,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_TARGET_NAME = "Eurofurence Clip";
+				TEST_TARGET_NAME = EurofurenceClip;
 			};
 			name = Debug;
 		};
@@ -2182,7 +2203,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_TARGET_NAME = "Eurofurence Clip";
+				TEST_TARGET_NAME = EurofurenceClip;
 			};
 			name = Screenshots;
 		};
@@ -2208,7 +2229,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_TARGET_NAME = "Eurofurence Clip";
+				TEST_TARGET_NAME = EurofurenceClip;
 			};
 			name = Release;
 		};
@@ -2234,7 +2255,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_TARGET_NAME = "Eurofurence Clip";
+				TEST_TARGET_NAME = EurofurenceClip;
 			};
 			name = Profiling;
 		};

--- a/EurofurenceClip UITests/EurofurenceClip_EventDetailTests.swift
+++ b/EurofurenceClip UITests/EurofurenceClip_EventDetailTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+
+class EurofurenceClip_EventDetailTests: UIAutomationTestCase {
+    
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        
+        controller.app.launch()
+        controller.app.tables.staticTexts["Fursuit Lounge"].tap()
+    }
+    
+    func testNavigationTitle() {
+        let navigationTitle = controller
+            .app
+            .staticTexts
+            .matching(identifier: "org.eurofurence.event.navigationTitle")
+            .firstMatch
+        
+        XCTAssertFalse(navigationTitle.exists)
+        
+        controller.app.tables.cells.containing(.staticText, identifier: "Share").element.swipeUp()
+        
+        XCTAssertTrue(navigationTitle.exists)
+    }
+    
+}

--- a/Packages/EurofurenceClipLogic/Sources/EurofurenceClipLogic/AppClip+PrincipalWindowAssembler.swift
+++ b/Packages/EurofurenceClipLogic/Sources/EurofurenceClipLogic/AppClip+PrincipalWindowAssembler.swift
@@ -46,19 +46,19 @@ extension AppClip {
                 services: services
             )
             
-            var router = Routes()
-            
-            let rootContainerViewController = RootContainerViewController()
+            var routes = AppClipRoutes(window: window, components: components).routes
             
             let scheduleFactoryAdapter = ScheduleFactoryAdapter(
                 scheduleComponentFactory: components.scheduleComponentFactory,
-                router: router
+                router: routes
             )
             
             let dealersFactoryAdapter = DealersFactoryAdapter(
                 dealersComponentFactory: components.dealersComponentFactory,
-                router: router
+                router: routes
             )
+            
+            let rootContainerViewController = RootContainerViewController()
             
             let clipContentScene = WireframeBasedClipContentScene(
                 wireframe: rootContainerViewController,
@@ -66,10 +66,10 @@ extension AppClip {
                 dealersComponent: dealersFactoryAdapter
             )
             
-            let routes = AppClipRoutes(window: window, clipContentScene: clipContentScene, components: components)
-            router.install(routes)
+            routes.install(ReplaceSceneWithScheduleRoute(scene: clipContentScene))
+            routes.install(ReplaceSceneWithDealersRoute(scene: clipContentScene))
             
-            let clipRouting = EurofurenceClipRouting(router: router, clipScene: clipContentScene)
+            let clipRouting = EurofurenceClipRouting(router: routes, clipScene: clipContentScene)
             self.routing = clipRouting
             
             let appClipModule = ContainerModuleWrapper(containerViewController: rootContainerViewController)

--- a/Packages/EurofurenceClipLogic/Sources/EurofurenceClipLogic/AppClipRoutes.swift
+++ b/Packages/EurofurenceClipLogic/Sources/EurofurenceClipLogic/AppClipRoutes.swift
@@ -8,16 +8,12 @@ import UIKit
 struct AppClipRoutes: RouteProvider {
     
     var window: UIWindow
-    var clipContentScene: ClipContentScene
     var components: AppClip.Components
     
     var routes: Routes {
         Routes { (router) in
             let contentWireframe = WindowContentWireframe(window: window)
             let leaveFeedback = LeaveFeedbackFromEventNavigator(router: router)
-            
-            ReplaceSceneWithScheduleRoute(scene: clipContentScene)
-            ReplaceSceneWithDealersRoute(scene: clipContentScene)
             
             EventRoute(
                 eventModuleFactory: components.eventDetailComponentFactory,

--- a/Packages/EurofurenceComponents/Sources/URLContent/EurofurenceURLRouteable.swift
+++ b/Packages/EurofurenceComponents/Sources/URLContent/EurofurenceURLRouteable.swift
@@ -7,8 +7,8 @@ import KnowledgeDetailComponent
 import KnowledgeGroupsComponent
 import RouterCore
 import ScheduleComponent
-import URLRouteable
 import URLDecoder
+import URLRouteable
 
 public class EurofurenceURLRouteable: URLRouteable {
     

--- a/Test Plans/All Tests.xctestplan
+++ b/Test Plans/All Tests.xctestplan
@@ -194,6 +194,13 @@
         "identifier" : "EurofurenceClipLogicTests",
         "name" : "EurofurenceClipLogicTests"
       }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Eurofurence.xcodeproj",
+        "identifier" : "CA7A2F112606BCB400919DA0",
+        "name" : "Eurofurence Clip UITests"
+      }
     }
   ],
   "version" : 1


### PR DESCRIPTION
Due to copy-by-value for routes leaving factories with blank route sets.