### PR TITLE
Enable time sensitive notifications for iOS 15

### DIFF
--- a/Eurofurence.xcodeproj/project.pbxproj
+++ b/Eurofurence.xcodeproj/project.pbxproj
@@ -980,7 +980,7 @@
 			attributes = {
 				DefaultBuildSystemTypeForWorkspace = Latest;
 				LastSwiftUpdateCheck = 1240;
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1320;
 				ORGANIZATIONNAME = Eurofurence;
 				TargetAttributes = {
 					78D7EEA01F17F40C005372A9 = {

--- a/Eurofurence.xcodeproj/xcshareddata/xcschemes/Eurofurence Clip.xcscheme
+++ b/Eurofurence.xcodeproj/xcshareddata/xcschemes/Eurofurence Clip.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Eurofurence.xcodeproj/xcshareddata/xcschemes/Eurofurence.xcscheme
+++ b/Eurofurence.xcodeproj/xcshareddata/xcschemes/Eurofurence.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1320"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Eurofurence.xcodeproj/xcshareddata/xcschemes/EventsWidgetExtension.xcscheme
+++ b/Eurofurence.xcodeproj/xcshareddata/xcschemes/EventsWidgetExtension.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1320"
    wasCreatedForAppExtension = "YES"
    version = "2.0">
    <BuildAction

--- a/Eurofurence.xcodeproj/xcshareddata/xcschemes/Screenshots.xcscheme
+++ b/Eurofurence.xcodeproj/xcshareddata/xcschemes/Screenshots.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Eurofurence.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Eurofurence.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/firebase/firebase-ios-sdk.git",
         "state": {
           "branch": null,
-          "revision": "08686f04881483d2bc098b2696e674c0ba135e47",
-          "version": "8.10.0"
+          "revision": "78f7087fd5d48eb7c36e299f330b6dddccd647b2",
+          "version": "8.12.1"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/google/GoogleAppMeasurement.git",
         "state": {
           "branch": null,
-          "revision": "9b2f6aca5b4685c45f9f5481f19bee8e7982c538",
-          "version": "8.9.1"
+          "revision": "6cc2991c11872510a5314bc112cc7558dd9d046a",
+          "version": "8.12.0"
         }
       },
       {
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/google/GoogleUtilities.git",
         "state": {
           "branch": null,
-          "revision": "797005ad8a1f0614063933e2fa010a5d13cb09d0",
-          "version": "7.6.0"
+          "revision": "b3bb0c5551fb3f80ca939829639ab5b093edd14f",
+          "version": "7.7.0"
         }
       },
       {
@@ -132,8 +132,8 @@
         "repositoryURL": "https://github.com/apple/swift-protobuf.git",
         "state": {
           "branch": null,
-          "revision": "7e2c5f3cbbeea68e004915e3a8961e20bd11d824",
-          "version": "1.18.0"
+          "revision": "e1499bc69b9040b29184f7f2996f7bab467c1639",
+          "version": "1.19.0"
         }
       },
       {

--- a/Eurofurence/AppNotificationDelegate.swift
+++ b/Eurofurence/AppNotificationDelegate.swift
@@ -43,7 +43,13 @@ class AppNotificationDelegate: NSObject, UNUserNotificationCenterDelegate {
     }
     
     private func requestNotificationPermissions() {
-        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound]) { (_, error) in
+        var authorizationOptions: UNAuthorizationOptions = [.alert, .badge, .sound]
+        
+        if #available(iOS 15, *) {
+            authorizationOptions.insert(.timeSensitive)
+        }
+        
+        UNUserNotificationCenter.current().requestAuthorization(options: authorizationOptions) { (_, error) in
             if let error = error {
                 print("Failed to register for notifications with error: \(error)")
             }

--- a/Eurofurence/Eurofurence.entitlements
+++ b/Eurofurence/Eurofurence.entitlements
@@ -10,6 +10,15 @@
 		<string>webcredentials:reg.eurofurence.org</string>
 		<string>activitycontinuation:app.eurofurence.org</string>
 	</array>
+	<key>com.apple.developer.nfc.readersession.formats</key>
+	<array>
+		<string>NDEF</string>
+		<string>TAG</string>
+	</array>
+	<key>com.apple.developer.siri</key>
+	<true/>
+	<key>com.apple.developer.usernotifications.time-sensitive</key>
+	<true/>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
 	<key>com.apple.security.application-groups</key>

--- a/Packages/EurofurenceApplication/.swiftpm/xcode/xcshareddata/xcschemes/EurofurenceApplication.xcscheme
+++ b/Packages/EurofurenceApplication/.swiftpm/xcode/xcshareddata/xcschemes/EurofurenceApplication.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Controllers/Notifications/Scheduling/UserNotificationsScheduler.swift
+++ b/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Controllers/Notifications/Scheduling/UserNotificationsScheduler.swift
@@ -29,7 +29,7 @@ struct UserNotificationsScheduler: NotificationScheduler {
             }
         }
     }
-
+                                
     func cancelNotification(forEvent identifier: EventIdentifier) {
         UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [identifier.rawValue])
     }

--- a/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Controllers/Notifications/Scheduling/UserNotificationsScheduler.swift
+++ b/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Controllers/Notifications/Scheduling/UserNotificationsScheduler.swift
@@ -13,6 +13,10 @@ struct UserNotificationsScheduler: NotificationScheduler {
         content.body = body
         content.userInfo = userInfo.xpcSafeDictionary
         
+        if #available(iOS 15.0, *) {
+            content.interruptionLevel = .timeSensitive
+        }
+        
         let soundName = UNNotificationSoundName(rawValue: "personal_notification.caf")
         content.sound = UNNotificationSound(named: soundName)
 

--- a/Packages/EurofurenceClipLogic/.swiftpm/xcode/xcshareddata/xcschemes/EurofurenceClipLogic.xcscheme
+++ b/Packages/EurofurenceClipLogic/.swiftpm/xcode/xcshareddata/xcschemes/EurofurenceClipLogic.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Packages/EurofurenceComponents/.swiftpm/xcode/xcshareddata/xcschemes/ComponentBaseTests.xcscheme
+++ b/Packages/EurofurenceComponents/.swiftpm/xcode/xcshareddata/xcschemes/ComponentBaseTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Packages/EurofurenceComponents/.swiftpm/xcode/xcshareddata/xcschemes/DealersJourney.xcscheme
+++ b/Packages/EurofurenceComponents/.swiftpm/xcode/xcshareddata/xcschemes/DealersJourney.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Packages/EurofurenceComponents/.swiftpm/xcode/xcshareddata/xcschemes/DealersJourneyTests.xcscheme
+++ b/Packages/EurofurenceComponents/.swiftpm/xcode/xcshareddata/xcschemes/DealersJourneyTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Packages/EurofurenceComponents/.swiftpm/xcode/xcshareddata/xcschemes/EventsJourney.xcscheme
+++ b/Packages/EurofurenceComponents/.swiftpm/xcode/xcshareddata/xcschemes/EventsJourney.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Packages/EurofurenceComponents/.swiftpm/xcode/xcshareddata/xcschemes/EventsJourneyTests.xcscheme
+++ b/Packages/EurofurenceComponents/.swiftpm/xcode/xcshareddata/xcschemes/EventsJourneyTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Packages/EurofurenceComponents/.swiftpm/xcode/xcshareddata/xcschemes/KnowledgeGroupsComponent.xcscheme
+++ b/Packages/EurofurenceComponents/.swiftpm/xcode/xcshareddata/xcschemes/KnowledgeGroupsComponent.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Packages/EurofurenceComponents/.swiftpm/xcode/xcshareddata/xcschemes/KnowledgeJourney.xcscheme
+++ b/Packages/EurofurenceComponents/.swiftpm/xcode/xcshareddata/xcschemes/KnowledgeJourney.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Packages/EurofurenceComponents/.swiftpm/xcode/xcshareddata/xcschemes/KnowledgeJourneyTests.xcscheme
+++ b/Packages/EurofurenceComponents/.swiftpm/xcode/xcshareddata/xcschemes/KnowledgeJourneyTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Packages/EurofurenceComponents/.swiftpm/xcode/xcshareddata/xcschemes/URLContent.xcscheme
+++ b/Packages/EurofurenceComponents/.swiftpm/xcode/xcshareddata/xcschemes/URLContent.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Packages/EurofurenceComponents/.swiftpm/xcode/xcshareddata/xcschemes/URLContentTests.xcscheme
+++ b/Packages/EurofurenceComponents/.swiftpm/xcode/xcshareddata/xcschemes/URLContentTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
Support the new time sensitive notification entitlement and apply it to events for user filtering. Remote notifications to be annoted as appropriate in due course