### PR TITLE
Richen Announcements entity with read state

### DIFF
--- a/EventsWidget/EventsTimelineProvider.swift
+++ b/EventsWidget/EventsTimelineProvider.swift
@@ -103,7 +103,7 @@ struct EventsTimelineProvider: IntentTimelineProvider {
     
     private func prepareModuleBridge(clock: Clock) -> EventsBridge {
         let session = EurofurenceSessionBuilder.buildingForEurofurenceApplication().with(clock).build()
-        let eventsService = session.services.events
+        let eventsService = session.repositories.events
         let bridge = EventsBridge()
         eventsService.add(bridge)
         

--- a/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application.swift
+++ b/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application.swift
@@ -78,7 +78,7 @@ public class Application {
         // TODO: Source from preferences/Firebase
         let upcomingEventReminderInterval: TimeInterval = 900
         notificationScheduleController = NotificationScheduleController(
-            eventsService: session.services.events,
+            eventsService: session.repositories.events,
             notificationScheduler: UserNotificationsScheduler(),
             hoursDateFormatter: FoundationHoursDateFormatter.shared,
             upcomingEventReminderInterval: upcomingEventReminderInterval,
@@ -91,13 +91,13 @@ public class Application {
             versionProviding: BundleAppVersionProviding.shared,
             reviewPromptAppVersionRepository: UserDefaultsReviewPromptAppVersionRepository(),
             appStateProviding: ApplicationAppStateProviding(),
-            eventsService: session.services.events
+            eventsService: session.repositories.events
         )
         
         _ = EventWidgetUpdater(
             widgetService: SystemWidgetService(), 
             refreshService: session.services.refresh, 
-            eventsService: session.services.events
+            eventsService: session.repositories.events
         )
     }
     

--- a/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Announcement Detail/View Model/Default/DefaultAnnouncementDetailViewModelFactory.swift
+++ b/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Announcement Detail/View Model/Default/DefaultAnnouncementDetailViewModelFactory.swift
@@ -4,11 +4,11 @@ import Foundation.NSAttributedString
 
 public struct DefaultAnnouncementDetailViewModelFactory: AnnouncementDetailViewModelFactory {
 
-    private let announcementsService: AnnouncementsService
+    private let announcementsService: AnnouncementsRepository
     private let markdownRenderer: MarkdownRenderer
     
     public init(
-        announcementsService: AnnouncementsService,
+        announcementsService: AnnouncementsRepository,
         markdownRenderer: MarkdownRenderer
     ) {
         self.announcementsService = announcementsService

--- a/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Announcement Detail/View Model/Default/DefaultAnnouncementDetailViewModelFactory.swift
+++ b/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Announcement Detail/View Model/Default/DefaultAnnouncementDetailViewModelFactory.swift
@@ -20,6 +20,7 @@ public struct DefaultAnnouncementDetailViewModelFactory: AnnouncementDetailViewM
         completionHandler: @escaping (AnnouncementDetailViewModel) -> Void
     ) {
         if let announcement = announcementsService.fetchAnnouncement(identifier: identifier) {
+            announcement.markRead()
             announcement.fetchAnnouncementImagePNGData { (imageData) in
                 let contents = self.markdownRenderer.render(announcement.content)
                 let viewModel = AnnouncementDetailViewModel(
@@ -27,7 +28,7 @@ public struct DefaultAnnouncementDetailViewModelFactory: AnnouncementDetailViewM
                     contents: contents,
                     imagePNGData: imageData
                 )
-                
+
                 completionHandler(viewModel)
             }
         } else {

--- a/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Announcements/View Model/DefaultAnnouncementsViewModelFactory.swift
+++ b/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Announcements/View Model/DefaultAnnouncementsViewModelFactory.swift
@@ -4,12 +4,12 @@ import Foundation
 
 public struct DefaultAnnouncementsViewModelFactory: AnnouncementsViewModelFactory {
 
-    var announcementsService: AnnouncementsService
+    var announcementsService: AnnouncementsRepository
     var announcementDateFormatter: AnnouncementDateFormatter
 	var markdownRenderer: MarkdownRenderer
     
     public init(
-        announcementsService: AnnouncementsService,
+        announcementsService: AnnouncementsRepository,
         announcementDateFormatter: AnnouncementDateFormatter,
         markdownRenderer: MarkdownRenderer
     ) {
@@ -26,14 +26,14 @@ public struct DefaultAnnouncementsViewModelFactory: AnnouncementsViewModelFactor
         ))
     }
 
-    private class ViewModel: AnnouncementsListViewModel, AnnouncementsServiceObserver {
+    private class ViewModel: AnnouncementsListViewModel, AnnouncementsRepositoryObserver {
 
         private let announcementDateFormatter: AnnouncementDateFormatter
 		private let markdownRenderer: MarkdownRenderer
         private var announcements = [Announcement]()
         private var readAnnouncements = [AnnouncementIdentifier]()
 
-        init(announcementsService: AnnouncementsService,
+        init(announcementsService: AnnouncementsRepository,
              announcementDateFormatter: AnnouncementDateFormatter,
              markdownRenderer: MarkdownRenderer) {
             self.announcementDateFormatter = announcementDateFormatter

--- a/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/ComponentRegistry.swift
+++ b/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/ComponentRegistry.swift
@@ -53,11 +53,11 @@ struct ComponentRegistry {
         ).build()
         
         let newsViewModelProducer = DefaultNewsViewModelProducer(
-            announcementsService: services.announcements,
+            announcementsService: repositories.announcements,
             authenticationService: services.authentication,
             privateMessagesService: services.privateMessages,
             daysUntilConventionService: services.conventionCountdown,
-            eventsService: services.events,
+            eventsService: repositories.events,
             relativeTimeIntervalCountdownFormatter: FoundationRelativeTimeIntervalCountdownFormatter.shared,
             hoursDateFormatter: FoundationHoursDateFormatter.shared,
             clock: SystemClock.shared,
@@ -68,6 +68,7 @@ struct ComponentRegistry {
         
         if dependencies.isCompositionalNewsComponentEnabled {
             newsComponentFactory = CompositionalNewsComponentDefaultWidgetsBuilder(
+                repositories: repositories,
                 services: services
             ).buildNewsComponent()
         } else {
@@ -77,7 +78,7 @@ struct ComponentRegistry {
         }
         
         let scheduleViewModelFactory = DefaultScheduleViewModelFactory(
-            eventsService: services.events,
+            eventsService: repositories.events,
             hoursDateFormatter: FoundationHoursDateFormatter.shared,
             shortFormDateFormatter: FoundationShortFormDateFormatter.shared,
             shortFormDayAndTimeFormatter: FoundationShortFormDayAndTimeFormatter.shared,
@@ -171,7 +172,7 @@ struct ComponentRegistry {
         ).build()
         
         let announcementsViewModelFactory = DefaultAnnouncementsViewModelFactory(
-            announcementsService: services.announcements,
+            announcementsService: repositories.announcements,
             announcementDateFormatter: FoundationAnnouncementDateFormatter.shared,
             markdownRenderer: subtleMarkdownRenderer
         )
@@ -181,7 +182,7 @@ struct ComponentRegistry {
         ).build()
         
         let announcementDetailViewModelFactory = DefaultAnnouncementDetailViewModelFactory(
-            announcementsService: services.announcements,
+            announcementsService: repositories.announcements,
             markdownRenderer: defaultMarkdownRenderer
         )
         
@@ -190,14 +191,14 @@ struct ComponentRegistry {
         ).build()
         
         let eventInteractionRecorder = SystemEventInteractionsRecorder(
-            eventsService: services.events,
+            eventsService: repositories.events,
             eventIntentDonor: dependencies.viewEventIntentDonor,
             activityFactory: activityFactory
         )
         
         let eventDetailViewModelFactory = DefaultEventDetailViewModelFactory(
             dateRangeFormatter: FoundationDateRangeFormatter.shared,
-            eventsService: services.events,
+            eventsService: repositories.events,
             markdownRenderer: DefaultDownMarkdownRenderer(),
             shareService: shareService
         )
@@ -208,7 +209,7 @@ struct ComponentRegistry {
         ).build()
         
         let eventFeedbackPresenterFactory = EventFeedbackPresenterFactoryImpl(
-            eventService: services.events,
+            eventService: repositories.events,
             dayOfWeekFormatter: FoundationDayOfWeekFormatter.shared,
             startTimeFormatter: FoundationHoursDateFormatter.shared,
             endTimeFormatter: FoundationHoursDateFormatter.shared,

--- a/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/News/Compositional/Component/CompositionalNewsComponentDefaultWidgetsBuilder.swift
+++ b/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/News/Compositional/Component/CompositionalNewsComponentDefaultWidgetsBuilder.swift
@@ -3,6 +3,7 @@ import EurofurenceModel
 
 struct CompositionalNewsComponentDefaultWidgetsBuilder {
     
+    let repositories: Repositories
     let services: Services
     private let builder = CompositionalNewsComponentBuilder()
     
@@ -57,7 +58,7 @@ struct CompositionalNewsComponentDefaultWidgetsBuilder {
         _ specification: S
     ) -> some EventsWidgetDataSource where S.Element == Event {
         FilteredScheduleWidgetDataSource(
-            repository: services.events,
+            repository: repositories.events,
             specification: specification
         )
     }

--- a/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/News/Legacy/View Model/DefaultNewsViewModelProducer.swift
+++ b/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/News/Legacy/View Model/DefaultNewsViewModelProducer.swift
@@ -3,7 +3,7 @@ import EurofurenceModel
 import Foundation
 
 public class DefaultNewsViewModelProducer: NewsViewModelProducer,
-                                           AnnouncementsServiceObserver,
+                                           AnnouncementsRepositoryObserver,
                                            AuthenticationStateObserver,
                                            PrivateMessagesObserver,
                                            ConventionCountdownServiceObserver,
@@ -33,7 +33,7 @@ public class DefaultNewsViewModelProducer: NewsViewModelProducer,
     // MARK: Initialization
 
     public init(
-        announcementsService: AnnouncementsService,
+        announcementsService: AnnouncementsRepository,
         authenticationService: AuthenticationService,
         privateMessagesService: PrivateMessagesService,
         daysUntilConventionService: ConventionCountdownService,
@@ -95,7 +95,7 @@ public class DefaultNewsViewModelProducer: NewsViewModelProducer,
         refreshService.refreshLocalStore { (_) in }
     }
 
-    // MARK: AnnouncementsServiceObserver
+    // MARK: AnnouncementsRepositoryObserver
 
     public func announcementsServiceDidChangeAnnouncements(_ announcements: [Announcement]) {
         self.announcements = Array(announcements.prefix(3))

--- a/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/Announcement Detail/Presenter Tests/AnnouncementDetailPresenterTestBuilder.swift
+++ b/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/Announcement Detail/Presenter Tests/AnnouncementDetailPresenterTestBuilder.swift
@@ -14,7 +14,7 @@ class AnnouncementDetailPresenterTestBuilder {
 
     func build() -> Context {
         let sceneFactory = StubAnnouncementDetailSceneFactory()
-        let announcement: StubAnnouncement = .random
+        let announcement: FakeAnnouncement = .random
         let announcementDetailViewModelFactory = StubAnnouncementDetailViewModelFactory(for: announcement.identifier)
         let module = AnnouncementDetailComponentBuilder(
             announcementDetailViewModelFactory: announcementDetailViewModelFactory

--- a/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/Announcement Detail/View Model Tests/AnnouncementDetailViewModelFactoryTestBuilder.swift
+++ b/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/Announcement Detail/View Model Tests/AnnouncementDetailViewModelFactoryTestBuilder.swift
@@ -10,7 +10,7 @@ class AnnouncementDetailViewModelFactoryTestBuilder {
         var viewModelFactory: AnnouncementDetailViewModelFactory
         var markdownRenderer: StubMarkdownRenderer
         var announcement: StubAnnouncement
-        var announcementsService: FakeAnnouncementsService
+        var announcementsService: FakeAnnouncementsRepository
     }
     
     private var imagePNGData: Data?
@@ -24,7 +24,7 @@ class AnnouncementDetailViewModelFactoryTestBuilder {
         let announcement = StubAnnouncement.random
         announcement.identifier = identifier
         announcement.imagePNGData = imagePNGData
-        let announcementsService = FakeAnnouncementsService(announcements: [announcement])
+        let announcementsService = FakeAnnouncementsRepository(announcements: [announcement])
         let markdownRenderer = StubMarkdownRenderer()
         let viewModelFactory = DefaultAnnouncementDetailViewModelFactory(announcementsService: announcementsService,
                                                              markdownRenderer: markdownRenderer)
@@ -36,7 +36,7 @@ class AnnouncementDetailViewModelFactoryTestBuilder {
     }
     
     func buildForMissingAnnouncement() -> Context {
-        let announcementsService = FakeAnnouncementsService(announcements: [])
+        let announcementsService = FakeAnnouncementsRepository(announcements: [])
         let markdownRenderer = StubMarkdownRenderer()
         let viewModelFactory = DefaultAnnouncementDetailViewModelFactory(announcementsService: announcementsService,
                                                              markdownRenderer: markdownRenderer)

--- a/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/Announcement Detail/View Model Tests/AnnouncementDetailViewModelFactoryTestBuilder.swift
+++ b/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/Announcement Detail/View Model Tests/AnnouncementDetailViewModelFactoryTestBuilder.swift
@@ -9,7 +9,7 @@ class AnnouncementDetailViewModelFactoryTestBuilder {
     struct Context {
         var viewModelFactory: AnnouncementDetailViewModelFactory
         var markdownRenderer: StubMarkdownRenderer
-        var announcement: StubAnnouncement
+        var announcement: FakeAnnouncement
         var announcementsService: FakeAnnouncementsRepository
     }
     
@@ -21,7 +21,7 @@ class AnnouncementDetailViewModelFactoryTestBuilder {
     }
 
     func build(for identifier: AnnouncementIdentifier = .random) -> Context {
-        let announcement = StubAnnouncement.random
+        let announcement = FakeAnnouncement.random
         announcement.identifier = identifier
         announcement.imagePNGData = imagePNGData
         let announcementsService = FakeAnnouncementsRepository(announcements: [announcement])

--- a/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/Announcement Detail/View Model Tests/DefaultAnnouncementDetailViewModelFactoryShould.swift
+++ b/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/Announcement Detail/View Model Tests/DefaultAnnouncementDetailViewModelFactoryShould.swift
@@ -27,5 +27,12 @@ class DefaultAnnouncementDetailViewModelFactoryShould: XCTestCase {
         XCTAssertEqual(String.invalidAnnouncementAlertTitle, viewModel?.heading)
         XCTAssertEqual(expectedContents, viewModel?.contents)
     }
+    
+    func testMarkAnnouncementAsRead() {
+        let context = AnnouncementDetailViewModelFactoryTestBuilder().build()
+        let viewModel = context.makeViewModel()
+        
+        XCTAssertEqual(.read, context.announcement.readStatus)
+    }
 
 }

--- a/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/Announcements/View Model Tests/WhenPreparingViewModel_AnnouncementsViewModelFactoryShould.swift
+++ b/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/Announcements/View Model Tests/WhenPreparingViewModel_AnnouncementsViewModelFactoryShould.swift
@@ -6,7 +6,7 @@ import XCTEurofurenceModel
 
 class WhenPreparingViewModel_AnnouncementsViewModelFactoryShould: XCTestCase {
 
-    var announcementsService: FakeAnnouncementsService!
+    var announcementsService: FakeAnnouncementsRepository!
     var viewModelFactory: DefaultAnnouncementsViewModelFactory!
     var announcementDateFormatter: FakeAnnouncementDateFormatter!
 	var markdownRenderer: StubMarkdownRenderer!
@@ -18,7 +18,7 @@ class WhenPreparingViewModel_AnnouncementsViewModelFactoryShould: XCTestCase {
 
         announcements = [StubAnnouncement].random
         announcement = announcements.randomElement()
-        announcementsService = FakeAnnouncementsService(announcements: announcements)
+        announcementsService = FakeAnnouncementsRepository(announcements: announcements)
         announcementDateFormatter = FakeAnnouncementDateFormatter()
 		markdownRenderer = StubMarkdownRenderer()
 		viewModelFactory = DefaultAnnouncementsViewModelFactory(

--- a/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/Announcements/View Model Tests/WhenPreparingViewModel_AnnouncementsViewModelFactoryShould.swift
+++ b/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/Announcements/View Model Tests/WhenPreparingViewModel_AnnouncementsViewModelFactoryShould.swift
@@ -16,7 +16,7 @@ class WhenPreparingViewModel_AnnouncementsViewModelFactoryShould: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        announcements = [StubAnnouncement].random
+        announcements = [FakeAnnouncement].random
         announcement = announcements.randomElement()
         announcementsService = FakeAnnouncementsRepository(announcements: announcements)
         announcementDateFormatter = FakeAnnouncementDateFormatter()
@@ -55,7 +55,7 @@ class WhenPreparingViewModel_AnnouncementsViewModelFactoryShould: XCTestCase {
     func testUpdateTheAvailableViewModelsWhenAnnouncementsChange() {
         var viewModel: AnnouncementsListViewModel?
         viewModelFactory.makeViewModel { viewModel = $0 }
-        let newAnnouncements = [StubAnnouncement].random(upperLimit: announcements.count)
+        let newAnnouncements = [FakeAnnouncement].random(upperLimit: announcements.count)
         let delegate = CapturingAnnouncementsListViewModelDelegate()
         viewModel?.setDelegate(delegate)
         announcementsService.updateAnnouncements(newAnnouncements)

--- a/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/News/Legacy/Presenter Tests/WhenBindingAnnouncement_NewsPresenterShould.swift
+++ b/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/News/Legacy/Presenter Tests/WhenBindingAnnouncement_NewsPresenterShould.swift
@@ -42,7 +42,7 @@ class WhenBindingAnnouncement_NewsPresenterShould: XCTestCase {
     }
 
     func testTellTheDelegateAnnouncementSelectedWhenSceneSelectsComponentAtIndexPath() {
-        let announcement = StubAnnouncement.random
+        let announcement = FakeAnnouncement.random
         viewModel.stub(.announcement(announcement.identifier), at: indexPath)
         context.selectComponent(at: indexPath)
 
@@ -50,7 +50,7 @@ class WhenBindingAnnouncement_NewsPresenterShould: XCTestCase {
     }
 
     func testNotTellTheDelegateToShowPrivateMessagesWhenSelectingAnnouncement() {
-        let announcement = StubAnnouncement.random
+        let announcement = FakeAnnouncement.random
         viewModel.stub(.announcement(announcement.identifier), at: indexPath)
         context.selectComponent(at: indexPath)
 

--- a/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/News/Legacy/View Model Tests/Before Convention/WhenLoggedInBeforeConvention_NewsViewModelProducerShould.swift
+++ b/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/News/Legacy/View Model Tests/Before Convention/WhenLoggedInBeforeConvention_NewsViewModelProducerShould.swift
@@ -8,7 +8,7 @@ class WhenLoggedInBeforeConvention_NewsViewModelProducerShould: XCTestCase {
     func testProduceViewModelWithMessagesPrompt_DaysUntilConvention_AndAnnouncements() throws {
         let context = DefaultNewsViewModelProducerTestBuilder()
             .with(FakeAuthenticationService.loggedInService())
-            .with(FakeAnnouncementsService(announcements: [StubAnnouncement].random))
+            .with(FakeAnnouncementsRepository(announcements: [StubAnnouncement].random))
             .build()
         context.subscribeViewModelUpdates()
 

--- a/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/News/Legacy/View Model Tests/Before Convention/WhenLoggedInBeforeConvention_NewsViewModelProducerShould.swift
+++ b/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/News/Legacy/View Model Tests/Before Convention/WhenLoggedInBeforeConvention_NewsViewModelProducerShould.swift
@@ -8,7 +8,7 @@ class WhenLoggedInBeforeConvention_NewsViewModelProducerShould: XCTestCase {
     func testProduceViewModelWithMessagesPrompt_DaysUntilConvention_AndAnnouncements() throws {
         let context = DefaultNewsViewModelProducerTestBuilder()
             .with(FakeAuthenticationService.loggedInService())
-            .with(FakeAnnouncementsRepository(announcements: [StubAnnouncement].random))
+            .with(FakeAnnouncementsRepository(announcements: [FakeAnnouncement].random))
             .build()
         context.subscribeViewModelUpdates()
 

--- a/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/News/Legacy/View Model Tests/Before Convention/WhenLoggedInBeforeConvention_ThenLogOut_NewsViewModelProducerShould.swift
+++ b/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/News/Legacy/View Model Tests/Before Convention/WhenLoggedInBeforeConvention_ThenLogOut_NewsViewModelProducerShould.swift
@@ -8,7 +8,7 @@ class WhenLoggedInBeforeConvention_ThenLogOut_NewsViewModelProducerShould: XCTes
     func testUpdateTheDelegateWithLoggedOutUserWidget() throws {
         let authenticationService = FakeAuthenticationService.loggedInService()
         let context = DefaultNewsViewModelProducerTestBuilder()
-            .with(FakeAnnouncementsRepository(announcements: [StubAnnouncement].random))
+            .with(FakeAnnouncementsRepository(announcements: [FakeAnnouncement].random))
             .with(authenticationService)
             .build()
         context.subscribeViewModelUpdates()

--- a/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/News/Legacy/View Model Tests/Before Convention/WhenLoggedInBeforeConvention_ThenLogOut_NewsViewModelProducerShould.swift
+++ b/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/News/Legacy/View Model Tests/Before Convention/WhenLoggedInBeforeConvention_ThenLogOut_NewsViewModelProducerShould.swift
@@ -8,7 +8,7 @@ class WhenLoggedInBeforeConvention_ThenLogOut_NewsViewModelProducerShould: XCTes
     func testUpdateTheDelegateWithLoggedOutUserWidget() throws {
         let authenticationService = FakeAuthenticationService.loggedInService()
         let context = DefaultNewsViewModelProducerTestBuilder()
-            .with(FakeAnnouncementsService(announcements: [StubAnnouncement].random))
+            .with(FakeAnnouncementsRepository(announcements: [StubAnnouncement].random))
             .with(authenticationService)
             .build()
         context.subscribeViewModelUpdates()

--- a/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/News/Legacy/View Model Tests/Before Convention/WhenLoggedInBeforeConvention_ThenPersonalMessageIsReceived_NewsViewModelProducerShould.swift
+++ b/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/News/Legacy/View Model Tests/Before Convention/WhenLoggedInBeforeConvention_ThenPersonalMessageIsReceived_NewsViewModelProducerShould.swift
@@ -9,7 +9,7 @@ class WhenLoggedInBeforeConvention_ThenPersonalMessageIsReceived_NewsViewModelPr
         let privateMessagesService = CapturingPrivateMessagesService()
         let context = DefaultNewsViewModelProducerTestBuilder()
             .with(FakeAuthenticationService.loggedInService())
-            .with(FakeAnnouncementsService(announcements: [StubAnnouncement].random))
+            .with(FakeAnnouncementsRepository(announcements: [StubAnnouncement].random))
             .with(privateMessagesService)
             .build()
         context.subscribeViewModelUpdates()

--- a/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/News/Legacy/View Model Tests/Before Convention/WhenLoggedInBeforeConvention_ThenPersonalMessageIsReceived_NewsViewModelProducerShould.swift
+++ b/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/News/Legacy/View Model Tests/Before Convention/WhenLoggedInBeforeConvention_ThenPersonalMessageIsReceived_NewsViewModelProducerShould.swift
@@ -9,7 +9,7 @@ class WhenLoggedInBeforeConvention_ThenPersonalMessageIsReceived_NewsViewModelPr
         let privateMessagesService = CapturingPrivateMessagesService()
         let context = DefaultNewsViewModelProducerTestBuilder()
             .with(FakeAuthenticationService.loggedInService())
-            .with(FakeAnnouncementsRepository(announcements: [StubAnnouncement].random))
+            .with(FakeAnnouncementsRepository(announcements: [FakeAnnouncement].random))
             .with(privateMessagesService)
             .build()
         context.subscribeViewModelUpdates()

--- a/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/News/Legacy/View Model Tests/Before Convention/WhenLoggedOutBeforeConvention_NewsViewModelProducerShould.swift
+++ b/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/News/Legacy/View Model Tests/Before Convention/WhenLoggedOutBeforeConvention_NewsViewModelProducerShould.swift
@@ -11,7 +11,7 @@ class WhenLoggedOutBeforeConvention_NewsViewModelProducerShould: XCTestCase {
         super.setUp()
 
         context = DefaultNewsViewModelProducerTestBuilder()
-            .with(FakeAnnouncementsRepository(announcements: [StubAnnouncement].random))
+            .with(FakeAnnouncementsRepository(announcements: [FakeAnnouncement].random))
             .with(FakeAuthenticationService.loggedOutService())
             .build()
         context.subscribeViewModelUpdates()

--- a/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/News/Legacy/View Model Tests/Before Convention/WhenLoggedOutBeforeConvention_NewsViewModelProducerShould.swift
+++ b/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/News/Legacy/View Model Tests/Before Convention/WhenLoggedOutBeforeConvention_NewsViewModelProducerShould.swift
@@ -11,7 +11,7 @@ class WhenLoggedOutBeforeConvention_NewsViewModelProducerShould: XCTestCase {
         super.setUp()
 
         context = DefaultNewsViewModelProducerTestBuilder()
-            .with(FakeAnnouncementsService(announcements: [StubAnnouncement].random))
+            .with(FakeAnnouncementsRepository(announcements: [StubAnnouncement].random))
             .with(FakeAuthenticationService.loggedOutService())
             .build()
         context.subscribeViewModelUpdates()

--- a/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/News/Legacy/View Model Tests/Before Convention/WhenLoggedOutBeforeConvention_ThenLogIn_NewsViewModelProducerShould.swift
+++ b/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/News/Legacy/View Model Tests/Before Convention/WhenLoggedOutBeforeConvention_ThenLogIn_NewsViewModelProducerShould.swift
@@ -8,7 +8,7 @@ class WhenLoggedOutBeforeConvention_ThenLogIn_NewsViewModelProducerShould: XCTes
     func testUpdateTheDelegateWithLoggedInUserWidget() throws {
         let authenticationService = FakeAuthenticationService.loggedOutService()
         let context = DefaultNewsViewModelProducerTestBuilder()
-            .with(FakeAnnouncementsService(announcements: [StubAnnouncement].random))
+            .with(FakeAnnouncementsRepository(announcements: [StubAnnouncement].random))
             .with(authenticationService)
             .build()
         context.subscribeViewModelUpdates()

--- a/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/News/Legacy/View Model Tests/Before Convention/WhenLoggedOutBeforeConvention_ThenLogIn_NewsViewModelProducerShould.swift
+++ b/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/News/Legacy/View Model Tests/Before Convention/WhenLoggedOutBeforeConvention_ThenLogIn_NewsViewModelProducerShould.swift
@@ -8,7 +8,7 @@ class WhenLoggedOutBeforeConvention_ThenLogIn_NewsViewModelProducerShould: XCTes
     func testUpdateTheDelegateWithLoggedInUserWidget() throws {
         let authenticationService = FakeAuthenticationService.loggedOutService()
         let context = DefaultNewsViewModelProducerTestBuilder()
-            .with(FakeAnnouncementsRepository(announcements: [StubAnnouncement].random))
+            .with(FakeAnnouncementsRepository(announcements: [FakeAnnouncement].random))
             .with(authenticationService)
             .build()
         context.subscribeViewModelUpdates()

--- a/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/News/Legacy/View Model Tests/DefaultNewsViewModelProducerTestBuilder.swift
+++ b/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/News/Legacy/View Model Tests/DefaultNewsViewModelProducerTestBuilder.swift
@@ -12,7 +12,7 @@ class DefaultNewsViewModelProducerTestBuilder {
         var relativeTimeFormatter: FakeRelativeTimeIntervalCountdownFormatter
         var hoursDateFormatter: FakeHoursDateFormatter
         var authenticationService: FakeAuthenticationService
-        var announcementsService: FakeAnnouncementsService
+        var announcementsService: FakeAnnouncementsRepository
         var privateMessagesService: CapturingPrivateMessagesService
         var daysUntilConventionService: StubConventionCountdownService
         var eventsService: FakeScheduleRepository
@@ -22,14 +22,14 @@ class DefaultNewsViewModelProducerTestBuilder {
 		var markdownRenderer: StubMarkdownRenderer
     }
 
-    private var announcementsService: FakeAnnouncementsService
+    private var announcementsService: FakeAnnouncementsRepository
     private var authenticationService: FakeAuthenticationService
     private var privateMessagesService: CapturingPrivateMessagesService
     private var daysUntilConventionService: StubConventionCountdownService
     private var eventsService: FakeScheduleRepository
 
     init() {
-        announcementsService = FakeAnnouncementsService(announcements: [])
+        announcementsService = FakeAnnouncementsRepository(announcements: [])
         authenticationService = FakeAuthenticationService(authState: .loggedOut)
         privateMessagesService = CapturingPrivateMessagesService()
         daysUntilConventionService = StubConventionCountdownService()
@@ -37,7 +37,7 @@ class DefaultNewsViewModelProducerTestBuilder {
     }
 
     @discardableResult
-    func with(_ announcementsService: FakeAnnouncementsService) -> DefaultNewsViewModelProducerTestBuilder {
+    func with(_ announcementsService: FakeAnnouncementsRepository) -> DefaultNewsViewModelProducerTestBuilder {
         self.announcementsService = announcementsService
         return self
     }

--- a/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/News/Legacy/View Model Tests/During Convention/WhenLoggedOutDuringConvention_NewsViewModelProducerShould.swift
+++ b/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/News/Legacy/View Model Tests/During Convention/WhenLoggedOutDuringConvention_NewsViewModelProducerShould.swift
@@ -15,7 +15,7 @@ class WhenLoggedOutDuringConvention_NewsViewModelProducerShould: XCTestCase {
         eventsService.simulateDayChanged(to: .random)
         let context = DefaultNewsViewModelProducerTestBuilder()
             .with(FakeAuthenticationService.loggedOutService())
-            .with(FakeAnnouncementsService(announcements: [StubAnnouncement].random))
+            .with(FakeAnnouncementsRepository(announcements: [StubAnnouncement].random))
             .with(StubConventionCountdownService(countdownState: .countdownElapsed))
             .with(eventsService)
             .build()
@@ -37,7 +37,7 @@ class WhenLoggedOutDuringConvention_NewsViewModelProducerShould: XCTestCase {
         eventsService.upcomingEvents = upcomingEvents
         let context = DefaultNewsViewModelProducerTestBuilder()
             .with(FakeAuthenticationService.loggedOutService())
-            .with(FakeAnnouncementsService(announcements: [StubAnnouncement].random))
+            .with(FakeAnnouncementsRepository(announcements: [StubAnnouncement].random))
             .with(StubConventionCountdownService(countdownState: .countdownElapsed))
             .with(eventsService)
             .build()

--- a/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/News/Legacy/View Model Tests/During Convention/WhenLoggedOutDuringConvention_NewsViewModelProducerShould.swift
+++ b/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/News/Legacy/View Model Tests/During Convention/WhenLoggedOutDuringConvention_NewsViewModelProducerShould.swift
@@ -15,7 +15,7 @@ class WhenLoggedOutDuringConvention_NewsViewModelProducerShould: XCTestCase {
         eventsService.simulateDayChanged(to: .random)
         let context = DefaultNewsViewModelProducerTestBuilder()
             .with(FakeAuthenticationService.loggedOutService())
-            .with(FakeAnnouncementsRepository(announcements: [StubAnnouncement].random))
+            .with(FakeAnnouncementsRepository(announcements: [FakeAnnouncement].random))
             .with(StubConventionCountdownService(countdownState: .countdownElapsed))
             .with(eventsService)
             .build()
@@ -37,7 +37,7 @@ class WhenLoggedOutDuringConvention_NewsViewModelProducerShould: XCTestCase {
         eventsService.upcomingEvents = upcomingEvents
         let context = DefaultNewsViewModelProducerTestBuilder()
             .with(FakeAuthenticationService.loggedOutService())
-            .with(FakeAnnouncementsRepository(announcements: [StubAnnouncement].random))
+            .with(FakeAnnouncementsRepository(announcements: [FakeAnnouncement].random))
             .with(StubConventionCountdownService(countdownState: .countdownElapsed))
             .with(eventsService)
             .build()

--- a/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/News/Legacy/View Model Tests/During Convention/WhenLoggedOutDuringConvention_WithNoRunningEvents_NewsViewModelProducerShould.swift
+++ b/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/News/Legacy/View Model Tests/During Convention/WhenLoggedOutDuringConvention_WithNoRunningEvents_NewsViewModelProducerShould.swift
@@ -14,7 +14,7 @@ class WhenLoggedOutDuringConvention_WithNoRunningEvents_NewsViewModelProducerSho
         eventsService.simulateDayChanged(to: .random)
         let context = DefaultNewsViewModelProducerTestBuilder()
             .with(FakeAuthenticationService.loggedOutService())
-            .with(FakeAnnouncementsRepository(announcements: [StubAnnouncement].random))
+            .with(FakeAnnouncementsRepository(announcements: [FakeAnnouncement].random))
             .with(StubConventionCountdownService(countdownState: .countdownElapsed))
             .with(eventsService)
             .build()

--- a/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/News/Legacy/View Model Tests/During Convention/WhenLoggedOutDuringConvention_WithNoRunningEvents_NewsViewModelProducerShould.swift
+++ b/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/News/Legacy/View Model Tests/During Convention/WhenLoggedOutDuringConvention_WithNoRunningEvents_NewsViewModelProducerShould.swift
@@ -14,7 +14,7 @@ class WhenLoggedOutDuringConvention_WithNoRunningEvents_NewsViewModelProducerSho
         eventsService.simulateDayChanged(to: .random)
         let context = DefaultNewsViewModelProducerTestBuilder()
             .with(FakeAuthenticationService.loggedOutService())
-            .with(FakeAnnouncementsService(announcements: [StubAnnouncement].random))
+            .with(FakeAnnouncementsRepository(announcements: [StubAnnouncement].random))
             .with(StubConventionCountdownService(countdownState: .countdownElapsed))
             .with(eventsService)
             .build()

--- a/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/News/Legacy/View Model Tests/During Convention/WhenLoggedOutDuringConvention_WithNoUpcomingEvents_NewsViewModelProducerShould.swift
+++ b/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/News/Legacy/View Model Tests/During Convention/WhenLoggedOutDuringConvention_WithNoUpcomingEvents_NewsViewModelProducerShould.swift
@@ -14,7 +14,7 @@ class WhenLoggedOutDuringConvention_WithNoUpcomingEvents_NewsViewModelProducerSh
         eventsService.simulateDayChanged(to: .random)
         let context = DefaultNewsViewModelProducerTestBuilder()
             .with(FakeAuthenticationService.loggedOutService())
-            .with(FakeAnnouncementsRepository(announcements: [StubAnnouncement].random))
+            .with(FakeAnnouncementsRepository(announcements: [FakeAnnouncement].random))
             .with(StubConventionCountdownService(countdownState: .countdownElapsed))
             .with(eventsService)
             .build()

--- a/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/News/Legacy/View Model Tests/During Convention/WhenLoggedOutDuringConvention_WithNoUpcomingEvents_NewsViewModelProducerShould.swift
+++ b/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/News/Legacy/View Model Tests/During Convention/WhenLoggedOutDuringConvention_WithNoUpcomingEvents_NewsViewModelProducerShould.swift
@@ -14,7 +14,7 @@ class WhenLoggedOutDuringConvention_WithNoUpcomingEvents_NewsViewModelProducerSh
         eventsService.simulateDayChanged(to: .random)
         let context = DefaultNewsViewModelProducerTestBuilder()
             .with(FakeAuthenticationService.loggedOutService())
-            .with(FakeAnnouncementsService(announcements: [StubAnnouncement].random))
+            .with(FakeAnnouncementsRepository(announcements: [StubAnnouncement].random))
             .with(StubConventionCountdownService(countdownState: .countdownElapsed))
             .with(eventsService)
             .build()

--- a/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/News/Legacy/View Model Tests/WhenPreparingAnnouncementViewModel_ForReadAnnouncement_NewsViewModelProducerShould.swift
+++ b/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/News/Legacy/View Model Tests/WhenPreparingAnnouncementViewModel_ForReadAnnouncement_NewsViewModelProducerShould.swift
@@ -7,7 +7,7 @@ class WhenPreparingAnnouncementViewModel_ForReadAnnouncement_NewsViewModelProduc
 
     func testPrepareViewModelWithReadStatus() throws {
         let announcement = StubAnnouncement.random
-        let announcementsService = FakeAnnouncementsService(announcements: [announcement],
+        let announcementsService = FakeAnnouncementsRepository(announcements: [announcement],
                                                             stubbedReadAnnouncements: [announcement.identifier])
         let context = DefaultNewsViewModelProducerTestBuilder().with(announcementsService).build()
         context.subscribeViewModelUpdates()

--- a/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/News/Legacy/View Model Tests/WhenPreparingAnnouncementViewModel_ForReadAnnouncement_NewsViewModelProducerShould.swift
+++ b/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/News/Legacy/View Model Tests/WhenPreparingAnnouncementViewModel_ForReadAnnouncement_NewsViewModelProducerShould.swift
@@ -6,7 +6,7 @@ import XCTEurofurenceModel
 class WhenPreparingAnnouncementViewModel_ForReadAnnouncement_NewsViewModelProducerShould: XCTestCase {
 
     func testPrepareViewModelWithReadStatus() throws {
-        let announcement = StubAnnouncement.random
+        let announcement = FakeAnnouncement.random
         let announcementsService = FakeAnnouncementsRepository(announcements: [announcement],
                                                             stubbedReadAnnouncements: [announcement.identifier])
         let context = DefaultNewsViewModelProducerTestBuilder().with(announcementsService).build()

--- a/Packages/EurofurenceClipLogic/Sources/EurofurenceClipLogic/AppClip+Components.swift
+++ b/Packages/EurofurenceClipLogic/Sources/EurofurenceClipLogic/AppClip+Components.swift
@@ -39,7 +39,7 @@ extension AppClip {
             ).build()
             
             let scheduleViewModelFactory = DefaultScheduleViewModelFactory(
-                eventsService: services.events,
+                eventsService: repositories.events,
                 hoursDateFormatter: FoundationHoursDateFormatter.shared,
                 shortFormDateFormatter: FoundationShortFormDateFormatter.shared,
                 shortFormDayAndTimeFormatter: FoundationShortFormDayAndTimeFormatter.shared,
@@ -52,14 +52,14 @@ extension AppClip {
             ).build()
             
             let eventInteractionRecorder = SystemEventInteractionsRecorder(
-                eventsService: services.events,
+                eventsService: repositories.events,
                 eventIntentDonor: dependencies.eventIntentDonor,
                 activityFactory: activityFactory
             )
             
             let eventDetailViewModelFactory = DefaultEventDetailViewModelFactory(
                 dateRangeFormatter: FoundationDateRangeFormatter.shared,
-                eventsService: services.events,
+                eventsService: repositories.events,
                 markdownRenderer: DefaultDownMarkdownRenderer(),
                 shareService: shareService
             )

--- a/Packages/EurofurenceModel/Sources/EurofurenceModel/Private/ConcreteSession.swift
+++ b/Packages/EurofurenceModel/Sources/EurofurenceModel/Private/ConcreteSession.swift
@@ -12,7 +12,7 @@ class ConcreteSession: EurofurenceSession {
     private let privateMessagesService: ConcretePrivateMessagesService
     private let conventionCountdownService: ConcreteConventionCountdownService
     
-    private let announcementsService: ConcreteAnnouncementsService
+    private let announcementsService: ConcreteAnnouncementsRepository
     private let knowledgeService: ConcreteKnowledgeService
     private let eventsService: ConcreteScheduleRepository
     private let dealersService: ConcreteDealersService
@@ -79,7 +79,7 @@ class ConcreteSession: EurofurenceSession {
             clock: clock
         )
         
-        announcementsService = ConcreteAnnouncementsService(
+        announcementsService = ConcreteAnnouncementsRepository(
             eventBus: eventBus,
             dataStore: dataStore,
             imageRepository: imageRepository

--- a/Packages/EurofurenceModel/Sources/EurofurenceModel/Private/ConcreteSession.swift
+++ b/Packages/EurofurenceModel/Sources/EurofurenceModel/Private/ConcreteSession.swift
@@ -12,9 +12,9 @@ class ConcreteSession: EurofurenceSession {
     private let privateMessagesService: ConcretePrivateMessagesService
     private let conventionCountdownService: ConcreteConventionCountdownService
     
-    private let announcementsService: ConcreteAnnouncementsRepository
+    private let announcementsRepository: ConcreteAnnouncementsRepository
     private let knowledgeService: ConcreteKnowledgeService
-    private let eventsService: ConcreteScheduleRepository
+    private let scheduleRepository: ConcreteScheduleRepository
     private let dealersService: ConcreteDealersService
     private let significantTimeObserver: SignificantTimeObserver
     private let collectThemAllService: ConcreteCollectThemAllService
@@ -79,7 +79,7 @@ class ConcreteSession: EurofurenceSession {
             clock: clock
         )
         
-        announcementsService = ConcreteAnnouncementsRepository(
+        announcementsRepository = ConcreteAnnouncementsRepository(
             eventBus: eventBus,
             dataStore: dataStore,
             imageRepository: imageRepository
@@ -97,7 +97,7 @@ class ConcreteSession: EurofurenceSession {
             imageRepository: imageRepository
         )
         
-        eventsService = ConcreteScheduleRepository(
+        scheduleRepository = ConcreteScheduleRepository(
             eventBus: eventBus,
             dataStore: dataStore,
             imageCache: imageCache,
@@ -162,7 +162,7 @@ class ConcreteSession: EurofurenceSession {
         notificationService = ConcreteNotificationService(eventBus: eventBus)
         
         let urlEntityProcessor = URLEntityProcessor(
-            eventsService: eventsService,
+            eventsService: scheduleRepository,
             dealersService: dealersService, dataStore: dataStore
         )
         
@@ -176,9 +176,7 @@ class ConcreteSession: EurofurenceSession {
     lazy var services = Services(
         notifications: notificationService,
         refresh: refreshService,
-        announcements: announcementsService,
         authentication: authenticationService,
-        events: eventsService,
         dealers: dealersService,
         knowledge: knowledgeService,
         contentLinks: contentLinksService,
@@ -189,6 +187,10 @@ class ConcreteSession: EurofurenceSession {
         privateMessages: privateMessagesService
     )
     
-    lazy var repositories = Repositories(additionalServices: additionalServicesRepository)
+    lazy var repositories = Repositories(
+        additionalServices: additionalServicesRepository,
+        announcements: announcementsRepository,
+        events: scheduleRepository
+    )
     
 }

--- a/Packages/EurofurenceModel/Sources/EurofurenceModel/Private/Objects/Entities/AnnouncementImpl.swift
+++ b/Packages/EurofurenceModel/Sources/EurofurenceModel/Private/Objects/Entities/AnnouncementImpl.swift
@@ -2,6 +2,7 @@ import Foundation
 
 struct AnnouncementImpl: Announcement {
     
+    private unowned let repository: ConcreteAnnouncementsRepository
     private let dataStore: DataStore
     private let imageRepository: ImageRepository
     private let characteristics: AnnouncementCharacteristics
@@ -11,11 +12,18 @@ struct AnnouncementImpl: Announcement {
     var content: String
     var date: Date
     
+    var isRead: Bool {
+        let readAnnouncements = dataStore.fetchReadAnnouncementIdentifiers() ?? []
+        return readAnnouncements.contains(identifier)
+    }
+    
     init(
+        repository: ConcreteAnnouncementsRepository,
         dataStore: DataStore,
         imageRepository: ImageRepository,
         characteristics: AnnouncementCharacteristics
     ) {
+        self.repository = repository
         self.dataStore = dataStore
         self.imageRepository = imageRepository
         self.characteristics = characteristics
@@ -27,7 +35,7 @@ struct AnnouncementImpl: Announcement {
     }
     
     func markRead() {
-        
+        repository.markRead(announcement: self)
     }
     
     func fetchAnnouncementImagePNGData(completionHandler: @escaping (Data?) -> Void) {

--- a/Packages/EurofurenceModel/Sources/EurofurenceModel/Private/Objects/Entities/AnnouncementImpl.swift
+++ b/Packages/EurofurenceModel/Sources/EurofurenceModel/Private/Objects/Entities/AnnouncementImpl.swift
@@ -26,6 +26,10 @@ struct AnnouncementImpl: Announcement {
         self.date = characteristics.lastChangedDateTime
     }
     
+    func markRead() {
+        
+    }
+    
     func fetchAnnouncementImagePNGData(completionHandler: @escaping (Data?) -> Void) {
         var imageData: Data?
         if let imageIdentifier = characteristics.imageIdentifier {

--- a/Packages/EurofurenceModel/Sources/EurofurenceModel/Private/Services/ConcreteAnnouncementsService.swift
+++ b/Packages/EurofurenceModel/Sources/EurofurenceModel/Private/Services/ConcreteAnnouncementsService.swift
@@ -43,15 +43,13 @@ class ConcreteAnnouncementsRepository: AnnouncementsRepository {
     }
     
     func markRead(announcement: AnnouncementImpl) {
-        if readAnnouncementIdentifiers.contains(announcement.identifier) == false {
-            readAnnouncementIdentifiers.append(announcement.identifier)
-            announcementsObservers.forEach({ (observer) in
-                observer.announcementsServiceDidUpdateReadAnnouncements(readAnnouncementIdentifiers)
-            })
-            
-            dataStore.performTransaction { (transaction) in
-                transaction.saveReadAnnouncements(self.readAnnouncementIdentifiers)
-            }
+        readAnnouncementIdentifiers.append(announcement.identifier)
+        announcementsObservers.forEach({ (observer) in
+            observer.announcementsServiceDidUpdateReadAnnouncements(readAnnouncementIdentifiers)
+        })
+        
+        dataStore.performTransaction { (transaction) in
+            transaction.saveReadAnnouncements(self.readAnnouncementIdentifiers)
         }
     }
 

--- a/Packages/EurofurenceModel/Sources/EurofurenceModel/Private/Services/ConcreteAnnouncementsService.swift
+++ b/Packages/EurofurenceModel/Sources/EurofurenceModel/Private/Services/ConcreteAnnouncementsService.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-class ConcreteAnnouncementsService: AnnouncementsService {
+class ConcreteAnnouncementsRepository: AnnouncementsRepository {
 
     // MARK: Properties
 
@@ -15,7 +15,7 @@ class ConcreteAnnouncementsService: AnnouncementsService {
         }
     }
 
-    private var announcementsObservers = [AnnouncementsServiceObserver]()
+    private var announcementsObservers = [AnnouncementsRepositoryObserver]()
 
     // MARK: Initialization
 
@@ -33,7 +33,7 @@ class ConcreteAnnouncementsService: AnnouncementsService {
 
     // MARK: Functions
 
-    func add(_ observer: AnnouncementsServiceObserver) {
+    func add(_ observer: AnnouncementsRepositoryObserver) {
         provideLatestData(to: observer)
         announcementsObservers.append(observer)
     }
@@ -73,7 +73,7 @@ class ConcreteAnnouncementsService: AnnouncementsService {
         return first.lastChangedDateTime.compare(second.lastChangedDateTime) == .orderedDescending
     }
 
-    private func provideLatestData(to observer: AnnouncementsServiceObserver) {
+    private func provideLatestData(to observer: AnnouncementsRepositoryObserver) {
         observer.announcementsServiceDidChangeAnnouncements(models)
         observer.announcementsServiceDidUpdateReadAnnouncements(readAnnouncementIdentifiers)
     }

--- a/Packages/EurofurenceModel/Sources/EurofurenceModel/Private/Services/ConcreteAnnouncementsService.swift
+++ b/Packages/EurofurenceModel/Sources/EurofurenceModel/Private/Services/ConcreteAnnouncementsService.swift
@@ -39,10 +39,12 @@ class ConcreteAnnouncementsRepository: AnnouncementsRepository {
     }
     
     func fetchAnnouncement(identifier: AnnouncementIdentifier) -> Announcement? {
-        guard let model = models.first(where: { $0.identifier == identifier }) else { return nil }
-        
-        if readAnnouncementIdentifiers.contains(identifier) == false {
-            readAnnouncementIdentifiers.append(identifier)
+        models.first(where: { $0.identifier == identifier })
+    }
+    
+    func markRead(announcement: AnnouncementImpl) {
+        if readAnnouncementIdentifiers.contains(announcement.identifier) == false {
+            readAnnouncementIdentifiers.append(announcement.identifier)
             announcementsObservers.forEach({ (observer) in
                 observer.announcementsServiceDidUpdateReadAnnouncements(readAnnouncementIdentifiers)
             })
@@ -51,8 +53,6 @@ class ConcreteAnnouncementsRepository: AnnouncementsRepository {
                 transaction.saveReadAnnouncements(self.readAnnouncementIdentifiers)
             }
         }
-        
-        return model
     }
 
     // MARK: Private
@@ -63,7 +63,12 @@ class ConcreteAnnouncementsRepository: AnnouncementsRepository {
     }
     
     private func makeAnnouncement(from characteristics: AnnouncementCharacteristics) -> AnnouncementImpl {
-        AnnouncementImpl(dataStore: dataStore, imageRepository: imageRepository, characteristics: characteristics)
+        AnnouncementImpl(
+            repository: self,
+            dataStore: dataStore,
+            imageRepository: imageRepository,
+            characteristics: characteristics
+        )
     }
 
     private func isLastEditTimeAscending(

--- a/Packages/EurofurenceModel/Sources/EurofurenceModel/Public/Objects/Entities/Announcement.swift
+++ b/Packages/EurofurenceModel/Sources/EurofurenceModel/Public/Objects/Entities/Announcement.swift
@@ -9,6 +9,7 @@ public protocol Announcement {
     var content: String { get }
     var date: Date { get }
     
+    func markRead()
     func fetchAnnouncementImagePNGData(completionHandler: @escaping (Data?) -> Void)
 
 }

--- a/Packages/EurofurenceModel/Sources/EurofurenceModel/Public/Objects/Entities/Announcement.swift
+++ b/Packages/EurofurenceModel/Sources/EurofurenceModel/Public/Objects/Entities/Announcement.swift
@@ -8,6 +8,7 @@ public protocol Announcement {
     var title: String { get }
     var content: String { get }
     var date: Date { get }
+    var isRead: Bool { get }
     
     func markRead()
     func fetchAnnouncementImagePNGData(completionHandler: @escaping (Data?) -> Void)

--- a/Packages/EurofurenceModel/Sources/EurofurenceModel/Public/Objects/Entities/Announcement.swift
+++ b/Packages/EurofurenceModel/Sources/EurofurenceModel/Public/Objects/Entities/Announcement.swift
@@ -10,7 +10,15 @@ public protocol Announcement {
     var date: Date { get }
     var isRead: Bool { get }
     
+    func add(_ observer: AnnouncementObserver)
     func markRead()
     func fetchAnnouncementImagePNGData(completionHandler: @escaping (Data?) -> Void)
 
+}
+
+public protocol AnnouncementObserver {
+    
+    func announcementEnteredUnreadState(_ announcement: Announcement)
+    func announcementEnteredReadState(_ announcement: Announcement)
+    
 }

--- a/Packages/EurofurenceModel/Sources/EurofurenceModel/Public/Session/Repositories.swift
+++ b/Packages/EurofurenceModel/Sources/EurofurenceModel/Public/Session/Repositories.swift
@@ -1,5 +1,7 @@
 public struct Repositories {
     
     public var additionalServices: AdditionalServicesRepository
+    public var announcements: AnnouncementsRepository
+    public var events: ScheduleRepository
     
 }

--- a/Packages/EurofurenceModel/Sources/EurofurenceModel/Public/Session/Repositories/AnnouncementsRepository.swift
+++ b/Packages/EurofurenceModel/Sources/EurofurenceModel/Public/Session/Repositories/AnnouncementsRepository.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-public protocol AnnouncementsService {
+public protocol AnnouncementsRepository {
     
-    func add(_ observer: AnnouncementsServiceObserver)
+    func add(_ observer: AnnouncementsRepositoryObserver)
     func fetchAnnouncement(identifier: AnnouncementIdentifier) -> Announcement?
 
 }
 
-public protocol AnnouncementsServiceObserver {
+public protocol AnnouncementsRepositoryObserver {
 
     func announcementsServiceDidChangeAnnouncements(_ announcements: [Announcement])
     func announcementsServiceDidUpdateReadAnnouncements(_ readAnnouncements: [AnnouncementIdentifier])

--- a/Packages/EurofurenceModel/Sources/EurofurenceModel/Public/Session/Services.swift
+++ b/Packages/EurofurenceModel/Sources/EurofurenceModel/Public/Session/Services.swift
@@ -4,7 +4,7 @@ public struct Services {
 
     public var notifications: NotificationService
     public var refresh: RefreshService
-    public var announcements: AnnouncementsService
+    public var announcements: AnnouncementsRepository
     public var authentication: AuthenticationService
     public var events: ScheduleRepository
     public var dealers: DealersService

--- a/Packages/EurofurenceModel/Sources/EurofurenceModel/Public/Session/Services.swift
+++ b/Packages/EurofurenceModel/Sources/EurofurenceModel/Public/Session/Services.swift
@@ -4,9 +4,7 @@ public struct Services {
 
     public var notifications: NotificationService
     public var refresh: RefreshService
-    public var announcements: AnnouncementsRepository
     public var authentication: AuthenticationService
-    public var events: ScheduleRepository
     public var dealers: DealersService
     public var knowledge: KnowledgeService
     public var contentLinks: ContentLinksService

--- a/Packages/EurofurenceModel/Sources/XCTEurofurenceModel/Entity Test Doubles/FakeAnnouncement.swift
+++ b/Packages/EurofurenceModel/Sources/XCTEurofurenceModel/Entity Test Doubles/FakeAnnouncement.swift
@@ -14,6 +14,10 @@ public final class FakeAnnouncement: Announcement {
     public var content: String
     public var date: Date
     
+    public var isRead: Bool {
+        readStatus == .read
+    }
+    
     public var imagePNGData: Data?
     
     public private(set) var readStatus: ReadStatus = .unread

--- a/Packages/EurofurenceModel/Sources/XCTEurofurenceModel/Entity Test Doubles/FakeAnnouncement.swift
+++ b/Packages/EurofurenceModel/Sources/XCTEurofurenceModel/Entity Test Doubles/FakeAnnouncement.swift
@@ -2,7 +2,7 @@ import EurofurenceModel
 import Foundation
 import TestUtilities
 
-public final class StubAnnouncement: Announcement {
+public final class FakeAnnouncement: Announcement {
     
     public enum ReadStatus: Equatable {
         case unread
@@ -40,10 +40,10 @@ public final class StubAnnouncement: Announcement {
 
 }
 
-extension StubAnnouncement: RandomValueProviding {
+extension FakeAnnouncement: RandomValueProviding {
 
-    public static var random: StubAnnouncement {
-        return StubAnnouncement(
+    public static var random: FakeAnnouncement {
+        return FakeAnnouncement(
             identifier: .random,
             title: .random,
             content: .random,

--- a/Packages/EurofurenceModel/Sources/XCTEurofurenceModel/Entity Test Doubles/FakeAnnouncement.swift
+++ b/Packages/EurofurenceModel/Sources/XCTEurofurenceModel/Entity Test Doubles/FakeAnnouncement.swift
@@ -34,6 +34,11 @@ public final class FakeAnnouncement: Announcement {
         self.date = date
     }
     
+    private var observers = [AnnouncementObserver]()
+    public func add(_ observer: AnnouncementObserver) {
+        observers.append(observer)
+    }
+    
     public func fetchAnnouncementImagePNGData(completionHandler: @escaping (Data?) -> Void) {
         completionHandler(imagePNGData)
     }

--- a/Packages/EurofurenceModel/Sources/XCTEurofurenceModel/Entity Test Doubles/StubAnnouncement.swift
+++ b/Packages/EurofurenceModel/Sources/XCTEurofurenceModel/Entity Test Doubles/StubAnnouncement.swift
@@ -3,6 +3,11 @@ import Foundation
 import TestUtilities
 
 public final class StubAnnouncement: Announcement {
+    
+    public enum ReadStatus: Equatable {
+        case unread
+        case read
+    }
 
     public var identifier: AnnouncementIdentifier
     public var title: String
@@ -10,11 +15,15 @@ public final class StubAnnouncement: Announcement {
     public var date: Date
     
     public var imagePNGData: Data?
+    
+    public private(set) var readStatus: ReadStatus = .unread
 
-    public init(identifier: AnnouncementIdentifier,
-                title: String,
-                content: String,
-                date: Date) {
+    public init(
+        identifier: AnnouncementIdentifier,
+        title: String,
+        content: String,
+        date: Date
+    ) {
         self.identifier = identifier
         self.title = title
         self.content = content
@@ -24,16 +33,22 @@ public final class StubAnnouncement: Announcement {
     public func fetchAnnouncementImagePNGData(completionHandler: @escaping (Data?) -> Void) {
         completionHandler(imagePNGData)
     }
+    
+    public func markRead() {
+        readStatus = .read
+    }
 
 }
 
 extension StubAnnouncement: RandomValueProviding {
 
     public static var random: StubAnnouncement {
-        return StubAnnouncement(identifier: .random,
-                                title: .random,
-                                content: .random,
-                                date: .random)
+        return StubAnnouncement(
+            identifier: .random,
+            title: .random,
+            content: .random,
+            date: .random
+        )
     }
-
+    
 }

--- a/Packages/EurofurenceModel/Sources/XCTEurofurenceModel/FakeAnnouncementsService.swift
+++ b/Packages/EurofurenceModel/Sources/XCTEurofurenceModel/FakeAnnouncementsService.swift
@@ -1,7 +1,7 @@
 import EurofurenceModel
 import Foundation
 
-public class FakeAnnouncementsService: AnnouncementsService {
+public class FakeAnnouncementsRepository: AnnouncementsRepository {
 
     public var announcements: [Announcement]
     public var stubbedReadAnnouncements: [AnnouncementIdentifier]
@@ -11,8 +11,8 @@ public class FakeAnnouncementsService: AnnouncementsService {
         self.stubbedReadAnnouncements = stubbedReadAnnouncements
     }
 
-    fileprivate var observers = [AnnouncementsServiceObserver]()
-    public func add(_ observer: AnnouncementsServiceObserver) {
+    fileprivate var observers = [AnnouncementsRepositoryObserver]()
+    public func add(_ observer: AnnouncementsRepositoryObserver) {
         observers.append(observer)
         observer.announcementsServiceDidChangeAnnouncements(announcements)
         observer.announcementsServiceDidUpdateReadAnnouncements(stubbedReadAnnouncements)
@@ -24,7 +24,7 @@ public class FakeAnnouncementsService: AnnouncementsService {
 
 }
 
-public extension FakeAnnouncementsService {
+public extension FakeAnnouncementsRepository {
 
     func updateAnnouncements(_ announcements: [Announcement]) {
         observers.forEach({ $0.announcementsServiceDidChangeAnnouncements(announcements) })

--- a/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Announcements/AnnouncementObservationTests.swift
+++ b/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Announcements/AnnouncementObservationTests.swift
@@ -1,0 +1,86 @@
+import EurofurenceModel
+import XCTest
+import XCTEurofurenceModel
+
+class AnnouncementObservationTests: XCTestCase {
+    
+    private var context: EurofurenceSessionTestBuilder.Context!
+    private var syncResponse: ModelCharacteristics!
+    private var announcement: Announcement!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        context = EurofurenceSessionTestBuilder().build()
+        syncResponse = ModelCharacteristics.randomWithoutDeletions
+        context.performSuccessfulSync(response: syncResponse)
+        
+        let announcements = syncResponse.announcements.changed
+        let randomAnnouncement = announcements.randomElement().element
+        let announcementIdentifier = AnnouncementIdentifier(randomAnnouncement.identifier)
+        announcement = try XCTUnwrap(context.announcementsService.fetchAnnouncement(identifier: announcementIdentifier))
+    }
+    
+    func testUnreadAnnouncementInitialObservation() {
+        let observer = CapturingAnnouncementObserver()
+        announcement.add(observer)
+        
+        XCTAssertEqual(.unread, observer.readState)
+    }
+    
+    func testObservingAnnouncementTransitioningFromUnreadToRead() {
+        let observer = CapturingAnnouncementObserver()
+        announcement.add(observer)
+        announcement.markRead()
+        
+        XCTAssertEqual(.read, observer.readState)
+    }
+    
+    func testReadAnnouncementInitialObservation() {
+        let observer = CapturingAnnouncementObserver()
+        announcement.markRead()
+        announcement.add(observer)
+        
+        XCTAssertEqual(.read, observer.readState)
+    }
+    
+    func testDoesNotOverNotifyWhenMarkingReadAnnouncementAsRead() {
+        class JournallingAnnouncementObserver: CapturingAnnouncementObserver {
+            
+            private(set) var enteredReadStateCount = 0
+            override func announcementEnteredReadState(_ announcement: Announcement) {
+                enteredReadStateCount += 1
+                super.announcementEnteredReadState(announcement)
+            }
+            
+        }
+        
+        let observer = JournallingAnnouncementObserver()
+        announcement.markRead()
+        announcement.add(observer)
+        announcement.markRead()
+        
+        XCTAssertEqual(1, observer.enteredReadStateCount)
+    }
+    
+    private class CapturingAnnouncementObserver: AnnouncementObserver {
+        
+        enum ReadState: Equatable {
+            case unknown
+            case unread
+            case read
+        }
+        
+        private(set) var readState: ReadState = .unknown
+        
+        func announcementEnteredUnreadState(_ announcement: Announcement) {
+            readState = .unread
+        }
+        
+        func announcementEnteredReadState(_ announcement: Announcement) {
+            readState = .read
+        }
+        
+    }
+    
+}

--- a/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Announcements/WhenAddingAnnouncementsObserverAfterSuccessfulRefresh.swift
+++ b/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Announcements/WhenAddingAnnouncementsObserverAfterSuccessfulRefresh.swift
@@ -8,7 +8,7 @@ class WhenAddingAnnouncementsObserverAfterSuccessfulRefresh: XCTestCase {
         let syncResponse = ModelCharacteristics.randomWithoutDeletions
 
         context.performSuccessfulSync(response: syncResponse)
-        let observer = CapturingAnnouncementsServiceObserver()
+        let observer = CapturingAnnouncementsRepositoryObserver()
         context.announcementsService.add(observer)
 
         AnnouncementAssertion().assertOrderedAnnouncements(observer.allAnnouncements,

--- a/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Announcements/WhenAddingAnnouncementsObserverBeforeLoadingAnything.swift
+++ b/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Announcements/WhenAddingAnnouncementsObserverBeforeLoadingAnything.swift
@@ -5,7 +5,7 @@ class WhenAddingAnnouncementsObserverBeforeLoadingAnything: XCTestCase {
 
     func testEmptyAnnouncementsAreStillPropogatedToTheObserver() {
         let context = EurofurenceSessionTestBuilder().build()
-        let observer = CapturingAnnouncementsServiceObserver()
+        let observer = CapturingAnnouncementsRepositoryObserver()
         context.announcementsService.add(observer)
 
         XCTAssertTrue(observer.didReceieveEmptyAllAnnouncements)

--- a/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Announcements/WhenAddingAnnouncementsObserver_ThenRefreshSucceeds_ApplicationShould.swift
+++ b/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Announcements/WhenAddingAnnouncementsObserver_ThenRefreshSucceeds_ApplicationShould.swift
@@ -7,7 +7,7 @@ class WhenAddingAnnouncementsObserver_ThenRefreshSucceeds_ApplicationShould: XCT
         let context = EurofurenceSessionTestBuilder().build()
         let syncResponse = ModelCharacteristics.randomWithoutDeletions
 
-        let observer = CapturingAnnouncementsServiceObserver()
+        let observer = CapturingAnnouncementsRepositoryObserver()
         context.announcementsService.add(observer)
         context.performSuccessfulSync(response: syncResponse)
 

--- a/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Announcements/WhenApplicationInitialises_WithAnnouncementsSavedToStore.swift
+++ b/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Announcements/WhenApplicationInitialises_WithAnnouncementsSavedToStore.swift
@@ -8,7 +8,7 @@ class WhenApplicationInitialises_WithAnnouncementsSavedToStore: XCTestCase {
         let characteristics = ModelCharacteristics.randomWithoutDeletions
         let dataStore = InMemoryDataStore(response: characteristics)
         let context = EurofurenceSessionTestBuilder().with(dataStore).build()
-        let observer = CapturingAnnouncementsServiceObserver()
+        let observer = CapturingAnnouncementsRepositoryObserver()
         context.announcementsService.add(observer)
 
         let announcements = characteristics.announcements.changed

--- a/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Announcements/WhenOpeningAnnouncement_ApplicationShould.swift
+++ b/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Announcements/WhenOpeningAnnouncement_ApplicationShould.swift
@@ -63,7 +63,7 @@ class WhenOpeningAnnouncement_ApplicationShould: XCTestCase {
         let firstIdentifier = firstAnnouncement.identifier
         let secondAnnouncement = announcements.randomElement().element
         let secondIdentifier = secondAnnouncement.identifier
-        let observer = CapturingAnnouncementsServiceObserver()
+        let observer = CapturingAnnouncementsRepositoryObserver()
         context.announcementsService.add(observer)
         openAnnouncement(AnnouncementIdentifier(firstIdentifier))
         openAnnouncement(AnnouncementIdentifier(secondIdentifier))
@@ -81,7 +81,7 @@ class WhenOpeningAnnouncement_ApplicationShould: XCTestCase {
         openAnnouncement(AnnouncementIdentifier(firstIdentifier))
         openAnnouncement(AnnouncementIdentifier(secondIdentifier))
         let expected = [firstIdentifier, secondIdentifier].map({ AnnouncementIdentifier($0) })
-        let observer = CapturingAnnouncementsServiceObserver()
+        let observer = CapturingAnnouncementsRepositoryObserver()
         context.announcementsService.add(observer)
 
         XCTAssertTrue(observer.readAnnouncementIdentifiers.contains(elementsFrom: expected))
@@ -101,7 +101,7 @@ class WhenOpeningAnnouncement_ApplicationShould: XCTestCase {
         }
 
         let context = EurofurenceSessionTestBuilder().with(dataStore).build()
-        let observer = CapturingAnnouncementsServiceObserver()
+        let observer = CapturingAnnouncementsRepositoryObserver()
         context.announcementsService.add(observer)
 
         XCTAssertTrue(observer.readAnnouncementIdentifiers.contains(elementsFrom: identifiers))

--- a/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Announcements/WhenOpeningAnnouncement_ApplicationShould.swift
+++ b/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Announcements/WhenOpeningAnnouncement_ApplicationShould.swift
@@ -18,10 +18,6 @@ class WhenOpeningAnnouncement_ApplicationShould: XCTestCase {
     @discardableResult
     private func openAnnouncement(_ identifier: AnnouncementIdentifier) -> Announcement? {
         let announcement = context.announcementsService.fetchAnnouncement(identifier: identifier)
-        
-        // TODO: Seperate opening from fetching by requiring something like:
-//        announcement?.open()
-
         return announcement
     }
 
@@ -33,15 +29,28 @@ class WhenOpeningAnnouncement_ApplicationShould: XCTestCase {
 
         AnnouncementAssertion().assertAnnouncement(model, characterisedBy: announcement)
     }
+    
+    func testAnnouncementsNotImplicitlyMarkedAsReady() throws {
+        let announcements = syncResponse.announcements.changed
+        let announcement = announcements.randomElement().element
+        let identifier = announcement.identifier
+        let entity = try XCTUnwrap(openAnnouncement(AnnouncementIdentifier(identifier)))
+        let readAnnouncementIdentifiers = context.dataStore.fetchReadAnnouncementIdentifiers() ?? []
+        
+        XCTAssertTrue(readAnnouncementIdentifiers.isEmpty)
+        XCTAssertFalse(entity.isRead)
+    }
 
-    func testSaveTheAnnouncementIdentifierAsReadAnnouncementToStore() {
+    func testReadAnnouncementsSaveTheAnnouncementIdentifierToStore() throws {
         let announcements = syncResponse.announcements.changed
         let announcement = announcements.randomElement().element
         let identifier = announcement.identifier
         let entityIdentifier = AnnouncementIdentifier(identifier)
-        openAnnouncement(AnnouncementIdentifier(identifier))
+        let entity = try XCTUnwrap(openAnnouncement(AnnouncementIdentifier(identifier)))
+        entity.markRead()
     
         XCTAssertTrue([entityIdentifier].contains(elementsFrom: context.dataStore.fetchReadAnnouncementIdentifiers()))
+        XCTAssertTrue(entity.isRead)
     }
 
     func testSaveAllPreviouslyReadAnnouncementIdentifierAsRead() {
@@ -50,8 +59,8 @@ class WhenOpeningAnnouncement_ApplicationShould: XCTestCase {
         let firstIdentifier = firstAnnouncement.identifier
         let secondAnnouncement = announcements.randomElement().element
         let secondIdentifier = secondAnnouncement.identifier
-        openAnnouncement(AnnouncementIdentifier(firstIdentifier))
-        openAnnouncement(AnnouncementIdentifier(secondIdentifier))
+        openAnnouncement(AnnouncementIdentifier(firstIdentifier))?.markRead()
+        openAnnouncement(AnnouncementIdentifier(secondIdentifier))?.markRead()
         let expected = [firstIdentifier, secondIdentifier].map({ AnnouncementIdentifier($0) })
 
         XCTAssertTrue(expected.contains(elementsFrom: context.dataStore.fetchReadAnnouncementIdentifiers()))
@@ -65,8 +74,8 @@ class WhenOpeningAnnouncement_ApplicationShould: XCTestCase {
         let secondIdentifier = secondAnnouncement.identifier
         let observer = CapturingAnnouncementsRepositoryObserver()
         context.announcementsService.add(observer)
-        openAnnouncement(AnnouncementIdentifier(firstIdentifier))
-        openAnnouncement(AnnouncementIdentifier(secondIdentifier))
+        openAnnouncement(AnnouncementIdentifier(firstIdentifier))?.markRead()
+        openAnnouncement(AnnouncementIdentifier(secondIdentifier))?.markRead()
         let expected = [firstIdentifier, secondIdentifier].map({ AnnouncementIdentifier($0) })
 
         XCTAssertTrue(observer.readAnnouncementIdentifiers.contains(elementsFrom: expected))
@@ -78,8 +87,8 @@ class WhenOpeningAnnouncement_ApplicationShould: XCTestCase {
         let firstIdentifier = firstAnnouncement.identifier
         let secondAnnouncement = announcements.randomElement().element
         let secondIdentifier = secondAnnouncement.identifier
-        openAnnouncement(AnnouncementIdentifier(firstIdentifier))
-        openAnnouncement(AnnouncementIdentifier(secondIdentifier))
+        openAnnouncement(AnnouncementIdentifier(firstIdentifier))?.markRead()
+        openAnnouncement(AnnouncementIdentifier(secondIdentifier))?.markRead()
         let expected = [firstIdentifier, secondIdentifier].map({ AnnouncementIdentifier($0) })
         let observer = CapturingAnnouncementsRepositoryObserver()
         context.announcementsService.add(observer)
@@ -112,8 +121,8 @@ class WhenOpeningAnnouncement_ApplicationShould: XCTestCase {
         let announcement = announcements.randomElement().element
         let identifier = announcement.identifier
         let entityIdentifier = AnnouncementIdentifier(identifier)
-        openAnnouncement(AnnouncementIdentifier(identifier))
-        openAnnouncement(AnnouncementIdentifier(identifier))
+        openAnnouncement(AnnouncementIdentifier(identifier))?.markRead()
+        openAnnouncement(AnnouncementIdentifier(identifier))?.markRead()
         
         let readAnnouncements = try XCTUnwrap(context.dataStore.fetchReadAnnouncementIdentifiers())
         XCTAssertEqual([entityIdentifier], readAnnouncements)

--- a/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Deletions/AnnouncementRemoveAllBeforeInsertTests.swift
+++ b/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Deletions/AnnouncementRemoveAllBeforeInsertTests.swift
@@ -10,7 +10,7 @@ class AnnouncementRemoveAllBeforeInsertTests: XCTestCase {
         let context = EurofurenceSessionTestBuilder().build()
         context.performSuccessfulSync(response: originalResponse)
         context.performSuccessfulSync(response: subsequentResponse)
-        let observer = CapturingAnnouncementsServiceObserver()
+        let observer = CapturingAnnouncementsRepositoryObserver()
         context.announcementsService.add(observer)
 
         AnnouncementAssertion().assertOrderedAnnouncements(observer.allAnnouncements,
@@ -25,7 +25,7 @@ class AnnouncementRemoveAllBeforeInsertTests: XCTestCase {
         context.performSuccessfulSync(response: originalResponse)
         context.performSuccessfulSync(response: subsequentResponse)
         let combinedResponses = originalResponse.announcements.changed + subsequentResponse.announcements.changed
-        let observer = CapturingAnnouncementsServiceObserver()
+        let observer = CapturingAnnouncementsRepositoryObserver()
         context.announcementsService.add(observer)
 
         AnnouncementAssertion().assertOrderedAnnouncements(observer.allAnnouncements,

--- a/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Deletions/WhenDeletingAnnouncement_AfterSuccessfulSync_ApplicationShould.swift
+++ b/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Deletions/WhenDeletingAnnouncement_AfterSuccessfulSync_ApplicationShould.swift
@@ -6,7 +6,7 @@ class WhenDeletingAnnouncement_AfterSuccessfulSync_ApplicationShould: XCTestCase
     func testUpdateDelegateWithoutDeletedAnnouncement() {
         var response = ModelCharacteristics.randomWithoutDeletions
         let context = EurofurenceSessionTestBuilder().build()
-        let delegate = CapturingAnnouncementsServiceObserver()
+        let delegate = CapturingAnnouncementsRepositoryObserver()
         context.announcementsService.add(delegate)
         context.refreshLocalStore()
         context.api.simulateSuccessfulSync(response)

--- a/Packages/EurofurenceModel/Tests/EurofurenceModelTests/EurofurenceSessionTestBuilder.swift
+++ b/Packages/EurofurenceModel/Tests/EurofurenceModelTests/EurofurenceSessionTestBuilder.swift
@@ -65,7 +65,7 @@ class EurofurenceSessionTestBuilder {
             return services.refresh
         }
 
-        var announcementsService: AnnouncementsService {
+        var announcementsService: AnnouncementsRepository {
             return services.announcements
         }
 

--- a/Packages/EurofurenceModel/Tests/EurofurenceModelTests/EurofurenceSessionTestBuilder.swift
+++ b/Packages/EurofurenceModel/Tests/EurofurenceModelTests/EurofurenceSessionTestBuilder.swift
@@ -21,19 +21,21 @@ class EurofurenceSessionTestBuilder {
         
         private(set) var lastRefreshError: RefreshServiceError?
 
-        fileprivate init(session: EurofurenceSession,
-                         clock: StubClock,
-                         notificationTokenRegistration: CapturingRemoteNotificationsTokenRegistration,
-                         credentialRepository: CapturingCredentialStore,
-                         api: FakeAPI,
-                         dataStore: InMemoryDataStore,
-                         conventionStartDateRepository: StubConventionStartDateRepository,
-                         imageRepository: CapturingImageRepository,
-                         significantTimeChangeAdapter: CapturingSignificantTimeChangeAdapter,
-                         urlOpener: CapturingURLOpener,
-                         longRunningTaskManager: FakeLongRunningTaskManager,
-                         mapCoordinateRender: CapturingMapCoordinateRender,
-                         refreshObserver: CapturingRefreshServiceObserver) {
+        fileprivate init(
+            session: EurofurenceSession,
+            clock: StubClock,
+            notificationTokenRegistration: CapturingRemoteNotificationsTokenRegistration,
+            credentialRepository: CapturingCredentialStore,
+            api: FakeAPI,
+            dataStore: InMemoryDataStore,
+            conventionStartDateRepository: StubConventionStartDateRepository,
+            imageRepository: CapturingImageRepository,
+            significantTimeChangeAdapter: CapturingSignificantTimeChangeAdapter,
+            urlOpener: CapturingURLOpener,
+            longRunningTaskManager: FakeLongRunningTaskManager,
+            mapCoordinateRender: CapturingMapCoordinateRender,
+            refreshObserver: CapturingRefreshServiceObserver
+        ) {
             self.session = session
             self.clock = clock
             self.notificationTokenRegistration = notificationTokenRegistration
@@ -53,6 +55,10 @@ class EurofurenceSessionTestBuilder {
             return session.services
         }
         
+        var repositories: Repositories {
+            return session.repositories
+        }
+        
         var additionalServicesRepository: AdditionalServicesRepository {
             return session.repositories.additionalServices
         }
@@ -66,7 +72,7 @@ class EurofurenceSessionTestBuilder {
         }
 
         var announcementsService: AnnouncementsRepository {
-            return services.announcements
+            return repositories.announcements
         }
 
         var authenticationService: AuthenticationService {
@@ -74,7 +80,7 @@ class EurofurenceSessionTestBuilder {
         }
 
         var eventsService: ScheduleRepository {
-            return services.events
+            return repositories.events
         }
 
         var dealersService: DealersService {

--- a/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Events/Favourites/WhenFavouritingMultipleEvents_ApplicationShould.swift
+++ b/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Events/Favourites/WhenFavouritingMultipleEvents_ApplicationShould.swift
@@ -42,7 +42,7 @@ class WhenFavouritingMultipleEvents_ApplicationShould: XCTestCase {
         context.eventsService.add(observer)
         favouriteEvents(identifiers, service: context.eventsService)
         let randomIdentifier = identifiers.randomElement()
-        let schedule = context.services.events.loadSchedule(tag: "Test")
+        let schedule = context.eventsService.loadSchedule(tag: "Test")
         let event = schedule.loadEvent(identifier: randomIdentifier.element)
         event?.unfavourite()
         var expected = identifiers

--- a/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Events/Favourites/WhenFavouritingThenUnfavouritingEvent.swift
+++ b/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Events/Favourites/WhenFavouritingThenUnfavouritingEvent.swift
@@ -15,7 +15,7 @@ class WhenFavouritingThenUnfavouritingEvent: XCTestCase {
         let randomEvent = modelCharacteristics.events.changed.randomElement().element
         context.performSuccessfulSync(response: modelCharacteristics)
         let identifier = EventIdentifier(randomEvent.identifier)
-        let schedule = context.services.events.loadSchedule(tag: "Test")
+        let schedule = context.eventsService.loadSchedule(tag: "Test")
         event = schedule.loadEvent(identifier: identifier)
         eventObserver = CapturingEventObserver()
     }

--- a/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Events/Favourites/WhenObservingEvent_ThatIsFavourite.swift
+++ b/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Events/Favourites/WhenObservingEvent_ThatIsFavourite.swift
@@ -9,7 +9,7 @@ class WhenObservingEvent_ThatIsFavourite: XCTestCase {
         let dataStore = InMemoryDataStore(response: response)
         let context = EurofurenceSessionTestBuilder().with(dataStore).build()
         let randomEvent = response.events.changed.randomElement().element
-        let schedule = context.services.events.loadSchedule(tag: "Test")
+        let schedule = context.eventsService.loadSchedule(tag: "Test")
         let event = schedule.loadEvent(identifier: EventIdentifier(randomEvent.identifier))
         event?.favourite()
 

--- a/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Events/Favourites/WhenObservingEvent_ThatIsFavourite_FromPreviousSession.swift
+++ b/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Events/Favourites/WhenObservingEvent_ThatIsFavourite_FromPreviousSession.swift
@@ -14,7 +14,7 @@ class WhenObservingEvent_ThatIsFavourite_FromPreviousSession: XCTestCase {
         }
 
         let context = EurofurenceSessionTestBuilder().with(dataStore).build()
-        let schedule = context.services.events.loadSchedule(tag: "Test")
+        let schedule = context.eventsService.loadSchedule(tag: "Test")
         let event = schedule.loadEvent(identifier: eventIdentifier)
         let observer = CapturingEventObserver()
         event?.add(observer)

--- a/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Events/Favourites/WhenUnfavouritingEvent_ApplicationShould.swift
+++ b/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Events/Favourites/WhenUnfavouritingEvent_ApplicationShould.swift
@@ -19,7 +19,7 @@ class WhenUnfavouritingEvent_ApplicationShould: XCTestCase {
         context.performSuccessfulSync(response: modelCharacteristics)
 
         identifier = EventIdentifier(randomEvent.identifier)
-        let schedule = context.services.events.loadSchedule(tag: "Test")
+        let schedule = context.eventsService.loadSchedule(tag: "Test")
         event = schedule.loadEvent(identifier: identifier)
         event.favourite()
         event.unfavourite()

--- a/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Events/Feedback/WhenCharacteristicsIndicatesEventAcceptsFeedback.swift
+++ b/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Events/Feedback/WhenCharacteristicsIndicatesEventAcceptsFeedback.swift
@@ -12,7 +12,7 @@ class WhenCharacteristicsIndicatesEventAcceptsFeedback: XCTestCase {
         characteristics.events.changed[randomEvent.index] = event
         let store = InMemoryDataStore(response: characteristics)
         let context = EurofurenceSessionTestBuilder().with(store).build()
-        let schedule = context.services.events.loadSchedule(tag: "Test")
+        let schedule = context.eventsService.loadSchedule(tag: "Test")
         let entity = schedule.loadEvent(identifier: EventIdentifier(event.identifier))
         
         XCTAssertEqual(true, entity?.isAcceptingFeedback)

--- a/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Events/Feedback/WhenCharacteristicsIndicatesEventDoesNotAcceptFeedback.swift
+++ b/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Events/Feedback/WhenCharacteristicsIndicatesEventDoesNotAcceptFeedback.swift
@@ -12,7 +12,7 @@ class WhenCharacteristicsIndicatesEventDoesNotAcceptFeedback: XCTestCase {
         characteristics.events.changed[randomEvent.index] = event
         let store = InMemoryDataStore(response: characteristics)
         let context = EurofurenceSessionTestBuilder().with(store).build()
-        let schedule = context.services.events.loadSchedule(tag: "Test")
+        let schedule = context.eventsService.loadSchedule(tag: "Test")
         let entity = schedule.loadEvent(identifier: EventIdentifier(event.identifier))
         
         XCTAssertEqual(false, entity?.isAcceptingFeedback)

--- a/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Events/Feedback/WhenSubmittingFeedback_AndFeedbackIsSuccessful.swift
+++ b/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Events/Feedback/WhenSubmittingFeedback_AndFeedbackIsSuccessful.swift
@@ -12,7 +12,7 @@ class WhenSubmittingFeedback_AndFeedbackIsSuccessful: XCTestCase {
         characteristics.events.changed[randomEvent.index] = event
         let store = InMemoryDataStore(response: characteristics)
         let context = EurofurenceSessionTestBuilder().with(store).build()
-        let schedule = context.services.events.loadSchedule(tag: "Test")
+        let schedule = context.eventsService.loadSchedule(tag: "Test")
         let entity = schedule.loadEvent(identifier: EventIdentifier(event.identifier))
         let delegate = CapturingEventFeedbackDelegate()
         let feedback = entity?.prepareFeedback()
@@ -33,7 +33,7 @@ class WhenSubmittingFeedback_AndFeedbackIsSuccessful: XCTestCase {
         characteristics.events.changed[randomEvent.index] = event
         let store = InMemoryDataStore(response: characteristics)
         let context = EurofurenceSessionTestBuilder().with(store).build()
-        let schedule = context.services.events.loadSchedule(tag: "Test")
+        let schedule = context.eventsService.loadSchedule(tag: "Test")
         let entity = schedule.loadEvent(identifier: EventIdentifier(event.identifier))
         let delegate = CapturingEventFeedbackDelegate()
         let feedback = entity?.prepareFeedback()

--- a/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Events/Feedback/WhenSubmittingFeedback_AndFeedbackIsUnsuccessful.swift
+++ b/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Events/Feedback/WhenSubmittingFeedback_AndFeedbackIsUnsuccessful.swift
@@ -12,7 +12,7 @@ class WhenSubmittingFeedback_AndFeedbackIsUnsuccessful: XCTestCase {
         characteristics.events.changed[randomEvent.index] = event
         let store = InMemoryDataStore(response: characteristics)
         let context = EurofurenceSessionTestBuilder().with(store).build()
-        let schedule = context.services.events.loadSchedule(tag: "Test")
+        let schedule = context.eventsService.loadSchedule(tag: "Test")
         let entity = schedule.loadEvent(identifier: EventIdentifier(event.identifier))
         let delegate = CapturingEventFeedbackDelegate()
         let feedback = entity?.prepareFeedback()

--- a/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Events/Feedback/WhenSubmittingFeedback_ForEventNotAcceptingFeedback.swift
+++ b/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Events/Feedback/WhenSubmittingFeedback_ForEventNotAcceptingFeedback.swift
@@ -12,7 +12,7 @@ class WhenSubmittingFeedback_ForEventNotAcceptingFeedback: XCTestCase {
         characteristics.events.changed[randomEvent.index] = event
         let store = InMemoryDataStore(response: characteristics)
         let context = EurofurenceSessionTestBuilder().with(store).build()
-        let schedule = context.services.events.loadSchedule(tag: "Test")
+        let schedule = context.eventsService.loadSchedule(tag: "Test")
         let entity = schedule.loadEvent(identifier: EventIdentifier(event.identifier))
         let delegate = CapturingEventFeedbackDelegate()
         entity?.prepareFeedback().submit(delegate)

--- a/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Events/Observation/WhenUnhookingFromEventObservation.swift
+++ b/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Events/Observation/WhenUnhookingFromEventObservation.swift
@@ -8,7 +8,7 @@ class WhenUnhookingFromEventObservation: XCTestCase {
         let characteristics = ModelCharacteristics.randomWithoutDeletions
         let event = characteristics.events.changed.randomElement().element
         context.performSuccessfulSync(response: characteristics)
-        let schedule = context.services.events.loadSchedule(tag: "Test")
+        let schedule = context.eventsService.loadSchedule(tag: "Test")
         let entity = schedule.loadEvent(identifier: EventIdentifier(event.identifier))
         let observer = CapturingEventObserver()
         entity?.add(observer)

--- a/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Events/WhenObservingEvent_ThatIsNotFavourite.swift
+++ b/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Events/WhenObservingEvent_ThatIsNotFavourite.swift
@@ -9,7 +9,7 @@ class WhenObservingEvent_ThatIsNotFavourite: XCTestCase {
         let dataStore = InMemoryDataStore(response: response)
         let context = EurofurenceSessionTestBuilder().with(dataStore).build()
         let randomEvent = response.events.changed.randomElement().element
-        let schedule = context.services.events.loadSchedule(tag: "Test")
+        let schedule = context.eventsService.loadSchedule(tag: "Test")
         let event = schedule.loadEvent(identifier: EventIdentifier(randomEvent.identifier))
         let observer = CapturingEventObserver()
         event?.add(observer)

--- a/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Events/WhenRequestingShareableURL_EventShould.swift
+++ b/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Events/WhenRequestingShareableURL_EventShould.swift
@@ -10,7 +10,7 @@ class WhenRequestingShareableURL_EventShould: XCTestCase {
         let dataStore = InMemoryDataStore(response: characteristics)
         let context = EurofurenceSessionTestBuilder().with(dataStore).build()
         let identifier = EventIdentifier(event.identifier)
-        let schedule = context.services.events.loadSchedule(tag: "Test")
+        let schedule = context.eventsService.loadSchedule(tag: "Test")
         let entity = schedule.loadEvent(identifier: EventIdentifier(event.identifier))
         let url = entity?.contentURL
         

--- a/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Events/WhenResolvingEventByIdentifier_ForEventThatExists_ApplicationShould.swift
+++ b/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Events/WhenResolvingEventByIdentifier_ForEventThatExists_ApplicationShould.swift
@@ -9,7 +9,7 @@ class WhenResolvingEventByIdentifier_ForEventThatExists_ApplicationShould: XCTes
         context.refreshLocalStore()
         context.api.simulateSuccessfulSync(response)
         let characteristics = response.events.changed.randomElement().element
-        let schedule = context.services.events.loadSchedule(tag: "Test")
+        let schedule = context.eventsService.loadSchedule(tag: "Test")
         let actual = schedule.loadEvent(identifier: EventIdentifier(characteristics.identifier))
 
         try EventAssertion(context: context, modelCharacteristics: response)

--- a/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Full Refresh/WhenFullRefreshOccurs_YieldingOrphanedEntities.swift
+++ b/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Full Refresh/WhenFullRefreshOccurs_YieldingOrphanedEntities.swift
@@ -24,7 +24,7 @@ class WhenFullRefreshOccurs_YieldingOrphanedEntities: XCTestCase {
     }
 
     func testTheOrphanedAnnouncementsAreRemoved() {
-        let announcementsObserver = CapturingAnnouncementsServiceObserver()
+        let announcementsObserver = CapturingAnnouncementsRepositoryObserver()
         context.announcementsService.add(announcementsObserver)
         let originalAnnouncementIdentifiers = originalResponse.announcements.changed.identifiers
         let announcementIdentifiers = announcementsObserver.allAnnouncements.map(\.identifier.rawValue)

--- a/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Test Doubles/Observers/CapturingAnnouncementsServiceObserver.swift
+++ b/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Test Doubles/Observers/CapturingAnnouncementsServiceObserver.swift
@@ -1,7 +1,7 @@
 import EurofurenceModel
 import Foundation
 
-class CapturingAnnouncementsServiceObserver: AnnouncementsServiceObserver {
+class CapturingAnnouncementsRepositoryObserver: AnnouncementsRepositoryObserver {
 
     private(set) var allAnnouncements: [Announcement] = []
     private(set) var didReceieveEmptyAllAnnouncements = false


### PR DESCRIPTION
Shifting some behaviour around to make the Announcement entity interactions a bit less messy