### PR TITLE
Fix deep links when app is booting from a cold start

### DIFF
--- a/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Scenes/Principal Scene/PrincipalWindowAssembler.swift
+++ b/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Scenes/Principal Scene/PrincipalWindowAssembler.swift
@@ -12,7 +12,7 @@ struct PrincipalWindowAssembler {
     
     private static let log = OSLog(subsystem: "org.eurofurence.EurofurenceApplication", category: "Principal Window")
     
-    private let router: Router
+    private var router: Router
     private let contentWireframe: WindowContentWireframe
     private let modalWireframe: WindowModalWireframe
     
@@ -47,7 +47,7 @@ struct PrincipalWindowAssembler {
             window: window
         )
         
-        self.router = PrincipalWindowRoutes(
+        let routes = PrincipalWindowRoutes(
             contentWireframe: contentWireframe,
             modalWireframe: modalWireframe,
             componentRegistry: componentRegistry,
@@ -57,10 +57,8 @@ struct PrincipalWindowAssembler {
             window: window
         ).routes
         
-        configureComponents(componentRegistry: componentRegistry, window: window, services: services)
-    }
-    
-    private func configureComponents(componentRegistry: ComponentRegistry, window: UIWindow, services: Services) {
+        self.router = routes
+        
         let applicationModuleFactories = makePrincipalWindowComponents(
             componentRegistry: componentRegistry,
             window: window,
@@ -77,6 +75,8 @@ struct PrincipalWindowAssembler {
         )
         
         _ = ContentSceneController(sessionState: services.sessionState, scene: principalWindowScene)
+        
+        self.router = LoadedContentRouter(stateService: services.sessionState, destinationRoutes: routes)
     }
     
     private func makePrincipalWindowComponents(

--- a/Packages/EurofurenceClipLogic/Sources/EurofurenceClipLogic/AppClip+PrincipalWindowAssembler.swift
+++ b/Packages/EurofurenceClipLogic/Sources/EurofurenceClipLogic/AppClip+PrincipalWindowAssembler.swift
@@ -68,9 +68,6 @@ extension AppClip {
             routes.install(ReplaceSceneWithScheduleRoute(scene: clipContentScene))
             routes.install(ReplaceSceneWithDealersRoute(scene: clipContentScene))
             
-            let clipRouting = EurofurenceClipRouting(router: routes, clipScene: clipContentScene)
-            self.routing = clipRouting
-            
             let appClipModule = ContainerModuleWrapper(containerViewController: rootContainerViewController)
             
             let scene = ComponentBasedBootstrappingScene(
@@ -84,6 +81,14 @@ extension AppClip {
                 sessionState: services.sessionState,
                 scene: scene
             )
+            
+            let stateSensitiveRoutes = LoadedContentRouter(
+                stateService: services.sessionState,
+                destinationRoutes: routes
+            )
+            
+            let clipRouting = EurofurenceClipRouting(router: stateSensitiveRoutes, clipScene: clipContentScene)
+            self.routing = clipRouting
         }
         
         private struct ScheduleFactoryAdapter: ClipContentControllerFactory {

--- a/Packages/EurofurenceComponents/Package.swift
+++ b/Packages/EurofurenceComponents/Package.swift
@@ -54,7 +54,8 @@ let package = Package(
         .testTarget(name: "ComponentBaseTests", dependencies: [
             .target(name: "ComponentBase"),
             .target(name: "XCTComponentBase"),
-            .product(name: "XCTEurofurenceModel", package: "EurofurenceModel")
+            .product(name: "XCTEurofurenceModel", package: "EurofurenceModel"),
+            .product(name: "XCTRouter", package: "Router")
         ], resources: [
             .process("Resources")
         ]),

--- a/Packages/EurofurenceComponents/Sources/ComponentBase/Loaded Content Router/LoadedContentRouter.swift
+++ b/Packages/EurofurenceComponents/Sources/ComponentBase/Loaded Content Router/LoadedContentRouter.swift
@@ -1,0 +1,42 @@
+import EurofurenceModel
+import RouterCore
+
+public class LoadedContentRouter<R>: Router where R: Router {
+    
+    private let stateSensitiveRouter: WaitUntilInitialized<R>
+    
+    public init(stateService: SessionStateService, destinationRoutes: R) {
+        stateSensitiveRouter = WaitUntilInitialized(router: destinationRoutes)
+        stateService.add(observer: stateSensitiveRouter)
+    }
+    
+    public func route<R>(_ content: R) throws where R: Routeable {
+        try stateSensitiveRouter.route(content)
+    }
+    
+    private class WaitUntilInitialized<R>: SessionStateObserver where R: Router {
+        
+        private let router: R
+        private var currentSessionState: EurofurenceSessionState = .uninitialized
+        private var pendingRoute: (() -> Void)?
+        
+        init(router: R) {
+            self.router = router
+        }
+        
+        func route<R>(_ content: R) throws where R: Routeable {
+            if currentSessionState == .initialized {
+                try router.route(content)
+            } else {
+                pendingRoute = { [weak self] in try? self?.router.route(content) }
+            }
+        }
+        
+        func sessionStateDidChange(_ newState: EurofurenceSessionState) {
+            currentSessionState = newState
+            pendingRoute?()
+        }
+        
+    }
+    
+}

--- a/Packages/EurofurenceComponents/Sources/ContentController/ComponentBasedBootstrappingScene.swift
+++ b/Packages/EurofurenceComponents/Sources/ContentController/ComponentBasedBootstrappingScene.swift
@@ -61,7 +61,7 @@ public struct ComponentBasedBootstrappingScene: ContentBootstrappingScene {
         }
         
         func preloadModuleDidFinishPreloading() {
-            scene.showContent()
+
         }
         
     }

--- a/Packages/EurofurenceComponents/Sources/ContentController/ContentSceneController.swift
+++ b/Packages/EurofurenceComponents/Sources/ContentController/ContentSceneController.swift
@@ -3,8 +3,15 @@ import EurofurenceModel
 public struct ContentSceneController {
     
     public init(sessionState: SessionStateService, scene: ContentBootstrappingScene) {
-        sessionState.determineSessionState(completionHandler: { (state) in
-            switch state {
+        sessionState.add(observer: UpdateSceneWhenStateChanges(scene: scene))
+    }
+    
+    private struct UpdateSceneWhenStateChanges: SessionStateObserver {
+        
+        var scene: ContentBootstrappingScene
+        
+        func sessionStateDidChange(_ newState: EurofurenceSessionState) {
+            switch newState {
             case .uninitialized:
                 scene.showTutorial()
                 
@@ -14,7 +21,8 @@ public struct ContentSceneController {
             case .initialized:
                 scene.showContent()
             }
-        })
+        }
+        
     }
     
 }

--- a/Packages/EurofurenceComponents/Tests/ComponentBaseTests/Loaded Content Router/LoadedContentRouterTests.swift
+++ b/Packages/EurofurenceComponents/Tests/ComponentBaseTests/Loaded Content Router/LoadedContentRouterTests.swift
@@ -1,0 +1,48 @@
+import ComponentBase
+import EurofurenceModel
+import RouterCore
+import XCTest
+import XCTEurofurenceModel
+import XCTRouter
+
+class LoadedContentRouterTests: XCTestCase {
+    
+    func testContentLoadedForwardsRouteable() throws {
+        let inner = FakeContentRouter()
+        let stateService = ControllableSessionStateService()
+        stateService.simulatedState = .initialized
+        let router = LoadedContentRouter(stateService: stateService, destinationRoutes: inner)
+        let routeable = SomeRouteable(value: 42)
+        try router.route(routeable)
+        
+        inner.assertRouted(to: routeable)
+    }
+    
+    func testContentUnitializedDoesNotForwardRouteable() throws {
+        let inner = FakeContentRouter()
+        let stateService = ControllableSessionStateService()
+        stateService.simulatedState = .uninitialized
+        let router = LoadedContentRouter(stateService: stateService, destinationRoutes: inner)
+        let routeable = SomeRouteable(value: 42)
+        try router.route(routeable)
+        
+        inner.assertDidNotRoute(to: routeable)
+    }
+    
+    func testContentBecomesInitializedAfterAttemptingRoutingForwardsRouteable() throws {
+        let inner = FakeContentRouter()
+        let stateService = ControllableSessionStateService()
+        stateService.simulatedState = .uninitialized
+        let router = LoadedContentRouter(stateService: stateService, destinationRoutes: inner)
+        let routeable = SomeRouteable(value: 42)
+        try router.route(routeable)
+        stateService.simulatedState = .initialized
+        
+        inner.assertRouted(to: routeable)
+    }
+    
+    private struct SomeRouteable: Routeable {
+        var value: Int
+    }
+    
+}

--- a/Packages/EurofurenceComponents/Tests/ContentControllerTests/ComponentBasedBootstrappingSceneTests.swift
+++ b/Packages/EurofurenceComponents/Tests/ContentControllerTests/ComponentBasedBootstrappingSceneTests.swift
@@ -62,13 +62,5 @@ class ComponentBasedBootstrappingSceneTests: XCTestCase {
         
         XCTAssertEqual(tutorialModule.stubInterface, windowWireframe.capturedRootInterface)
     }
-    
-    func testMovingFromPreloadToContent() {
-        windowScene.showTutorial()
-        tutorialModule.simulateTutorialFinished()
-        preloadModule.simulatePreloadFinished()
-        
-        XCTAssertEqual(principalContentModule.stubInterface, windowWireframe.capturedRootInterface)
-    }
 
 }

--- a/Packages/EurofurenceModel/Sources/EurofurenceModel/Private/ConcreteSession.swift
+++ b/Packages/EurofurenceModel/Sources/EurofurenceModel/Private/ConcreteSession.swift
@@ -49,9 +49,12 @@ class ConcreteSession: EurofurenceSession {
         
         let dataStore = dataStoreFactory.makeDataStore(for: conventionIdentifier)
         
-        sessionStateService = ConcreteSessionStateService(forceRefreshRequired: forceRefreshRequired,
-                                                          userPreferences: userPreferences,
-                                                          dataStore: dataStore)
+        sessionStateService = ConcreteSessionStateService(
+            eventBus: eventBus,
+            forceRefreshRequired: forceRefreshRequired,
+            userPreferences: userPreferences,
+            dataStore: dataStore
+        )
         
         remoteNotificationRegistrationController = RemoteNotificationRegistrationController(
             eventBus: eventBus,

--- a/Packages/EurofurenceModel/Sources/EurofurenceModel/Private/Services/ConcreteSessionStateService.swift
+++ b/Packages/EurofurenceModel/Sources/EurofurenceModel/Private/Services/ConcreteSessionStateService.swift
@@ -5,17 +5,18 @@ struct ConcreteSessionStateService: SessionStateService {
     var forceRefreshRequired: ForceRefreshRequired
     var userPreferences: UserPreferences
     var dataStore: DataStore
-
-    func determineSessionState(completionHandler: @escaping (EurofurenceSessionState) -> Void) {
+    
+    private var currentState: EurofurenceSessionState {
         let shouldPerformForceRefresh: Bool = forceRefreshRequired.isForceRefreshRequired
-        let state: EurofurenceSessionState = {
-            guard dataStore.fetchLastRefreshDate() != nil else { return .uninitialized }
+        
+        guard dataStore.fetchLastRefreshDate() != nil else { return .uninitialized }
 
-            let dataStoreStale = shouldPerformForceRefresh || userPreferences.refreshStoreOnLaunch
-            return dataStoreStale ? .stale : .initialized
-        }()
-
-        completionHandler(state)
+        let dataStoreStale = shouldPerformForceRefresh || userPreferences.refreshStoreOnLaunch
+        return dataStoreStale ? .stale : .initialized
+    }
+    
+    func add(observer: SessionStateObserver) {
+        observer.sessionStateDidChange(currentState)
     }
 
 }

--- a/Packages/EurofurenceModel/Sources/EurofurenceModel/Public/Session/Services/SessionStateService.swift
+++ b/Packages/EurofurenceModel/Sources/EurofurenceModel/Public/Session/Services/SessionStateService.swift
@@ -2,6 +2,12 @@ import Foundation
 
 public protocol SessionStateService {
 
-    func determineSessionState(completionHandler: @escaping (EurofurenceSessionState) -> Void)
+    func add(observer: SessionStateObserver)
 
+}
+
+public protocol SessionStateObserver {
+    
+    func sessionStateDidChange(_ newState: EurofurenceSessionState)
+    
 }

--- a/Packages/EurofurenceModel/Sources/EurofurenceModel/Public/Session/Services/SessionStateService.swift
+++ b/Packages/EurofurenceModel/Sources/EurofurenceModel/Public/Session/Services/SessionStateService.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public protocol SessionStateService {
 
-    func add(observer: SessionStateObserver)
+    func add(observer: any SessionStateObserver)
 
 }
 

--- a/Packages/EurofurenceModel/Sources/XCTEurofurenceModel/ControllableSessionStateService.swift
+++ b/Packages/EurofurenceModel/Sources/XCTEurofurenceModel/ControllableSessionStateService.swift
@@ -6,9 +6,18 @@ public class ControllableSessionStateService: SessionStateService {
         
     }
     
-    public var simulatedState: EurofurenceSessionState = .uninitialized
+    public var simulatedState: EurofurenceSessionState = .uninitialized {
+        didSet {
+            for observer in observers {
+                observer.sessionStateDidChange(simulatedState)
+            }
+        }
+    }
+    
+    private var observers = [any SessionStateObserver]()
     
     public func add(observer: SessionStateObserver) {
+        observers.append(observer)
         observer.sessionStateDidChange(simulatedState)
     }
     

--- a/Packages/EurofurenceModel/Sources/XCTEurofurenceModel/ControllableSessionStateService.swift
+++ b/Packages/EurofurenceModel/Sources/XCTEurofurenceModel/ControllableSessionStateService.swift
@@ -8,8 +8,8 @@ public class ControllableSessionStateService: SessionStateService {
     
     public var simulatedState: EurofurenceSessionState = .uninitialized
     
-    public func determineSessionState(completionHandler: @escaping (EurofurenceSessionState) -> Void) {
-        completionHandler(simulatedState)
+    public func add(observer: SessionStateObserver) {
+        observer.sessionStateDidChange(simulatedState)
     }
     
 }

--- a/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Test Doubles/Observers/CapturingSessionStateObserver.swift
+++ b/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Test Doubles/Observers/CapturingSessionStateObserver.swift
@@ -1,0 +1,11 @@
+import EurofurenceModel
+
+class CapturingSessionStateObserver: SessionStateObserver {
+    
+    private(set) var state: EurofurenceSessionState?
+    
+    func sessionStateDidChange(_ newState: EurofurenceSessionState) {
+        state = newState
+    }
+    
+}

--- a/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Upgrade Path/WhenUpgradingBetweenAppVersions_ApplicationShould.swift
+++ b/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Upgrade Path/WhenUpgradingBetweenAppVersions_ApplicationShould.swift
@@ -12,10 +12,10 @@ class WhenUpgradingBetweenAppVersions_ApplicationShould: XCTestCase {
         }
         
         let context = EurofurenceSessionTestBuilder().with(presentDataStore).with(forceUpgradeRequired).build()
-        var dataStoreState: EurofurenceSessionState?
-        context.sessionStateService.determineSessionState { dataStoreState = $0 }
+        let sessionStateObserver = CapturingSessionStateObserver()
+        context.sessionStateService.add(observer: sessionStateObserver)
 
-        XCTAssertEqual(EurofurenceSessionState.stale, dataStoreState)
+        XCTAssertEqual(EurofurenceSessionState.stale, sessionStateObserver.state)
     }
 
     func testAlwaysEnquireWhetherUpgradeRequiredEvenWhenRefreshWouldOccurByPreference() {
@@ -29,7 +29,8 @@ class WhenUpgradingBetweenAppVersions_ApplicationShould: XCTestCase {
             .with(forceUpgradeRequired)
             .build()
         
-        context.sessionStateService.determineSessionState { (_) in }
+        let sessionStateObserver = CapturingSessionStateObserver()
+        context.sessionStateService.add(observer: sessionStateObserver)
 
         XCTAssertTrue(forceUpgradeRequired.wasEnquiredWhetherForceRefreshRequired)
     }
@@ -45,7 +46,8 @@ class WhenUpgradingBetweenAppVersions_ApplicationShould: XCTestCase {
             .with(forceUpgradeRequired)
             .build()
         
-        context.sessionStateService.determineSessionState { (_) in }
+        let sessionStateObserver = CapturingSessionStateObserver()
+        context.sessionStateService.add(observer: sessionStateObserver)
 
         XCTAssertTrue(forceUpgradeRequired.wasEnquiredWhetherForceRefreshRequired)
     }

--- a/Packages/EurofurenceModel/Tests/EurofurenceModelTests/WhenResolvingDataStoreState.swift
+++ b/Packages/EurofurenceModel/Tests/EurofurenceModelTests/WhenResolvingDataStoreState.swift
@@ -7,10 +7,10 @@ class WhenResolvingDataStoreState: XCTestCase {
     func testStoreWithNoLastRefreshTimeIsAbsent() {
         let capturingDataStore = InMemoryDataStore()
         let context = EurofurenceSessionTestBuilder().with(capturingDataStore).build()
-        var state: EurofurenceSessionState?
-        context.sessionStateService.determineSessionState { state = $0 }
+        let sessionStateObserver = CapturingSessionStateObserver()
+        context.sessionStateService.add(observer: sessionStateObserver)
 
-        XCTAssertEqual(.uninitialized, state)
+        XCTAssertEqual(.uninitialized, sessionStateObserver.state)
     }
 
     func testStoreWithLastRefreshDateWithRefreshOnLaunchEnabledIsStale() {
@@ -22,10 +22,10 @@ class WhenResolvingDataStoreState: XCTestCase {
         let userPreferences = StubUserPreferences()
         userPreferences.refreshStoreOnLaunch = true
         let context = EurofurenceSessionTestBuilder().with(capturingDataStore).with(userPreferences).build()
-        var state: EurofurenceSessionState?
-        context.sessionStateService.determineSessionState { state = $0 }
+        let sessionStateObserver = CapturingSessionStateObserver()
+        context.sessionStateService.add(observer: sessionStateObserver)
 
-        XCTAssertEqual(.stale, state)
+        XCTAssertEqual(.stale, sessionStateObserver.state)
     }
 
     func testStoreWithLastRefreshDateWithRefreshOnLaunchDisabledIsAvailable() {
@@ -37,10 +37,10 @@ class WhenResolvingDataStoreState: XCTestCase {
         let userPreferences = StubUserPreferences()
         userPreferences.refreshStoreOnLaunch = false
         let context = EurofurenceSessionTestBuilder().with(capturingDataStore).with(userPreferences).build()
-        var state: EurofurenceSessionState?
-        context.sessionStateService.determineSessionState { state = $0 }
+        let sessionStateObserver = CapturingSessionStateObserver()
+        context.sessionStateService.add(observer: sessionStateObserver)
 
-        XCTAssertEqual(.initialized, state)
+        XCTAssertEqual(.initialized, sessionStateObserver.state)
     }
 
 }

--- a/Packages/EurofurenceModel/Tests/EurofurenceModelTests/WhenResolvingDataStoreState.swift
+++ b/Packages/EurofurenceModel/Tests/EurofurenceModelTests/WhenResolvingDataStoreState.swift
@@ -42,5 +42,15 @@ class WhenResolvingDataStoreState: XCTestCase {
 
         XCTAssertEqual(.initialized, sessionStateObserver.state)
     }
+    
+    func testStoreBeginsUninitializedThenBecomesInitialized() {
+        let capturingDataStore = InMemoryDataStore()
+        let context = EurofurenceSessionTestBuilder().with(capturingDataStore).build()
+        let sessionStateObserver = CapturingSessionStateObserver()
+        context.sessionStateService.add(observer: sessionStateObserver)
+        context.performSuccessfulSync(response: .randomWithoutDeletions)
+        
+        XCTAssertEqual(.initialized, sessionStateObserver.state)
+    }
 
 }


### PR DESCRIPTION
Amend the deep link handling process when the app is booting for the first time, re-routing the URL when we've loaded the content to actually route to.