### PR TITLE
Persist selection states; drop previously dismissed content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ Screenshots/de-DE/
 Screenshots/en-US/
 Screenshots/screenshots.html
 
+/EurofurenceUITests/Resources/TestAccountCredentials.plist

--- a/.gitignore
+++ b/.gitignore
@@ -67,5 +67,3 @@ fastlane/report.xml
 Screenshots/de-DE/
 Screenshots/en-US/
 Screenshots/screenshots.html
-
-/EurofurenceUITests/Resources/TestAccountCredentials.plist

--- a/Eurofurence.xcodeproj/project.pbxproj
+++ b/Eurofurence.xcodeproj/project.pbxproj
@@ -72,6 +72,13 @@
 		CA8F7D2F256182EF0096E206 /* WidgetKitConformances.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA8F7D2E256182EF0096E206 /* WidgetKitConformances.swift */; };
 		CA9768DD25FE39C6001AE029 /* EurofurenceApplicationSession in Frameworks */ = {isa = PBXBuildFile; productRef = CA9768DC25FE39C6001AE029 /* EurofurenceApplicationSession */; };
 		CA9768FB25FE3A81001AE029 /* EurofurenceModel in Frameworks */ = {isa = PBXBuildFile; productRef = CA9768FA25FE3A81001AE029 /* EurofurenceModel */; };
+		CAA53E1B2874DEE800FC5925 /* NewsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA53E1A2874DEE800FC5925 /* NewsTests.swift */; };
+		CAA53E1D2874E32100FC5925 /* TestAccountCredentials.plist in Resources */ = {isa = PBXBuildFile; fileRef = CAA53E1C2874E32100FC5925 /* TestAccountCredentials.plist */; };
+		CAA53E202875682D00FC5925 /* TestResources.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA53E1F2875682D00FC5925 /* TestResources.swift */; };
+		CAA53E21287568A200FC5925 /* NewsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA53E1A2874DEE800FC5925 /* NewsTests.swift */; };
+		CAA53E22287568A300FC5925 /* NewsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA53E1A2874DEE800FC5925 /* NewsTests.swift */; };
+		CAA53E23287568C800FC5925 /* TestResources.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA53E1F2875682D00FC5925 /* TestResources.swift */; };
+		CAA53E24287568C900FC5925 /* TestResources.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA53E1F2875682D00FC5925 /* TestResources.swift */; };
 		CAA5E5512854F11700FA4FB0 /* SmallEventsWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA5E5502854F11700FA4FB0 /* SmallEventsWidget.swift */; };
 		CAA5E5532854F13B00FA4FB0 /* LargeCalendarIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA5E5522854F13B00FA4FB0 /* LargeCalendarIcon.swift */; };
 		CAA5E5552854F14A00FA4FB0 /* EntryEventsCountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA5E5542854F14A00FA4FB0 /* EntryEventsCountView.swift */; };
@@ -311,6 +318,9 @@
 		CA9845C91F2907A800E8821D /* ScreenshotGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotGenerator.swift; sourceTree = "<group>"; };
 		CA9845D21F2909DB00E8821D /* SnapshotHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SnapshotHelper.swift; sourceTree = "<group>"; };
 		CAA4EFF5265C5003002CBDA6 /* Unit Tests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = "Unit Tests.xctestplan"; sourceTree = "<group>"; };
+		CAA53E1A2874DEE800FC5925 /* NewsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsTests.swift; sourceTree = "<group>"; };
+		CAA53E1C2874E32100FC5925 /* TestAccountCredentials.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = TestAccountCredentials.plist; sourceTree = "<group>"; };
+		CAA53E1F2875682D00FC5925 /* TestResources.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestResources.swift; sourceTree = "<group>"; };
 		CAA5E5502854F11700FA4FB0 /* SmallEventsWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmallEventsWidget.swift; sourceTree = "<group>"; };
 		CAA5E5522854F13B00FA4FB0 /* LargeCalendarIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeCalendarIcon.swift; sourceTree = "<group>"; };
 		CAA5E5542854F14A00FA4FB0 /* EntryEventsCountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryEventsCountView.swift; sourceTree = "<group>"; };
@@ -702,6 +712,14 @@
 			path = "Logic Adapter";
 			sourceTree = "<group>";
 		};
+		CAA53E1E2874E32900FC5925 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				CAA53E1C2874E32100FC5925 /* TestAccountCredentials.plist */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
 		CAA5E5582854F25C00FA4FB0 /* Modifiers */ = {
 			isa = PBXGroup;
 			children = (
@@ -757,7 +775,9 @@
 				CAF2552E251A6DC4008892ED /* EventDetailTests.swift */,
 				CAB7ABC828730E230037ACFB /* KnowledgeTests.swift */,
 				CAF254AC2517F983008892ED /* LaunchPerformanceTest.swift */,
+				CAA53E1A2874DEE800FC5925 /* NewsTests.swift */,
 				CABBCA2F2566FE0B007A11A2 /* SplitViewDetailBugTests.swift */,
+				CAA53E1E2874E32900FC5925 /* Resources */,
 				CAF254FD2517FB47008892ED /* UI Automation */,
 			);
 			path = EurofurenceUITests;
@@ -767,6 +787,7 @@
 			isa = PBXGroup;
 			children = (
 				CAF254FE2517FB65008892ED /* AutomationController.swift */,
+				CAA53E1F2875682D00FC5925 /* TestResources.swift */,
 				CAF25567251A8774008892ED /* UIAutomationTestCase.swift */,
 			);
 			path = "UI Automation";
@@ -1153,6 +1174,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CAA53E1D2874E32100FC5925 /* TestAccountCredentials.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1250,8 +1272,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				CAF2556D251A877A008892ED /* UIAutomationTestCase.swift in Sources */,
+				CAA53E23287568C800FC5925 /* TestResources.swift in Sources */,
 				CA25A89C22C4101D00226478 /* ScreenshotGenerator.swift in Sources */,
 				CA25A89D22C4101D00226478 /* SnapshotHelper.swift in Sources */,
+				CAA53E21287568A200FC5925 /* NewsTests.swift in Sources */,
 				CAF255082517FB92008892ED /* AutomationController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1334,8 +1358,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				CA04437B26DEBC63008CC04F /* UIAutomationTestCase.swift in Sources */,
+				CAA53E24287568C900FC5925 /* TestResources.swift in Sources */,
 				CA04437A26DEBC63008CC04F /* AutomationController.swift in Sources */,
 				CA7A2F152606BCB400919DA0 /* Eurofurence_Clip_UITests.swift in Sources */,
+				CAA53E22287568A300FC5925 /* NewsTests.swift in Sources */,
 				CA04437D26DEBC7E008CC04F /* EurofurenceClip_EventDetailTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1362,7 +1388,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				CAF254FF2517FB65008892ED /* AutomationController.swift in Sources */,
+				CAA53E202875682D00FC5925 /* TestResources.swift in Sources */,
 				CAF25568251A8774008892ED /* UIAutomationTestCase.swift in Sources */,
+				CAA53E1B2874DEE800FC5925 /* NewsTests.swift in Sources */,
 				CAB7ABC928730E230037ACFB /* KnowledgeTests.swift in Sources */,
 				CAF2552F251A6DC4008892ED /* EventDetailTests.swift in Sources */,
 				CA26503D25F7D3EB0080F132 /* DealerSearchTests.swift in Sources */,

--- a/Eurofurence.xcodeproj/project.pbxproj
+++ b/Eurofurence.xcodeproj/project.pbxproj
@@ -75,8 +75,6 @@
 		CAA53E1B2874DEE800FC5925 /* NewsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA53E1A2874DEE800FC5925 /* NewsTests.swift */; };
 		CAA53E1D2874E32100FC5925 /* TestAccountCredentials.plist in Resources */ = {isa = PBXBuildFile; fileRef = CAA53E1C2874E32100FC5925 /* TestAccountCredentials.plist */; };
 		CAA53E202875682D00FC5925 /* TestResources.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA53E1F2875682D00FC5925 /* TestResources.swift */; };
