### PR TITLE
Fix knowledge group listing appear in secondary pane

### DIFF
--- a/Eurofurence.xcodeproj/project.pbxproj
+++ b/Eurofurence.xcodeproj/project.pbxproj
@@ -92,6 +92,7 @@
 		CAB4E9182662704500EFE882 /* Intents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = CAB4E91126626F7100EFE882 /* Intents.intentdefinition */; settings = {ATTRIBUTES = (no_codegen, ); }; };
 		CAB4E9192662704600EFE882 /* Intents.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = CAB4E91126626F7100EFE882 /* Intents.intentdefinition */; settings = {ATTRIBUTES = (no_codegen, ); }; };
 		CAB4E91A2662705100EFE882 /* EurofurenceKit.h in Headers */ = {isa = PBXBuildFile; fileRef = CAB4E91226626F7100EFE882 /* EurofurenceKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CAB7ABC928730E230037ACFB /* KnowledgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAB7ABC828730E230037ACFB /* KnowledgeTests.swift */; };
 		CABBCA162565B153007A11A2 /* EventCategory+Intent.swift in Sources */ = {isa = PBXBuildFile; fileRef = CABBCA152565B153007A11A2 /* EventCategory+Intent.swift */; };
 		CABBCA302566FE0B007A11A2 /* SplitViewDetailBugTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CABBCA2F2566FE0B007A11A2 /* SplitViewDetailBugTests.swift */; };
 		CAC22AE325FEB7A7004E0587 /* EurofurenceApplication in Frameworks */ = {isa = PBXBuildFile; productRef = CAC22AE225FEB7A7004E0587 /* EurofurenceApplication */; };
@@ -326,6 +327,7 @@
 		CAB4E91126626F7100EFE882 /* Intents.intentdefinition */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.intentdefinition; path = Intents.intentdefinition; sourceTree = "<group>"; };
 		CAB4E91226626F7100EFE882 /* EurofurenceKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EurofurenceKit.h; sourceTree = "<group>"; };
 		CAB4E91326626F7100EFE882 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		CAB7ABC828730E230037ACFB /* KnowledgeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KnowledgeTests.swift; sourceTree = "<group>"; };
 		CABBCA152565B153007A11A2 /* EventCategory+Intent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EventCategory+Intent.swift"; sourceTree = "<group>"; };
 		CABBCA2F2566FE0B007A11A2 /* SplitViewDetailBugTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitViewDetailBugTests.swift; sourceTree = "<group>"; };
 		CACD371F25650BC400C23041 /* EurofurenceModel.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = EurofurenceModel.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -753,6 +755,7 @@
 				CAF255112517FE81008892ED /* DealerDetailTests.swift */,
 				CA26503C25F7D3EB0080F132 /* DealerSearchTests.swift */,
 				CAF2552E251A6DC4008892ED /* EventDetailTests.swift */,
+				CAB7ABC828730E230037ACFB /* KnowledgeTests.swift */,
 				CAF254AC2517F983008892ED /* LaunchPerformanceTest.swift */,
 				CABBCA2F2566FE0B007A11A2 /* SplitViewDetailBugTests.swift */,
 				CAF254FD2517FB47008892ED /* UI Automation */,
@@ -1360,6 +1363,7 @@
 			files = (
 				CAF254FF2517FB65008892ED /* AutomationController.swift in Sources */,
 				CAF25568251A8774008892ED /* UIAutomationTestCase.swift in Sources */,
+				CAB7ABC928730E230037ACFB /* KnowledgeTests.swift in Sources */,
 				CAF2552F251A6DC4008892ED /* EventDetailTests.swift in Sources */,
 				CA26503D25F7D3EB0080F132 /* DealerSearchTests.swift in Sources */,
 				CAF254AD2517F983008892ED /* LaunchPerformanceTest.swift in Sources */,

--- a/EurofurenceUITests/KnowledgeTests.swift
+++ b/EurofurenceUITests/KnowledgeTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+
+class KnowledgeTests: UIAutomationTestCase {
+    
+    func testKnowledgeEntriesDoesNotAppearInSecondaryPane() throws {
+        try controller.skipIfTablet()
+        
+        XCUIDevice.shared.orientation = .portrait
+        controller.app.launch()
+        controller.transitionToContent()
+        controller.tapTab(.information)
+        try controller.tapCellWithText("General Information")
+        XCUIDevice.shared.orientation = .landscapeLeft
+        
+        try XCTSkipIf(controller.app.navigationBars.count < 2, "Only applies to phones using split view in landscape")
+        
+        let generalInformationTitle = controller.app.navigationBars["General Information"]
+        
+        XCTAssertTrue(
+            generalInformationTitle.exists,
+            "General Information should still be presented after rotating from portrait to landscape"
+        )
+        
+        let informationNavigationTitle = controller.app.navigationBars["Information"]
+        XCTAssertFalse(informationNavigationTitle.exists, "General Information should override the primary pane")
+        
+        controller.assertPlaceholderVisible()
+    }
+    
+}

--- a/EurofurenceUITests/UI Automation/AutomationController.swift
+++ b/EurofurenceUITests/UI Automation/AutomationController.swift
@@ -62,6 +62,16 @@ extension AutomationController {
     
 }
 
+// MARK: - Skipping
+
+extension AutomationController {
+    
+    func skipIfTablet(file: StaticString = #file, line: UInt = #line) throws {
+        try XCTSkipIf(isTablet, "Does not apply to iPads", file: file, line: line)
+    }
+    
+}
+
 // MARK: - Selecting Tabs
 
 extension AutomationController {
@@ -130,6 +140,21 @@ extension AutomationController {
         default:
             return 400
         }
+    }
+    
+}
+
+// MARK: - Assertions
+
+extension AutomationController {
+    
+    func assertPlaceholderVisible(file: StaticString = #file, line: UInt = #line) {
+        XCTAssert(
+            app.images["org.eurofurence.NoContentPlaceholder"].exists,
+            "Placeholder view should be visible",
+            file: file,
+            line: line
+        )
     }
     
 }

