### PR TITLE
Re-enable website storage

### DIFF
--- a/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Collect-them-All/View/UIKit/HybridWebViewController.swift
+++ b/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Collect-them-All/View/UIKit/HybridWebViewController.swift
@@ -61,7 +61,6 @@ class HybridWebViewController: UIViewController, HybridWebScene {
         
         let webConfiguration = WKWebViewConfiguration()
         webConfiguration.preferences.javaScriptEnabled = true
-        webConfiguration.websiteDataStore = .nonPersistent()
         
         let webView = WKWebView(frame: view.bounds, configuration: webConfiguration)
         webView.allowsLinkPreview = false


### PR DESCRIPTION
Hybrid controllers now reload their contents when the user signs in or out, so there’s no need to use non-persistent storage to work around this