-		CAA53E21287568A200FC5925 /* NewsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA53E1A2874DEE800FC5925 /* NewsTests.swift */; };
-		CAA53E22287568A300FC5925 /* NewsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA53E1A2874DEE800FC5925 /* NewsTests.swift */; };
 		CAA53E23287568C800FC5925 /* TestResources.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA53E1F2875682D00FC5925 /* TestResources.swift */; };
 		CAA53E24287568C900FC5925 /* TestResources.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA53E1F2875682D00FC5925 /* TestResources.swift */; };
 		CAA5E5512854F11700FA4FB0 /* SmallEventsWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA5E5502854F11700FA4FB0 /* SmallEventsWidget.swift */; };
@@ -1275,7 +1273,6 @@
 				CAA53E23287568C800FC5925 /* TestResources.swift in Sources */,
 				CA25A89C22C4101D00226478 /* ScreenshotGenerator.swift in Sources */,
 				CA25A89D22C4101D00226478 /* SnapshotHelper.swift in Sources */,
-				CAA53E21287568A200FC5925 /* NewsTests.swift in Sources */,
 				CAF255082517FB92008892ED /* AutomationController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1361,7 +1358,6 @@
 				CAA53E24287568C900FC5925 /* TestResources.swift in Sources */,
 				CA04437A26DEBC63008CC04F /* AutomationController.swift in Sources */,
 				CA7A2F152606BCB400919DA0 /* Eurofurence_Clip_UITests.swift in Sources */,