--- a/Packages/EurofurenceComponents/Sources/ComponentBase/Branding/BrandedSplitViewController.swift
+++ b/Packages/EurofurenceComponents/Sources/ComponentBase/Branding/BrandedSplitViewController.swift
@@ -61,14 +61,26 @@ public class BrandedSplitViewController: UISplitViewController, UISplitViewContr
         guard navigationController.viewControllers.count > 1 else { return nil }
         guard let lastViewController = navigationController.popViewController(animated: false) else { return nil }
         
-        let separatedViewController: UIViewController
-        if let embeddedNavigationController = lastViewController as? UINavigationController {
-            separatedViewController = embeddedNavigationController
+        let secondaryViewController: UIViewController
+        if lastViewController is PrimaryContentPane {
+            // The terminal view controller should move back into the primary pane of the split view, instead of being
+            // moved into the secondary pane.
+            navigationController.pushViewController(lastViewController, animated: false)
+            
+            // As there are no further children to disclose into the secondary pane, use the placeholder view.
+            let noContentViewController = NoContentPlaceholderViewController.fromStoryboard()
+            secondaryViewController = UINavigationController(rootViewController: noContentViewController)
         } else {
-            separatedViewController = UINavigationController(rootViewController: lastViewController)
+            // The terminal view controller should be shifted into the secondary pane. All preceding children contained
+            // in the navigation view will remain in the priary pane.
+            if let embeddedNavigationController = lastViewController as? UINavigationController {
+                secondaryViewController = embeddedNavigationController
+            } else {
+                secondaryViewController = UINavigationController(rootViewController: lastViewController)
+            }
         }
         
-        return separatedViewController
+        return secondaryViewController
     }
     
     private func isPlaceholderContentController(_ viewController: UIViewController) -> Bool {

--- a/Packages/EurofurenceComponents/Sources/ComponentBase/Branding/PrimaryContentPane.swift
+++ b/Packages/EurofurenceComponents/Sources/ComponentBase/Branding/PrimaryContentPane.swift
@@ -1,0 +1,4 @@
+import UIKit
+
+/// Designates the receiver as a container that prefers to reside in the primary split view pane.
+public protocol PrimaryContentPane: UIContentContainer { }

--- a/Packages/EurofurenceComponents/Sources/ComponentBase/No Content Placeholder/NoContentPlaceholderViewController.swift
+++ b/Packages/EurofurenceComponents/Sources/ComponentBase/No Content Placeholder/NoContentPlaceholderViewController.swift
@@ -7,11 +7,11 @@ public class NoContentPlaceholderViewController: UIViewController {
         return storyboard.instantiate(NoContentPlaceholderViewController.self)
     }
     
-    @IBOutlet private weak var placeholderImageView: UIImageView!
-    
-    override public func viewDidLoad() {
-        super.viewDidLoad()
-        placeholderImageView.tintColor = .placeholder
+    @IBOutlet private weak var placeholderImageView: UIImageView! {
+        didSet {
+            placeholderImageView.accessibilityIdentifier = "org.eurofurence.NoContentPlaceholder"
+            placeholderImageView.tintColor = .placeholder
+        }
     }
     
 }

--- a/Packages/EurofurenceComponents/Sources/KnowledgeGroupComponent/Scene/UIKit/KnowledgeGroupEntriesViewController.swift
+++ b/Packages/EurofurenceComponents/Sources/KnowledgeGroupComponent/Scene/UIKit/KnowledgeGroupEntriesViewController.swift
@@ -1,6 +1,7 @@
+import ComponentBase
 import UIKit
 
-class KnowledgeGroupEntriesViewController: UITableViewController, KnowledgeGroupEntriesScene {
+class KnowledgeGroupEntriesViewController: UITableViewController, KnowledgeGroupEntriesScene, PrimaryContentPane {
 
     // MARK: Overrides
 


### PR DESCRIPTION
Add capability to strongly define whether a view controller desires to reside in the primary pane, and avoid shunting it into the secondary pane when expanding the split view controller into two panes.

Fixes #448