### PR TITLE
Remove explicit day zero selection in view controller

### DIFF
--- a/Packages/EurofurenceComponents/Sources/ScheduleComponent/View Model/DefaultScheduleViewModelFactory.swift
+++ b/Packages/EurofurenceComponents/Sources/ScheduleComponent/View Model/DefaultScheduleViewModelFactory.swift
@@ -144,7 +144,7 @@ public class DefaultScheduleViewModelFactory: ScheduleViewModelFactory {
         }
 
         func currentEventDayDidChange(to day: Day?) {
-            guard let day = day else { return }
+            guard let day = (day ?? days.first) else { return }
             schedule.filterSchedule(to: EventsOccurringOnDaySpecification(day: day))
 
             guard let idx = days.firstIndex(where: { $0.date == day.date }) else { return }

--- a/Packages/EurofurenceComponents/Sources/ScheduleComponent/View/UIKit/ScheduleViewController.swift
+++ b/Packages/EurofurenceComponents/Sources/ScheduleComponent/View/UIKit/ScheduleViewController.swift
@@ -75,7 +75,6 @@ public class ScheduleViewController: UIViewController,
         
         tableView.registerConventionBrandedHeader()
         delegate?.scheduleSceneDidLoad()
-        delegate?.scheduleSceneDidSelectDay(at: 0)
     }
     
     override public func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {

--- a/Packages/EurofurenceComponents/Tests/ScheduleComponentTests/View Model Tests/WhenPreparingViewModel_ScheduleViewModelFactoryShould.swift
+++ b/Packages/EurofurenceComponents/Tests/ScheduleComponentTests/View Model Tests/WhenPreparingViewModel_ScheduleViewModelFactoryShould.swift
@@ -62,5 +62,16 @@ class WhenPreparingViewModel_ScheduleViewModelFactoryShould: XCTestCase {
         let expected = EventsOccurringOnDaySpecification(day: currentDay.element)
         XCTAssertEqual(expected.eraseToAnySpecification(), eventsService.schedule(for: "Schedule")?.specification)
     }
+    
+    func testTellScheduleToRestrictEventsToFirstDayWhenOutsideConTime_BUG() throws {
+        let days = [Day].random
+        let firstDay = try XCTUnwrap(days.first)
+        eventsService.simulateDaysChanged(days)
+        eventsService.simulateDayChanged(to: nil)
+        context.makeViewModel()
+        
+        let expected = EventsOccurringOnDaySpecification(day: firstDay)
+        XCTAssertEqual(expected.eraseToAnySpecification(), eventsService.schedule(for: "Schedule")?.specification)
+    }
 
 }


### PR DESCRIPTION
Avoids forcing the schedule to filter to an earlier day during con time that also triggers a selection haptic when the user did not interact with the app.

Fixes #439, #442