-				CAA53E22287568A300FC5925 /* NewsTests.swift in Sources */,
 				CA04437D26DEBC7E008CC04F /* EurofurenceClip_EventDetailTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/EurofurenceUITests/NewsTests.swift
+++ b/EurofurenceUITests/NewsTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+
+class NewsTests: UIAutomationTestCase {
+    
+    func testMessagesListingDoesNotAppearInSecondaryPane() throws {
+        try controller.skipIfTablet()
+        
+        XCUIDevice.shared.orientation = .portrait
+        controller.app.launch()
+        controller.transitionToContent()
+        try controller.naivgateToMessages()
+        XCUIDevice.shared.orientation = .landscapeLeft
+        
+        let messagesNavigationBar = controller.app.navigationBars["Messages"]
+        XCTAssertTrue(messagesNavigationBar.exists, "Messages should still be visible when rotated into landscape")
+        
+        let newsNavigationBar = controller.app.navigationBars["News"]
+        XCTAssertFalse(newsNavigationBar.exists, "Messages should be inserted into the primary pane")
+    }
+    
+}

--- a/EurofurenceUITests/Resources/TestAccountCredentials.plist
+++ b/EurofurenceUITests/Resources/TestAccountCredentials.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>registrationNumber</key>
+	<string>UNSET</string>
+	<key>password</key>
+	<string>UNSET</string>
+	<key>username</key>
+	<string>UNSET</string>
+</dict>
+</plist>

--- a/EurofurenceUITests/UI Automation/AutomationController.swift
+++ b/EurofurenceUITests/UI Automation/AutomationController.swift
@@ -62,6 +62,33 @@ extension AutomationController {
     
 }
 
+// MARK: - Finding Elements
+
+extension AutomationController {
+    
+    private func wait(
+        for element: XCUIElement,
+        timeout: TimeInterval = 60,
+        search: () -> Void = {}
+    ) throws {
+        struct TimedOutWaitingForElement: Error {
+            var element: XCUIElement
+        }
+        
+        let startTime = Date()
+        let upperTimeLimit = startTime.addingTimeInterval(timeout)
+        while !element.isHittable {
+            let now = Date()
+            if now < upperTimeLimit {
+                search()
+            } else {
+                throw TimedOutWaitingForElement(element: element)
+            }
+        }
+    }
+    
+}
+
 // MARK: - Skipping
 
 extension AutomationController {
@@ -110,23 +137,19 @@ extension AutomationController {
 extension AutomationController {
     
     func tapCellWithText(_ text: String) throws {
-        struct TimedOutFindingText: Error {
+        struct TextNotFound: Error {
             var text: String
         }
         
         let table = app.tables.firstMatch
         let textElement = table.staticTexts[text]
         
-        let startTime = Date()
-        let timeout: TimeInterval = 60
-        let upperTimeLimit = startTime.addingTimeInterval(timeout)
-        while textElement.isHittable == false {
-            let now = Date()
-            if now < upperTimeLimit {
+        do {
+            try wait(for: textElement) {
                 table.swipeUp(velocity: verticalSwipeVelocity)
-            } else {
-                throw TimedOutFindingText(text: text)
             }
+        } catch {
+            throw TextNotFound(text: text)
         }
         
         textElement.tap()
@@ -140,6 +163,62 @@ extension AutomationController {
         default:
             return 400
         }
+    }
+    
+}
+
+// MARK: - Authenticating
+
+extension AutomationController {
+    
+    func naivgateToMessages() throws {
+        switch try ensureAuthenticated() {
+        case .authenticated:
+            // Signing in opens Messages; do nothing
+            break
+            
+        case .alreadyAuthenticated:
+            let credentials = try TestResources.loadTestCredentials()
+            try tapCellWithText("Welcome, \(credentials.username) (\(credentials.registrationNumber))")
+        }
+    }
+    
+    enum AuthenticationFlow {
+        case authenticated
+        case alreadyAuthenticated
+    }
+    
+    func ensureAuthenticated() throws -> AuthenticationFlow {
+        let signInPrompt = app.staticTexts["You are currently not logged in"]
+        guard signInPrompt.exists else { return .alreadyAuthenticated }
+        
+        signInPrompt.tap()
+        
+        let credentials = try TestResources.loadTestCredentials()
+        
+        let usernameText = app.textFields["org.eurofurence.login.username"]
+        try wait(for: usernameText)
+        usernameText.tap()
+        usernameText.typeText(credentials.username)
+        
+        let registrationNumberText = app.textFields["org.eurofurence.login.registration-number"]
+        registrationNumberText.tap()
+        registrationNumberText.typeText(credentials.registrationNumber)
+        
+        let passwordText = app.secureTextFields["org.eurofurence.login.password"]
+        passwordText.tap()
+        passwordText.typeText(credentials.password)
+        
+        let loginButton = app.buttons["org.eurofurence.login.confirm-button"]
+        loginButton.tap()
+        
+        // In compact size classes: the messages screen is now visible
+        // In regular size classes: the news screen and the messages screen is now visible
+        
+        let messagesNavigationTitle = app.navigationBars["Messages"]
+        try wait(for: messagesNavigationTitle)
+        
+        return .authenticated
     }
     
 }

--- a/EurofurenceUITests/UI Automation/AutomationController.swift
+++ b/EurofurenceUITests/UI Automation/AutomationController.swift
@@ -68,7 +68,7 @@ extension AutomationController {
     
     private func wait(
         for element: XCUIElement,
-        timeout: TimeInterval = 60,
+        timeout: TimeInterval = 120,
         search: () -> Void = {}
     ) throws {
         struct TimedOutWaitingForElement: Error {

--- a/EurofurenceUITests/UI Automation/TestResources.swift
+++ b/EurofurenceUITests/UI Automation/TestResources.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+struct TestResources {
+    
+    private static func loadResource(fileName: String, fileExtension: String) throws -> Data {
+        class BundleScope { }
+        
+        struct MissingResourceError: Error {
+            var fileName: String
+            var fileExtension: String
+        }
+        
+        let bundle = Bundle(for: BundleScope.self)
+        guard let testAccountCredentialsFileURL = bundle.url(forResource: fileName, withExtension: fileExtension) else {
+            throw MissingResourceError(fileName: fileName, fileExtension: fileExtension)
+        }
+        
+        return try Data(contentsOf: testAccountCredentialsFileURL)
+    }
+    
+}
+
+// MARK: - Credentials
+
+extension TestResources {
+    
+    struct Credentials: Decodable {
+        var username: String
+        var password: String
+        var registrationNumber: String
+    }
+    
+    static func loadTestCredentials() throws -> Credentials {
+        let data = try loadResource(fileName: "TestAccountCredentials", fileExtension: "plist")
+        let decoder = PropertyListDecoder()
+        
+        return try decoder.decode(Credentials.self, from: data)
+    }
+    
+}

--- a/EurofurenceUITests/UI Automation/TestResources.swift
+++ b/EurofurenceUITests/UI Automation/TestResources.swift
@@ -28,13 +28,25 @@ extension TestResources {
         var username: String
         var password: String
         var registrationNumber: String
+        
+        fileprivate func validate() throws {
+            struct UnsetCredential: Error {}
+            
+            let values = Set([username, password, registrationNumber])
+            if values.contains("UNSET") {
+                throw UnsetCredential()
+            }
+        }
     }
     
     static func loadTestCredentials() throws -> Credentials {
         let data = try loadResource(fileName: "TestAccountCredentials", fileExtension: "plist")
         let decoder = PropertyListDecoder()
         
-        return try decoder.decode(Credentials.self, from: data)
+        let credentials = try decoder.decode(Credentials.self, from: data)
+        try credentials.validate()
+        
+        return credentials
     }
     
 }

--- a/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Announcements/View/UIKit/AnnouncementsViewController.swift
+++ b/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Announcements/View/UIKit/AnnouncementsViewController.swift
@@ -1,6 +1,7 @@
+import ComponentBase
 import UIKit
 
-class AnnouncementsViewController: UIViewController, AnnouncementsScene {
+class AnnouncementsViewController: UIViewController, AnnouncementsScene, PrimaryContentPane {
 
     // MARK: Properties
 

--- a/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Login/View/LoginViewController.swift
+++ b/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Login/View/LoginViewController.swift
@@ -5,11 +5,31 @@ class LoginViewController: UITableViewController, UITextFieldDelegate, LoginScen
 
     // MARK: IBOutlets
 
-    @IBOutlet private weak var loginButton: UIButton!
+    @IBOutlet private weak var loginButton: UIButton! {
+        didSet {
+            loginButton.accessibilityIdentifier = "org.eurofurence.login.confirm-button"
+        }
+    }
+    
     @IBOutlet private weak var cancelButton: UIBarButtonItem!
-    @IBOutlet private weak var registrationNumberTextField: UITextField!
-    @IBOutlet private weak var usernameTextField: UITextField!
-    @IBOutlet private weak var passwordTextField: UITextField!
+    
+    @IBOutlet private weak var registrationNumberTextField: UITextField! {
+        didSet {
+            registrationNumberTextField.accessibilityIdentifier = "org.eurofurence.login.registration-number"
+        }
+    }
+    
+    @IBOutlet private weak var usernameTextField: UITextField! {
+        didSet {
+            usernameTextField.accessibilityIdentifier = "org.eurofurence.login.username"
+        }
+    }
+    
+    @IBOutlet private weak var passwordTextField: UITextField! {
+        didSet {
+            passwordTextField.accessibilityIdentifier = "org.eurofurence.login.password"
+        }
+    }
 
     // MARK: IBActions
 

--- a/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Messages/View/MessagesViewController.swift
+++ b/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Messages/View/MessagesViewController.swift
@@ -37,12 +37,6 @@ class MessagesViewController: UIViewController, UITableViewDelegate, MessagesSce
         
         delegate?.messagesSceneReady()
     }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        
-        tableView.reloadData()
-    }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         delegate?.messagesSceneDidSelectMessage(at: indexPath)

--- a/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Messages/View/MessagesViewController.swift
+++ b/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Messages/View/MessagesViewController.swift
@@ -31,7 +31,10 @@ class MessagesViewController: UIViewController, UITableViewDelegate, MessagesSce
         tableView.dataSource = dataSource
         tableView.delegate = self
         tableView.addSubview(refreshIndicator)
+        
         navigationItem.rightBarButtonItem = logoutBarButtonItem
+        logoutBarButtonItem.accessibilityIdentifier = "org.eurofurence.messages.logout-button"
+        
         delegate?.messagesSceneReady()
     }
     

--- a/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Messages/View/MessagesViewController.swift
+++ b/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Messages/View/MessagesViewController.swift
@@ -1,7 +1,7 @@
 import ComponentBase
 import UIKit
 
-class MessagesViewController: UIViewController, UITableViewDelegate, MessagesScene {
+class MessagesViewController: UIViewController, UITableViewDelegate, MessagesScene, PrimaryContentPane {
     
     deinit {
         delegate?.messagesSceneFinalizing()

--- a/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/News/View/CompositionalTableViewDataSource.swift
+++ b/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/News/View/CompositionalTableViewDataSource.swift
@@ -100,8 +100,6 @@ extension CompositionalTableViewDataSource: UITableViewDataSource {
 extension CompositionalTableViewDataSource: UITableViewDelegate {
     
     public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        tableView.deselectRow(at: indexPath, animated: true)
-        
         let mediator = mediators[indexPath.section]
         mediator.tableView?(tableView, didSelectRowAt: indexPath)
     }

--- a/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/News/Widgets/Announcements/View/AnnouncementsNewsWidgetTableViewDataSource.swift
+++ b/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/News/Widgets/Announcements/View/AnnouncementsNewsWidgetTableViewDataSource.swift
@@ -80,6 +80,7 @@ public class AnnouncementsNewsWidgetTableViewDataSource<
         
         switch visualElement {
         case .showMoreAnnouncements:
+            tableView.deselectRow(at: indexPath, animated: true)
             viewModel.openAllAnnouncements()
             
         case .announcement(let announcement):

--- a/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/News/Widgets/Your Eurofurence/View/YourEurofurenceWidgetTableViewDataSource.swift
+++ b/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/News/Widgets/Your Eurofurence/View/YourEurofurenceWidgetTableViewDataSource.swift
@@ -49,6 +49,7 @@ public class YourEurofurenceWidgetTableViewDataSource<
     }
     
     public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
         viewModel.showPersonalisedContent()
     }
     

--- a/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Content Router/Routes/News/ResetNewsAfterLogout.swift
+++ b/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Content Router/Routes/News/ResetNewsAfterLogout.swift
@@ -27,18 +27,20 @@ struct ResetNewsAfterLogout: NewsPresentation {
         tabBarController.selectedIndex = newsControllerIndex
         newsNavigationController.popToRootViewController(animated: UIView.areAnimationsEnabled)
         
-        if let detailNavigation = newsSplitViewController.viewControllers.last as? UINavigationController {
-            let navigationStack = detailNavigation.viewControllers
-            let nonMessageControllers = navigationStack.filter({ (viewController) in
-                (viewController is MessageDetailViewController || viewController is MessagesViewController) == false
-            })
-            
-            if nonMessageControllers.isEmpty {
-                let placeholderViewController = NoContentPlaceholderViewController.fromStoryboard()
-                newsSplitViewController.viewControllers = [newsNavigationController, placeholderViewController]
-            } else {
-                detailNavigation.setViewControllers(nonMessageControllers, animated: UIView.areAnimationsEnabled)
-            }
+        let secondaryViewController = newsSplitViewController.viewControllers.last
+        guard let detailNavigation = secondaryViewController as? UINavigationController else { return }
+        
+        let navigationStack = detailNavigation.viewControllers
+        let nonMessageControllers = navigationStack.filter({ (viewController) in
+            (viewController is MessageDetailViewController || viewController is MessagesViewController) == false
+        })
+        
+        if nonMessageControllers.isEmpty {
+            let placeholderController = NoContentPlaceholderViewController.fromStoryboard()
+            let placeholderNavigationController = UINavigationController(rootViewController: placeholderController)
+            newsSplitViewController.viewControllers = [newsNavigationController, placeholderNavigationController]
+        } else {
+            detailNavigation.setViewControllers(nonMessageControllers, animated: UIView.areAnimationsEnabled)
         }
     }
     

--- a/Packages/EurofurenceComponents/Sources/ComponentBase/Branding/BrandedNavigationController.swift
+++ b/Packages/EurofurenceComponents/Sources/ComponentBase/Branding/BrandedNavigationController.swift
@@ -18,13 +18,13 @@ public class BrandedNavigationController: UINavigationController {
     
     override public var viewControllers: [UIViewController] {
         didSet {
-            clearSelectionWhenSingleControllerRemaining(animated: false)
+            clearSelectionInTopmostViewController(animated: false)
         }
     }
     
     override public func popViewController(animated: Bool) -> UIViewController? {
         let viewController = super.popViewController(animated: animated)
-        clearSelectionWhenSingleControllerRemaining(animated: animated)
+        clearSelectionInTopmostViewController(animated: animated)
         
         return viewController
     }
@@ -34,14 +34,14 @@ public class BrandedNavigationController: UINavigationController {
         animated: Bool
     ) -> [UIViewController]? {
         let viewControllers = super.popToViewController(viewController, animated: animated)
-        clearSelectionWhenSingleControllerRemaining(animated: animated)
+        clearSelectionInTopmostViewController(animated: animated)
         
         return viewControllers
     }
     
     override public func popToRootViewController(animated: Bool) -> [UIViewController]? {
         let viewControllers = super.popToRootViewController(animated: animated)
-        clearSelectionWhenSingleControllerRemaining(animated: animated)
+        clearSelectionInTopmostViewController(animated: animated)
         
         return viewControllers
     }
@@ -50,9 +50,9 @@ public class BrandedNavigationController: UINavigationController {
         super.popViewController(animated: false)
     }
     
-    private func clearSelectionWhenSingleControllerRemaining(animated: Bool) {
-        guard let first = viewControllers.first, viewControllers.count == 1 else { return }
-        guard let tableView = findTableView(in: first.view) else { return }
+    private func clearSelectionInTopmostViewController(animated: Bool) {
+        guard let topViewController = topViewController else { return }
+        guard let tableView = findTableView(in: topViewController.view) else { return }
         guard let selectedIndexPath = tableView.indexPathForSelectedRow else { return }
         
         tableView.deselectRow(at: selectedIndexPath, animated: animated)

--- a/Packages/EurofurenceComponents/Sources/ComponentBase/Branding/BrandedNavigationController.swift
+++ b/Packages/EurofurenceComponents/Sources/ComponentBase/Branding/BrandedNavigationController.swift
@@ -16,4 +16,60 @@ public class BrandedNavigationController: UINavigationController {
         navigationBar.prefersLargeTitles = true
     }
     
+    override public var viewControllers: [UIViewController] {
+        didSet {
+            clearSelectionWhenSingleControllerRemaining(animated: false)
+        }
+    }
+    
+    override public func popViewController(animated: Bool) -> UIViewController? {
+        let viewController = super.popViewController(animated: animated)
+        clearSelectionWhenSingleControllerRemaining(animated: animated)
+        
+        return viewController
+    }
+    
+    override public func popToViewController(
+        _ viewController: UIViewController,
+        animated: Bool
+    ) -> [UIViewController]? {
+        let viewControllers = super.popToViewController(viewController, animated: animated)
+        clearSelectionWhenSingleControllerRemaining(animated: animated)
+        
+        return viewControllers
+    }
+    
+    override public func popToRootViewController(animated: Bool) -> [UIViewController]? {
+        let viewControllers = super.popToRootViewController(animated: animated)
+        clearSelectionWhenSingleControllerRemaining(animated: animated)
+        
+        return viewControllers
+    }
+    
+    func popLastWithoutClearingSelection() -> UIViewController? {
+        super.popViewController(animated: false)
+    }
+    
+    private func clearSelectionWhenSingleControllerRemaining(animated: Bool) {
+        guard let first = viewControllers.first, viewControllers.count == 1 else { return }
+        guard let tableView = findTableView(in: first.view) else { return }
+        guard let selectedIndexPath = tableView.indexPathForSelectedRow else { return }
+        
+        tableView.deselectRow(at: selectedIndexPath, animated: animated)
+    }
+    
+    private func findTableView(in view: UIView) -> UITableView? {
+        if let tableView = view as? UITableView {
+            return tableView
+        } else {
+            for subview in view.subviews {
+                if let tableView = findTableView(in: subview) {
+                    return tableView
+                }
+            }
+            
+            return nil
+        }
+    }
+    
 }

--- a/Packages/EurofurenceComponents/Sources/ComponentBase/Branding/BrandedSplitViewController.swift
+++ b/Packages/EurofurenceComponents/Sources/ComponentBase/Branding/BrandedSplitViewController.swift
@@ -50,44 +50,73 @@ public class BrandedSplitViewController: UISplitViewController, UISplitViewContr
         collapseSecondary secondaryViewController: UIViewController,
         onto primaryViewController: UIViewController
     ) -> Bool {
-        isPlaceholderContentController(secondaryViewController)
+        // Collapsing works as follows: the primary view controller consumes the secondary view controller, unless it
+        // is a navigation controller. Instead, it consumes all of the secondary view cotroller's children. The only
+        // exception is placeholder controllers, which are discarded.
+        guard let primaryNavigationController = primaryViewController as? UINavigationController else { return false }
+        
+        var viewControllers = [UIViewController]()
+        if let secondaryNavigationController = secondaryViewController as? UINavigationController {
+            viewControllers = secondaryNavigationController.viewControllers
+        } else {
+            viewControllers = [secondaryViewController]
+        }
+        
+        viewControllers.removeAll(where: { $0 is NoContentPlaceholderViewController })
+        for viewController in viewControllers {
+            primaryNavigationController.pushViewController(viewController, animated: false)
+        }
+        
+        return true
     }
     
     public func splitViewController(
         _ splitViewController: UISplitViewController,
         separateSecondaryFrom primaryViewController: UIViewController
     ) -> UIViewController? {
+        // Seperating works as follows: the primary view controller is expected to be navigation controller composed
+        // of the primary content controller and, optionally, zero to many secondary controllers. The primary view
+        // controllers will remain in the primary panel, with all secondary view controllers moved into the secondary
+        // panel.
+        // In the event the primary view controller is composed of a singular view controller (e.g. no content has
+        // been disclosed yet), the secondary panel will instead house a new placeholder view controller.
         guard let navigationController = primaryViewController as? UINavigationController else { return nil }
-        guard navigationController.viewControllers.count > 1 else { return nil }
-        guard let lastViewController = navigationController.viewControllers.last else { return nil }
         
-        let secondaryViewController: UIViewController
-        if lastViewController is PrimaryContentPane {
-            // The terminal view controller should move back into the primary pane of the split view, instead of being
-            // moved into the secondary pane.
-            // As there are no further children to disclose into the secondary pane, use the placeholder view.
-            let noContentViewController = NoContentPlaceholderViewController.fromStoryboard()
-            secondaryViewController = UINavigationController(rootViewController: noContentViewController)
+        if navigationController.viewControllers.count == 1 {
+            // Only one view controller exists - the secondary panel should house a new placeholder controller.
+            let noContentController = NoContentPlaceholderViewController.fromStoryboard()
+            return UINavigationController(rootViewController: noContentController)
         } else {
-            // The terminal view controller should be shifted into the secondary pane. All preceding children contained
-            // in the navigation view will remain in the primary pane.
-            let terminalViewController: UIViewController?
-            if let brandedNavigationController = navigationController as? BrandedNavigationController {
-                terminalViewController = brandedNavigationController.popLastWithoutClearingSelection()
+            guard let lastViewController = navigationController.viewControllers.last else { return nil }
+            
+            let secondaryViewController: UIViewController
+            if lastViewController is PrimaryContentPane {
+                // The terminal view controller should move back into the primary pane of the split view, instead of
+                // being moved into the secondary pane.
+                // As there are no further children to disclose into the secondary pane, use the placeholder view.
+                let noContentViewController = NoContentPlaceholderViewController.fromStoryboard()
+                secondaryViewController = UINavigationController(rootViewController: noContentViewController)
             } else {
-                terminalViewController = navigationController.popViewController(animated: false)
+                // The terminal view controller should be shifted into the secondary pane. All preceding children
+                // contained in the navigation view will remain in the primary pane.
+                let terminalViewController: UIViewController?
+                if let brandedNavigationController = navigationController as? BrandedNavigationController {
+                    terminalViewController = brandedNavigationController.popLastWithoutClearingSelection()
+                } else {
+                    terminalViewController = navigationController.popViewController(animated: false)
+                }
+                
+                guard let viewControllerToShift = terminalViewController else { return nil }
+                
+                if viewControllerToShift is UINavigationController {
+                    secondaryViewController = viewControllerToShift
+                } else {
+                    secondaryViewController = UINavigationController(rootViewController: viewControllerToShift)
+                }
             }
             
-            guard let viewControllerToShift = terminalViewController else { return nil }
-            
-            if viewControllerToShift is UINavigationController {
-                secondaryViewController = viewControllerToShift
-            } else {
-                secondaryViewController = UINavigationController(rootViewController: viewControllerToShift)
-            }
+            return secondaryViewController
         }
-        
-        return secondaryViewController
     }
     
     private func isPlaceholderContentController(_ viewController: UIViewController) -> Bool {

--- a/Packages/EurofurenceComponents/Sources/ComponentBase/Branding/BrandedSplitViewController.swift
+++ b/Packages/EurofurenceComponents/Sources/ComponentBase/Branding/BrandedSplitViewController.swift
@@ -59,24 +59,31 @@ public class BrandedSplitViewController: UISplitViewController, UISplitViewContr
     ) -> UIViewController? {
         guard let navigationController = primaryViewController as? UINavigationController else { return nil }
         guard navigationController.viewControllers.count > 1 else { return nil }
-        guard let lastViewController = navigationController.popViewController(animated: false) else { return nil }
+        guard let lastViewController = navigationController.viewControllers.last else { return nil }
         
         let secondaryViewController: UIViewController
         if lastViewController is PrimaryContentPane {
             // The terminal view controller should move back into the primary pane of the split view, instead of being
             // moved into the secondary pane.
-            navigationController.pushViewController(lastViewController, animated: false)
-            
             // As there are no further children to disclose into the secondary pane, use the placeholder view.
             let noContentViewController = NoContentPlaceholderViewController.fromStoryboard()
             secondaryViewController = UINavigationController(rootViewController: noContentViewController)
         } else {
             // The terminal view controller should be shifted into the secondary pane. All preceding children contained
-            // in the navigation view will remain in the priary pane.
-            if let embeddedNavigationController = lastViewController as? UINavigationController {
-                secondaryViewController = embeddedNavigationController
+            // in the navigation view will remain in the primary pane.
+            let terminalViewController: UIViewController?
+            if let brandedNavigationController = navigationController as? BrandedNavigationController {
+                terminalViewController = brandedNavigationController.popLastWithoutClearingSelection()
             } else {
-                secondaryViewController = UINavigationController(rootViewController: lastViewController)
+                terminalViewController = navigationController.popViewController(animated: false)
+            }
+            
+            guard let viewControllerToShift = terminalViewController else { return nil }
+            
+            if viewControllerToShift is UINavigationController {
+                secondaryViewController = viewControllerToShift
+            } else {
+                secondaryViewController = UINavigationController(rootViewController: viewControllerToShift)
             }
         }
         

--- a/Packages/EurofurenceComponents/Sources/ComponentBase/Extensions/UITableView+Extensions.swift
+++ b/Packages/EurofurenceComponents/Sources/ComponentBase/Extensions/UITableView+Extensions.swift
@@ -50,12 +50,6 @@ extension UITableView {
             horizontalScrollIndicatorInsets.right = -safeAreaInsets.right
         }
     }
-    
-    public func deselectSelectedRow(animated: Bool = false) {
-        if let indexPathForSelectedRow = indexPathForSelectedRow {
-            deselectRow(at: indexPathForSelectedRow, animated: animated)
-        }
-    }
 
     private func abortDueToUnregisteredOrMissingCell<T>(_ type: T.Type, identifier: String) -> Never {
         fatalError("Cell registered with identifier \"\(identifier)\" not present, or not an instance of \(type)")

--- a/Packages/EurofurenceComponents/Sources/DealersComponent/View/UIKit/DealersViewController.swift
+++ b/Packages/EurofurenceComponents/Sources/DealersComponent/View/UIKit/DealersViewController.swift
@@ -54,11 +54,6 @@ public class DealersViewController: UIViewController, DealersScene {
         delegate?.dealersSceneDidLoad()
     }
     
-    override public func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        tableView.deselectSelectedRow()
-    }
-    
     override public func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         tableView?.adjustScrollIndicatorInsetsForSafeAreaCompensation()

--- a/Packages/EurofurenceComponents/Sources/KnowledgeGroupComponent/Scene/UIKit/KnowledgeGroupEntries.storyboard
+++ b/Packages/EurofurenceComponents/Sources/KnowledgeGroupComponent/Scene/UIKit/KnowledgeGroupEntries.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -11,21 +11,21 @@
         <!--Title-->
         <scene sceneID="pEd-ig-wPL">
             <objects>
-                <tableViewController storyboardIdentifier="KnowledgeGroupEntriesViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="Fkx-F6-bqJ" customClass="KnowledgeGroupEntriesViewController" customModule="KnowledgeGroupComponent" sceneMemberID="viewController">
+                <tableViewController storyboardIdentifier="KnowledgeGroupEntriesViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" clearsSelectionOnViewWillAppear="NO" id="Fkx-F6-bqJ" customClass="KnowledgeGroupEntriesViewController" customModule="KnowledgeGroupComponent" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="hl2-mx-D5o">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="KnowledgeListEntryTableViewCell" textLabel="A8I-Hc-b0y" style="IBUITableViewCellStyleDefault" id="ZjT-Nf-OpS" customClass="KnowledgeListEntryTableViewCell" customModule="KnowledgeGroupComponent">
-                                <rect key="frame" x="0.0" y="28" width="375" height="43.5"/>
+                                <rect key="frame" x="0.0" y="44.5" width="375" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ZjT-Nf-OpS" id="hHc-Xp-ISB">
-                                    <rect key="frame" x="0.0" y="0.0" width="348" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="350.5" height="43.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="A8I-Hc-b0y">
-                                            <rect key="frame" x="16" y="0.0" width="324" height="43.5"/>
+                                            <rect key="frame" x="16" y="0.0" width="326.5" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>

--- a/Packages/EurofurenceComponents/Sources/KnowledgeGroupsComponent/Presenter/KnowledgeGroupsListPresenter.swift
+++ b/Packages/EurofurenceComponents/Sources/KnowledgeGroupsComponent/Presenter/KnowledgeGroupsListPresenter.swift
@@ -31,7 +31,6 @@ class KnowledgeGroupsListPresenter: KnowledgeListSceneDelegate, KnowledgeGroupsL
     }
 
     func knowledgeListSceneDidSelectKnowledgeGroup(at groupIndex: Int) {
-        scene.deselectKnowledgeEntry(at: IndexPath(item: groupIndex, section: 0))
         viewModel?.describeContentsOfKnowledgeItem(at: groupIndex, visitor: viewModelContentVisitor)
     }
 

--- a/Packages/EurofurenceComponents/Sources/KnowledgeGroupsComponent/View/Abstraction/KnowledgeListScene.swift
+++ b/Packages/EurofurenceComponents/Sources/KnowledgeGroupsComponent/View/Abstraction/KnowledgeListScene.swift
@@ -1,5 +1,3 @@
-import Foundation.NSIndexPath
-
 public protocol KnowledgeListScene {
 
     func setDelegate(_ delegate: KnowledgeListSceneDelegate)
@@ -8,6 +6,5 @@ public protocol KnowledgeListScene {
     func showLoadingIndicator()
     func hideLoadingIndicator()
     func prepareToDisplayKnowledgeGroups(numberOfGroups: Int, binder: KnowledgeListBinder)
-    func deselectKnowledgeEntry(at indexPath: IndexPath)
 
 }

--- a/Packages/EurofurenceComponents/Sources/KnowledgeGroupsComponent/View/UIKit/KnowledgeListViewController.swift
+++ b/Packages/EurofurenceComponents/Sources/KnowledgeGroupsComponent/View/UIKit/KnowledgeListViewController.swift
@@ -39,10 +39,6 @@ public class KnowledgeListViewController: UIViewController, KnowledgeListScene {
         tableView.reloadData()
     }
 
-    public func deselectKnowledgeEntry(at indexPath: IndexPath) {
-        tableView.deselectRow(at: indexPath, animated: true)
-    }
-
     // MARK: Overrides
 
     override public func viewDidLoad() {
@@ -56,11 +52,6 @@ public class KnowledgeListViewController: UIViewController, KnowledgeListScene {
         tableView.rowHeight = UITableView.automaticDimension
         tableView.sectionHeaderHeight = UITableView.automaticDimension
         delegate?.knowledgeListSceneDidLoad()
-    }
-    
-    override public func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        tableView.deselectSelectedRow()
     }
     
     override public func viewDidLayoutSubviews() {

--- a/Packages/EurofurenceComponents/Sources/ScheduleComponent/View/UIKit/ScheduleViewController.swift
+++ b/Packages/EurofurenceComponents/Sources/ScheduleComponent/View/UIKit/ScheduleViewController.swift
@@ -75,12 +75,6 @@ public class ScheduleViewController: UIViewController,
         tableView?.adjustScrollIndicatorInsetsForSafeAreaCompensation()
     }
     
-    override public func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        
-        tableView.deselectSelectedRow()
-    }
-    
     private func prepareSearchController() {
         let allEventsScopeTitle = NSLocalizedString(
             "AllEvents",

--- a/Packages/EurofurenceComponents/Tests/KnowledgeGroupsComponentTests/Presenter Tests/Test Doubles/CapturingKnowledgeListScene.swift
+++ b/Packages/EurofurenceComponents/Tests/KnowledgeGroupsComponentTests/Presenter Tests/Test Doubles/CapturingKnowledgeListScene.swift
@@ -36,11 +36,6 @@ class CapturingKnowledgeListScene: UIViewController, KnowledgeListScene {
         self.binder = binder
     }
 
-    private(set) var deselectedIndexPath: IndexPath?
-    func deselectKnowledgeEntry(at indexPath: IndexPath) {
-        deselectedIndexPath = indexPath
-    }
-
 }
 
 extension CapturingKnowledgeListScene {

--- a/Packages/EurofurenceComponents/Tests/KnowledgeGroupsComponentTests/Presenter Tests/WhenKnowledgeListViewModelIsPrepared.swift
+++ b/Packages/EurofurenceComponents/Tests/KnowledgeGroupsComponentTests/Presenter Tests/WhenKnowledgeListViewModelIsPrepared.swift
@@ -38,7 +38,6 @@ class WhenKnowledgeGroupsListViewModelIsPrepared: XCTestCase {
         context.scene.simulateSelectingKnowledgeGroup(at: randomGroup.index)
         let expectedIdentifier = viewModel.stubbedGroupIdentifier(at: randomGroup.index)
 
-        XCTAssertEqual(IndexPath(item: randomGroup.index, section: 0), context.scene.deselectedIndexPath)
         XCTAssertEqual(expectedIdentifier, context.delegate.capturedKnowledgeGroupToPresent)
     }
 

--- a/Packages/EurofurenceModel/Sources/EurofurenceModel/Private/Services/ConcretePrivateMessagesService.swift
+++ b/Packages/EurofurenceModel/Sources/EurofurenceModel/Private/Services/ConcretePrivateMessagesService.swift
@@ -177,6 +177,8 @@ class ConcretePrivateMessagesService: PrivateMessagesService {
         init(service: ConcretePrivateMessagesService, token: String) {
             self.token = token
             super.init(service: service)
+            
+            refreshMessages(completionHandler: nil)
         }
         
         override func refreshMessages(completionHandler: (([MessageCharacteristics]?) -> Void)?) {

--- a/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Authentication/WhenLoggingIn.swift
+++ b/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Authentication/WhenLoggingIn.swift
@@ -111,6 +111,19 @@ class WhenLoggingIn: XCTestCase {
         XCTAssertEqual(username, loginObserver.loggedInUser?.username)
         XCTAssertEqual(regNo, loginObserver.loggedInUser?.registrationNumber)
     }
+    
+    func testSuccessfulLoginShouldRequestLatestMessages() {
+        let loginObserver = CapturingLoginObserver()
+        let username = "Some cool guy"
+        let regNo = 42
+        context.login(registrationNumber: regNo, username: username, completionHandler: loginObserver.completionHandler)
+        context.api.simulateLoginResponse(makeLoginResponse())
+        
+        XCTAssertTrue(
+            context.api.wasToldToLoadPrivateMessages,
+            "Successful login should request the user's messages are loaded"
+        )
+    }
 
     func testSuccessfulLoginTellsObserversTheUserHasLoggedIn() {
         let observer = CapturingAuthenticationStateObserver()

--- a/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Private Messages/WhenLoggingOut_ThenRequestingPrivateMessages.swift
+++ b/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Private Messages/WhenLoggingOut_ThenRequestingPrivateMessages.swift
@@ -9,7 +9,11 @@ class WhenLoggingOut_ThenRequestingPrivateMessages: XCTestCase {
         context.logoutSuccessfully()
         context.privateMessagesService.refreshMessages()
         
-        XCTAssertFalse(context.api.wasToldToLoadPrivateMessages)
+        XCTAssertEqual(
+            1,
+            context.api.privateMessagesLoadCount,
+            "Messages should only be requested on initial login, and not subsequent load requests when logged out"
+        )
     }
 
 }

--- a/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Test Doubles/API/FakeAPI.swift
+++ b/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Test Doubles/API/FakeAPI.swift
@@ -31,11 +31,13 @@ class FakeAPI: API {
     }
 
     private(set) var wasToldToLoadPrivateMessages = false
+    private(set) var privateMessagesLoadCount = 0
     private(set) var capturedAuthToken: String?
     private var messagesHandler: (([MessageCharacteristics]?) -> Void)?
     func loadPrivateMessages(authorizationToken: String,
                              completionHandler: @escaping ([MessageCharacteristics]?) -> Void) {
         wasToldToLoadPrivateMessages = true
+        privateMessagesLoadCount += 1
         capturedAuthToken = authorizationToken
         self.messagesHandler = completionHandler
     }


### PR DESCRIPTION
Table views now retain their selection information long to survive orientation or multitasking changes, where displaying disclosed content. Content dismissed when collapsing the split view back into a compact view is now also dismissed when re-expanding the split view back into multiple columns.

Fixes #451