### PR TITLE
Fix dealer graphics using incorrect size

### DIFF
--- a/Packages/EurofurenceComponents/Sources/ComponentBase/Views/AspectRatioConstrainedImageView.swift
+++ b/Packages/EurofurenceComponents/Sources/ComponentBase/Views/AspectRatioConstrainedImageView.swift
@@ -23,21 +23,25 @@ public class AspectRatioConstrainedImageView: UIImageView {
                 let size = image.size
                 let constraint = NSLayoutConstraint(
                     item: self,
-                    attribute: .width,
+                    attribute: .height,
                     relatedBy: .equal,
                     toItem: self,
-                    attribute: .height,
-                    multiplier: size.width / size.height,
+                    attribute: .width,
+                    multiplier: size.height / size.width,
                     constant: 0
                 )
                 
                 constraint.identifier = "Image Aspect Ratio"
                 constraint.priority = .defaultHigh
                 
-                addConstraint(constraint)
                 aspectRatioConstraint = constraint
+                constraint.isActive = true
             }
         }
+    }
+    
+    override public var intrinsicContentSize: CGSize {
+        CGSize(width: UIView.noIntrinsicMetric, height: UIView.noIntrinsicMetric)
     }
     
 }


### PR DESCRIPTION
Aspect ratio constraint failed to apply on modern iOS versions as the view’s intrinsic content size was creating a constraint of a higher priority