### PR TITLE
Add face mask required indicator to event listings and event detail

### DIFF
--- a/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/News/Widgets/Events/View Model/DataSourceBackedEventsWidgetViewModel.swift
+++ b/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/News/Widgets/Events/View Model/DataSourceBackedEventsWidgetViewModel.swift
@@ -140,7 +140,7 @@ public class EventViewModelAdapter: EventViewModel {
     }
     
     public var isFaceMaskRequired: Bool {
-        false
+        event.isFaceMaskRequired
     }
     
     private class NotifyObjectChangedWhenEventChanges: EventObserver {

--- a/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/News/Widgets/Events/View Model/DataSourceBackedEventsWidgetViewModel.swift
+++ b/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/News/Widgets/Events/View Model/DataSourceBackedEventsWidgetViewModel.swift
@@ -139,6 +139,10 @@ public class EventViewModelAdapter: EventViewModel {
         event.isPhotoshoot
     }
     
+    public var isFaceMaskRequired: Bool {
+        false
+    }
+    
     private class NotifyObjectChangedWhenEventChanges: EventObserver {
         
         private unowned let adapter: EventViewModelAdapter

--- a/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/News/Widgets/Events/View Model/EventViewModel.swift
+++ b/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/News/Widgets/Events/View Model/EventViewModel.swift
@@ -14,5 +14,6 @@ public protocol EventViewModel: ObservedObject {
     var isDealersDen: Bool { get }
     var isMainStage: Bool { get }
     var isPhotoshoot: Bool { get }
+    var isFaceMaskRequired: Bool { get }
     
 }

--- a/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/News/Widgets/Events/View/EventsNewsWidgetTableViewDataSource.swift
+++ b/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/News/Widgets/Events/View/EventsNewsWidgetTableViewDataSource.swift
@@ -86,6 +86,7 @@ public class EventsNewsWidgetTableViewDataSource<T>: NSObject, TableViewMediator
             bindMainStageIndicator()
             bindPhotoshootIndicator()
             bindKageEventIndicator()
+            bindFaceMaskStatus()
         }
         
         private func bindSponsorOnlyIndicator() {
@@ -155,6 +156,14 @@ public class EventsNewsWidgetTableViewDataSource<T>: NSObject, TableViewMediator
                     }
                 }
                 .store(in: &cell.subscriptions)
+        }
+        
+        private func bindFaceMaskStatus() {
+            if event.isFaceMaskRequired {
+                cell.showFaceMaskRequiredIndicator()
+            } else {
+                cell.hideFaceMaskRequiredIndicator()
+            }
         }
         
     }

--- a/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/News/Widgets/Events/Test Doubles/FakeEventViewModel.swift
+++ b/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/News/Widgets/Events/Test Doubles/FakeEventViewModel.swift
@@ -15,6 +15,7 @@ class FakeEventViewModel: EventViewModel {
     @Observed var isDealersDen: Bool
     @Observed var isMainStage: Bool
     @Observed var isPhotoshoot: Bool
+    @Observed var isFaceMaskRequired: Bool
     
     init(
         name: String = "Name",
@@ -28,7 +29,8 @@ class FakeEventViewModel: EventViewModel {
         isKageEvent: Bool = false,
         isDealersDen: Bool = false,
         isMainStage: Bool = false,
-        isPhotoshoot: Bool = false
+        isPhotoshoot: Bool = false,
+        isFaceMaskRequired: Bool = false
     ) {
         self.name = name
         self.location = location
@@ -42,6 +44,7 @@ class FakeEventViewModel: EventViewModel {
         self.isDealersDen = isDealersDen
         self.isMainStage = isMainStage
         self.isPhotoshoot = isPhotoshoot
+        self.isFaceMaskRequired = isFaceMaskRequired
     }
     
 }

--- a/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/News/Widgets/Events/View Model/NewsEventsViewModelTests.swift
+++ b/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/News/Widgets/Events/View Model/NewsEventsViewModelTests.swift
@@ -105,6 +105,11 @@ class NewsEventsViewModelTests: XCTestCase {
         try assert(when: \FakeEvent.isPhotoshoot, is: false, then: \.isPhotoshoot, is: false)
     }
     
+    func testAdaptsRequiresFaceMaskState() throws {
+        try assert(when: \FakeEvent.isFaceMaskRequired, is: true, then: \.isFaceMaskRequired, is: true)
+        try assert(when: \FakeEvent.isFaceMaskRequired, is: false, then: \.isFaceMaskRequired, is: false)
+    }
+    
     func testEventTransitionsFromNotFavouriteToFavouriteNotifiesObserver() throws {
         let event = FakeEvent.random
         event.unfavourite()

--- a/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/News/Widgets/Events/View/EventsNewsWidgetTableViewDataSourceTests.swift
+++ b/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/News/Widgets/Events/View/EventsNewsWidgetTableViewDataSourceTests.swift
@@ -271,6 +271,22 @@ class EventsNewsWidgetTableViewDataSourceTests: XCTestCase {
         )
     }
     
+    func testBindsFaceMaskRequiredStateToEventTableViewCell() throws {
+        try assertViewModel(
+            with: \.isFaceMaskRequired,
+            as: false,
+            setsIsHiddenForViewWithAccessibilityIdentifier: "Event_IsFaceMaskRequired",
+            to: true
+        )
+        
+        try assertViewModel(
+            with: \.isFaceMaskRequired,
+            as: true,
+            setsIsHiddenForViewWithAccessibilityIdentifier: "Event_IsFaceMaskRequired",
+            to: false
+        )
+    }
+    
     func testSelectingCellUsesRowToNotifySelectedEventIndex() {
         prepareDataSource(events: [])
         dataSource?.tableView?(tableView, didSelectRowAt: IndexPath(row: 1, section: 2))
@@ -294,7 +310,8 @@ class EventsNewsWidgetTableViewDataSourceTests: XCTestCase {
         with viewModelKeyPath: WritableKeyPath<FakeEventViewModel, Bool>,
         as viewModelValue: Bool,
         setsIsHiddenForViewWithAccessibilityIdentifier accessibilityIdentifier: String,
-        to expected: Bool
+        to expected: Bool,
+        line: UInt = #line
     ) throws {
         var eventViewModel = FakeEventViewModel()
         eventViewModel[keyPath: viewModelKeyPath] = viewModelValue
@@ -302,7 +319,7 @@ class EventsNewsWidgetTableViewDataSourceTests: XCTestCase {
         let view = try findBindingTarget(accessibilityIdentifier: accessibilityIdentifier)
         let actual = view.isHidden
         
-        XCTAssertEqual(expected, actual)
+        XCTAssertEqual(expected, actual, line: line)
     }
     
 }

--- a/Packages/EurofurenceComponents/Sources/ComponentBase/Views/IconView.swift
+++ b/Packages/EurofurenceComponents/Sources/ComponentBase/Views/IconView.swift
@@ -15,6 +15,7 @@ public class IconView: UIImageView {
         case photoshoot
         case afterDarkDealersDen
         case warning
+        case faceMaskRequired
         
         fileprivate var view: UIView {
             switch self {
@@ -50,6 +51,9 @@ public class IconView: UIImageView {
                 
             case .warning:
                 return makeSymbolView(symbolName: "exclamationmark.triangle.fill", symbolWeight: .regular)
+                
+            case .faceMaskRequired:
+                return makeSymbolView(symbolName: "facemask.fill", symbolWeight: .regular)
             }
         }
         

--- a/Packages/EurofurenceComponents/Sources/EventDetailComponent/Presenter/EventDetailPresenter.swift
+++ b/Packages/EurofurenceComponents/Sources/EventDetailComponent/Presenter/EventDetailPresenter.swift
@@ -99,6 +99,12 @@ class EventDetailPresenter: EventDetailSceneDelegate, EventDetailViewModelDelega
             }
         }
         
+        func visit(_ faceMaskMessage: EventFaceMaskMessageViewModel) {
+            boundComponent = componentFactory.makeFaceMaskBannerComponent { (component) in
+                component.setBannerMessage(faceMaskMessage.message)
+            }
+        }
+        
         func visit(_ actionViewModel: EventActionViewModel) {
             boundComponent = componentFactory.makeEventActionBannerComponent { (component) in
                 actionViewModel.describe(to: ComponentRebindingEventActionVisitor(component: component))

--- a/Packages/EurofurenceComponents/Sources/EventDetailComponent/Resources/en.lproj/Localizable.strings
+++ b/Packages/EurofurenceComponents/Sources/EventDetailComponent/Resources/en.lproj/Localizable.strings
@@ -5,5 +5,6 @@
 "DealersDen" = "Dealers Den";
 "MainStageEvent" = "Main Stage Event";
 "Photoshoot" = "Photoshoot";
+"FaceMaskRequiredSlug" = "Face masks are mandatory for this event";
 
 "ViewEventFormatString" = "View event '%@'";

--- a/Packages/EurofurenceComponents/Sources/EventDetailComponent/View Model/Default/DefaultEventDetailViewModel.swift
+++ b/Packages/EurofurenceComponents/Sources/EventDetailComponent/View Model/Default/DefaultEventDetailViewModel.swift
@@ -144,12 +144,11 @@ class DefaultEventDetailViewModel: EventDetailViewModel, EventObserver {
     struct FaceMaskRequiredComponent: EventDetailViewModelComponent {
         
         func describe(to visitor: EventDetailViewModelVisitor) {
-            let message = """
-            FACE MASK MANDATORY / MASKENPFLICHT
-            
-            Wear mask before entering and maintain social distancing to stay safe!
-            
-            """
+            let message = NSLocalizedString(
+                "FaceMaskRequiredSlug",
+                bundle: .module,
+                comment: "Message shown in the event detail view when viewing event where a face mask is required"
+            )
             
             visitor.visit(EventFaceMaskMessageViewModel(message: message))
         }

--- a/Packages/EurofurenceComponents/Sources/EventDetailComponent/View Model/Default/DefaultEventDetailViewModel.swift
+++ b/Packages/EurofurenceComponents/Sources/EventDetailComponent/View Model/Default/DefaultEventDetailViewModel.swift
@@ -141,6 +141,21 @@ class DefaultEventDetailViewModel: EventDetailViewModel, EventObserver {
 
     }
     
+    struct FaceMaskRequiredComponent: EventDetailViewModelComponent {
+        
+        func describe(to visitor: EventDetailViewModelVisitor) {
+            let message = """
+            FACE MASK MANDATORY / MASKENPFLICHT
+            
+            Wear mask before entering and maintain social distancing to stay safe!
+            
+            """
+            
+            visitor.visit(EventFaceMaskMessageViewModel(message: message))
+        }
+        
+    }
+    
     struct ActionComponent: EventDetailViewModelComponent {
         
         let actionViewModel: EventActionViewModel

--- a/Packages/EurofurenceComponents/Sources/EventDetailComponent/View Model/Default/DefaultEventDetailViewModelFactory.swift
+++ b/Packages/EurofurenceComponents/Sources/EventDetailComponent/View Model/Default/DefaultEventDetailViewModelFactory.swift
@@ -124,6 +124,7 @@ public class DefaultEventDetailViewModelFactory: EventDetailViewModelFactory {
             buildDealersDenComponent()
             buildMainStageComponent()
             buildPhotoshootComponent()
+            buildFaceMaskRequiredComponent()
         }
         
         private func buildSponsorsOnlyComponent() {
@@ -165,6 +166,12 @@ public class DefaultEventDetailViewModelFactory: EventDetailViewModelFactory {
         private func buildPhotoshootComponent() {
             if event.isPhotoshoot {
                 components.append(DefaultEventDetailViewModel.PhotoshootComponent())
+            }
+        }
+        
+        private func buildFaceMaskRequiredComponent() {
+            if event.isFaceMaskRequired {
+                components.append(DefaultEventDetailViewModel.FaceMaskRequiredComponent())
             }
         }
         

--- a/Packages/EurofurenceComponents/Sources/EventDetailComponent/View Model/EventDetailViewModel.swift
+++ b/Packages/EurofurenceComponents/Sources/EventDetailComponent/View Model/EventDetailViewModel.swift
@@ -28,6 +28,7 @@ public protocol EventDetailViewModelVisitor {
     func visit(_ dealersDenMessage: EventDealersDenMessageViewModel)
     func visit(_ mainStageMessage: EventMainStageMessageViewModel)
     func visit(_ photoshootMessage: EventPhotoshootMessageViewModel)
+    func visit(_ faceMaskMessage: EventFaceMaskMessageViewModel)
     func visit(_ actionViewModel: EventActionViewModel)
 
 }
@@ -150,6 +151,16 @@ public struct EventPhotoshootMessageViewModel: Equatable {
         self.message = message
     }
 
+}
+
+public struct EventFaceMaskMessageViewModel: Equatable {
+    
+    public var message: String
+    
+    public init(message: String) {
+        self.message = message
+    }
+    
 }
 
 public protocol EventActionViewModel: AnyObject {

--- a/Packages/EurofurenceComponents/Sources/EventDetailComponent/View/Abstraction/EventDetailItemComponentFactory.swift
+++ b/Packages/EurofurenceComponents/Sources/EventDetailComponent/View/Abstraction/EventDetailItemComponentFactory.swift
@@ -18,6 +18,7 @@ public protocol EventDetailItemComponentFactory {
     func makeDealersDenBannerComponent(configuringUsing block: (EventInformationBannerComponent) -> Void) -> Component
     func makeMainStageBannerComponent(configuringUsing block: (EventInformationBannerComponent) -> Void) -> Component
     func makePhotoshootBannerComponent(configuringUsing block: (EventInformationBannerComponent) -> Void) -> Component
+    func makeFaceMaskBannerComponent(configuringUsing block: (EventInformationBannerComponent) -> Void) -> Component
     func makeEventActionBannerComponent(configuringUsing block: (EventActionBannerComponent) -> Void) -> Component
 
 }

--- a/Packages/EurofurenceComponents/Sources/EventDetailComponent/View/UIKit/EventDetailViewController.swift
+++ b/Packages/EurofurenceComponents/Sources/EventDetailComponent/View/UIKit/EventDetailViewController.swift
@@ -148,6 +148,12 @@ class EventDetailViewController: UIViewController, EventDetailScene {
             return makeBannerComponent(icons: .photoshoot, configuration: block)
         }
         
+        func makeFaceMaskBannerComponent(
+            configuringUsing block: (EventInformationBannerComponent) -> Void
+        ) -> UITableViewCell {
+            return makeBannerComponent(icons: .faceMaskRequired, configuration: block)
+        }
+        
         func makeEventActionBannerComponent(
             configuringUsing block: (EventActionBannerComponent) -> Void
         ) -> UITableViewCell {

--- a/Packages/EurofurenceComponents/Sources/ScheduleComponent/Presenter/SchedulePresenter.swift
+++ b/Packages/EurofurenceComponents/Sources/ScheduleComponent/Presenter/SchedulePresenter.swift
@@ -55,6 +55,7 @@ class SchedulePresenter: ScheduleSceneDelegate, ScheduleViewModelDelegate, Sched
             bindDealersDenIcon()
             bindMainStageIcon()
             bindPhotoshootIcon()
+            bindFaceMaskRequiredIcon()
         }
 
         private func bindSponsorOnlyIcon() {
@@ -118,6 +119,14 @@ class SchedulePresenter: ScheduleSceneDelegate, ScheduleViewModelDelegate, Sched
                 component.showPhotoshootStageEventIndicator()
             } else {
                 component.hidePhotoshootStageEventIndicator()
+            }
+        }
+        
+        private func bindFaceMaskRequiredIcon() {
+            if viewModel.isFaceMaskRequired {
+                component.showFaceMaskRequiredIndicator()
+            } else {
+                component.hideFaceMaskRequiredIndicator()
             }
         }
 

--- a/Packages/EurofurenceComponents/Sources/ScheduleComponent/View Model/DefaultScheduleViewModelFactory.swift
+++ b/Packages/EurofurenceComponents/Sources/ScheduleComponent/View Model/DefaultScheduleViewModelFactory.swift
@@ -336,7 +336,7 @@ public class DefaultScheduleViewModelFactory: ScheduleViewModelFactory {
         
         var isAcceptingFeedback: Bool { event.isAcceptingFeedback }
         
-        var isFaceMaskRequired: Bool { false }
+        var isFaceMaskRequired: Bool { event.isFaceMaskRequired }
         
         private weak var observer: ScheduleEventViewModelObserver?
         

--- a/Packages/EurofurenceComponents/Sources/ScheduleComponent/View Model/DefaultScheduleViewModelFactory.swift
+++ b/Packages/EurofurenceComponents/Sources/ScheduleComponent/View Model/DefaultScheduleViewModelFactory.swift
@@ -308,61 +308,35 @@ public class DefaultScheduleViewModelFactory: ScheduleViewModelFactory {
             event.add(self)
         }
         
-        var bannerGraphicPNGData: Data? {
-            event.bannerGraphicPNGData
-        }
+        var bannerGraphicPNGData: Data? { event.bannerGraphicPNGData }
         
-        var title: String {
-            event.title
-        }
+        var title: String { event.title }
         
-        var startTime: String {
-            hoursFormatter.hoursString(from: event.startDate)
-        }
+        var startTime: String { hoursFormatter.hoursString(from: event.startDate) }
         
-        var endTime: String {
-            hoursFormatter.hoursString(from: event.endDate)
-        }
+        var endTime: String { hoursFormatter.hoursString(from: event.endDate) }
         
-        var location: String {
-            event.room.name
-        }
+        var location: String { event.room.name }
         
-        var isFavourite: Bool {
-            event.isFavourite
-        }
+        var isFavourite: Bool { event.isFavourite }
         
-        var isSponsorOnly: Bool {
-            event.isSponsorOnly
-        }
+        var isSponsorOnly: Bool { event.isSponsorOnly }
         
-        var isSuperSponsorOnly: Bool {
-            event.isSuperSponsorOnly
-        }
+        var isSuperSponsorOnly: Bool { event.isSuperSponsorOnly }
         
-        var isArtShow: Bool {
-            event.isArtShow
-        }
+        var isArtShow: Bool { event.isArtShow }
         
-        var isKageEvent: Bool {
-            event.isKageEvent
-        }
+        var isKageEvent: Bool { event.isKageEvent }
         
-        var isDealersDenEvent: Bool {
-            event.isDealersDen
-        }
+        var isDealersDenEvent: Bool { event.isDealersDen }
         
-        var isMainStageEvent: Bool {
-            event.isMainStage
-        }
+        var isMainStageEvent: Bool { event.isMainStage }
         
-        var isPhotoshootEvent: Bool {
-            event.isPhotoshoot
-        }
+        var isPhotoshootEvent: Bool { event.isPhotoshoot }
         
-        var isAcceptingFeedback: Bool {
-            event.isAcceptingFeedback
-        }
+        var isAcceptingFeedback: Bool { event.isAcceptingFeedback }
+        
+        var isFaceMaskRequired: Bool { false }
         
         private weak var observer: ScheduleEventViewModelObserver?
         

--- a/Packages/EurofurenceComponents/Sources/ScheduleComponent/View Model/ScheduleEventViewModel.swift
+++ b/Packages/EurofurenceComponents/Sources/ScheduleComponent/View Model/ScheduleEventViewModel.swift
@@ -16,6 +16,7 @@ public protocol ScheduleEventViewModelProtocol {
     var isMainStageEvent: Bool { get }
     var isPhotoshootEvent: Bool { get }
     var isAcceptingFeedback: Bool { get }
+    var isFaceMaskRequired: Bool { get }
     
     func add(_ observer: ScheduleEventViewModelObserver)
     func favourite()

--- a/Packages/EurofurenceComponents/Sources/ScheduleComponent/View/Abstraction/ScheduleEventComponent.swift
+++ b/Packages/EurofurenceComponents/Sources/ScheduleComponent/View/Abstraction/ScheduleEventComponent.swift
@@ -25,5 +25,7 @@ public protocol ScheduleEventComponent {
     func hideMainStageEventIndicator()
     func showPhotoshootStageEventIndicator()
     func hidePhotoshootStageEventIndicator()
+    func showFaceMaskRequiredIndicator()
+    func hideFaceMaskRequiredIndicator()
 
 }

--- a/Packages/EurofurenceComponents/Sources/ScheduleComponent/View/UIKit/Event/EventTableViewCell.swift
+++ b/Packages/EurofurenceComponents/Sources/ScheduleComponent/View/UIKit/Event/EventTableViewCell.swift
@@ -46,6 +46,7 @@ public class EventTableViewCell: UITableViewCell, ScheduleEventComponent {
     private var dealersDenIndicatorView: UIView!
     private var mainStageIndicatorView: UIView!
     private var photoshootIndicatorView: UIView!
+    private var faceMaskIndicatorView: UIView!
     
     @IBOutlet private weak var verticalIconsStack: UIStackView!
     @IBOutlet private weak var eventBannerImageView: UIImageView!
@@ -82,6 +83,9 @@ public class EventTableViewCell: UITableViewCell, ScheduleEventComponent {
         photoshootIndicatorView = IconView(icon: .photoshoot)
         photoshootIndicatorView.accessibilityIdentifier = "Event_IsPhotoshoot"
         
+        faceMaskIndicatorView = IconView(icon: .faceMaskRequired)
+        faceMaskIndicatorView.accessibilityIdentifier = "Event_IsFaceMaskRequired"
+        
         let icons: [UIView] = [
             favouritedEventIndicator,
             sponsorEventIndicator,
@@ -91,7 +95,8 @@ public class EventTableViewCell: UITableViewCell, ScheduleEventComponent {
             kageWineGlassIndicatorView,
             dealersDenIndicatorView,
             mainStageIndicatorView,
-            photoshootIndicatorView
+            photoshootIndicatorView,
+            faceMaskIndicatorView
         ]
         
         for icon in icons.reversed() {
@@ -194,6 +199,14 @@ public class EventTableViewCell: UITableViewCell, ScheduleEventComponent {
 
     public func hidePhotoshootStageEventIndicator() {
         photoshootIndicatorView.isHidden = true
+    }
+    
+    public func showFaceMaskRequiredIndicator() {
+        faceMaskIndicatorView.isHidden = false
+    }
+    
+    public func hideFaceMaskRequiredIndicator() {
+        faceMaskIndicatorView.isHidden = true
     }
 
 }

--- a/Packages/EurofurenceComponents/Sources/XCTScheduleComponent/CapturingScheduleEventComponent.swift
+++ b/Packages/EurofurenceComponents/Sources/XCTScheduleComponent/CapturingScheduleEventComponent.swift
@@ -112,9 +112,17 @@ public class CapturingScheduleEventComponent: ScheduleEventComponent {
         photoshootIconVisibility = .visible
     }
 
-    public private(set) var didHidePhotoshootStageEventIndicator = false
     public func hidePhotoshootStageEventIndicator() {
         photoshootIconVisibility = .hidden
+    }
+    
+    public private(set) var faceMaskIconVisibility: VisibilityState = .unset
+    public func showFaceMaskRequiredIndicator() {
+        faceMaskIconVisibility = .visible
+    }
+    
+    public func hideFaceMaskRequiredIndicator() {
+        faceMaskIconVisibility = .hidden
     }
 
 }

--- a/Packages/EurofurenceComponents/Sources/XCTScheduleComponent/StubScheduleViewModel+RandomValueProviding.swift
+++ b/Packages/EurofurenceComponents/Sources/XCTScheduleComponent/StubScheduleViewModel+RandomValueProviding.swift
@@ -35,6 +35,7 @@ public final class StubScheduleEventViewModel: ScheduleEventViewModelProtocol {
     public var isMainStageEvent: Bool
     public var isPhotoshootEvent: Bool
     public var isAcceptingFeedback: Bool
+    public var isFaceMaskRequired: Bool
 
     public init(
         title: String,
@@ -50,7 +51,8 @@ public final class StubScheduleEventViewModel: ScheduleEventViewModelProtocol {
         isDealersDenEvent: Bool,
         isMainStageEvent: Bool,
         isPhotoshootEvent: Bool,
-        isAcceptingFeedback: Bool
+        isAcceptingFeedback: Bool,
+        isFaceMaskRequired: Bool
     ) {
         self.title = title
         self.startTime = startTime
@@ -66,6 +68,7 @@ public final class StubScheduleEventViewModel: ScheduleEventViewModelProtocol {
         self.isMainStageEvent = isMainStageEvent
         self.isPhotoshootEvent = isPhotoshootEvent
         self.isAcceptingFeedback = isAcceptingFeedback
+        self.isFaceMaskRequired = isFaceMaskRequired
     }
     
     private var observers = [ScheduleEventViewModelObserver]()
@@ -107,7 +110,8 @@ extension StubScheduleEventViewModel: RandomValueProviding {
             isDealersDenEvent: .random,
             isMainStageEvent: .random,
             isPhotoshootEvent: .random,
-            isAcceptingFeedback: .random
+            isAcceptingFeedback: .random,
+            isFaceMaskRequired: .random
         )
     }
 

--- a/Packages/EurofurenceComponents/Tests/EventDetailComponentTests/Presenter Tests/EventDetailPresenterBindingComponentTests.swift
+++ b/Packages/EurofurenceComponents/Tests/EventDetailComponentTests/Presenter Tests/EventDetailPresenterBindingComponentTests.swift
@@ -119,6 +119,15 @@ class EventDetailPresenterBindingComponentTests: XCTestCase {
         XCTAssertEqual(message, scene.stubbedArtShowMessageComponent.capturedMessage)
     }
     
+    func testBindingFaceMaskRequired() {
+        let message = String.random
+        let faceMaskViewModel = EventFaceMaskMessageViewModel(message: message)
+        let viewModel = StubFaceMaskEventViewModel(faceMaskMessageViewModel: faceMaskViewModel)
+        let scene = prepareSceneForBindingComponent(viewModel: viewModel)
+        
+        XCTAssertEqual(message, scene.stubbedFaceMaskMessageComponent.capturedMessage)
+    }
+    
     private func prepareSceneForBindingComponent(
         viewModel: EventDetailViewModel
     ) -> CapturingEventDetailScene {
@@ -130,5 +139,21 @@ class EventDetailPresenterBindingComponentTests: XCTestCase {
         
         return context.scene
     }
+
+}
+
+struct StubFaceMaskEventViewModel: EventDetailViewModel {
+
+    var faceMaskMessageViewModel: EventFaceMaskMessageViewModel
+
+    var numberOfComponents: Int { return 1 }
+    func setDelegate(_ delegate: EventDetailViewModelDelegate) { }
+    
+    func describe(componentAt index: Int, to visitor: EventDetailViewModelVisitor) {
+        visitor.visit(faceMaskMessageViewModel)
+    }
+    
+    func favourite() { }
+    func unfavourite() { }
 
 }

--- a/Packages/EurofurenceComponents/Tests/EventDetailComponentTests/Presenter Tests/Test Doubles/CapturingEventDetailScene.swift
+++ b/Packages/EurofurenceComponents/Tests/EventDetailComponentTests/Presenter Tests/Test Doubles/CapturingEventDetailScene.swift
@@ -151,6 +151,12 @@ class StubEventDetailItemComponentFactory: EventDetailItemComponentFactory {
         return stubbedPhotoshootMessageComponent
     }
     
+    let stubbedFaceMaskMessageComponent = CapturingEventInformationBannerComponent()
+    func makeFaceMaskBannerComponent(configuringUsing block: (EventInformationBannerComponent) -> Void) -> Any {
+        block(stubbedFaceMaskMessageComponent)
+        return stubbedPhotoshootMessageComponent
+    }
+    
     let stubbedActionComponent = CapturingEventActionBannerComponent()
     func makeEventActionBannerComponent(configuringUsing block: (EventActionBannerComponent) -> Void) -> Any {
         block(stubbedActionComponent)
@@ -216,6 +222,10 @@ extension CapturingEventDetailScene {
 
     var stubbedPhotoshootMessageComponent: CapturingEventInformationBannerComponent {
         return componentFactory.stubbedPhotoshootMessageComponent
+    }
+    
+    var stubbedFaceMaskMessageComponent: CapturingEventInformationBannerComponent {
+        return componentFactory.stubbedFaceMaskMessageComponent
     }
     
     var stubbedActionComponent: CapturingEventActionBannerComponent {

--- a/Packages/EurofurenceComponents/Tests/EventDetailComponentTests/View Model Tests/Test Doubles/CapturingEventDetailViewModelVisitor.swift
+++ b/Packages/EurofurenceComponents/Tests/EventDetailComponentTests/View Model Tests/Test Doubles/CapturingEventDetailViewModelVisitor.swift
@@ -45,6 +45,10 @@ class CapturingEventDetailViewModelVisitor: EventDetailViewModelVisitor {
         visitedViewModels.append(photoshootMessage)
     }
     
+    func visit(_ faceMaskMessage: EventFaceMaskMessageViewModel) {
+        visitedViewModels.append(faceMaskMessage)
+    }
+    
     func visit(_ actionViewModel: EventActionViewModel) {
         visitedViewModels.append(actionViewModel)
     }

--- a/Packages/EurofurenceComponents/Tests/EventDetailComponentTests/View Model Tests/WhenPreparingViewModel_ForEventRequiringFaceMask_EventDetailViewModelFactoryShould.swift
+++ b/Packages/EurofurenceComponents/Tests/EventDetailComponentTests/View Model Tests/WhenPreparingViewModel_ForEventRequiringFaceMask_EventDetailViewModelFactoryShould.swift
@@ -1,0 +1,28 @@
+import EurofurenceModel
+import EventDetailComponent
+import XCTest
+import XCTEurofurenceModel
+
+class WhenPreparingViewModel_ForEventRequiringFaceMask_EventDetailViewModelFactoryShould: XCTestCase {
+    
+    func testProduceSuperSponsorsOnlyComponentHeadingAfterDescriptionComponent() {
+        let event = FakeEvent.randomStandardEvent
+        event.isFaceMaskRequired = true
+        let context = EventDetailViewModelFactoryTestBuilder().build(for: event)
+        let visitor = context.prepareVisitorForTesting()
+        
+        let expectedMessage = """
+        FACE MASK MANDATORY / MASKENPFLICHT
+
+        Wear mask before entering and maintain social distancing to stay safe!
+
+        """
+        let expected = EventFaceMaskMessageViewModel(message: expectedMessage)
+
+        XCTAssertEqual(expected, visitor.visited(ofKind: EventFaceMaskMessageViewModel.self))
+        XCTAssertTrue(
+            visitor.does(EventFaceMaskMessageViewModel.self, precede: EventDescriptionViewModel.self)
+        )
+    }
+
+}

--- a/Packages/EurofurenceComponents/Tests/EventDetailComponentTests/View Model Tests/WhenPreparingViewModel_ForEventRequiringFaceMask_EventDetailViewModelFactoryShould.swift
+++ b/Packages/EurofurenceComponents/Tests/EventDetailComponentTests/View Model Tests/WhenPreparingViewModel_ForEventRequiringFaceMask_EventDetailViewModelFactoryShould.swift
@@ -10,14 +10,7 @@ class WhenPreparingViewModel_ForEventRequiringFaceMask_EventDetailViewModelFacto
         event.isFaceMaskRequired = true
         let context = EventDetailViewModelFactoryTestBuilder().build(for: event)
         let visitor = context.prepareVisitorForTesting()
-        
-        let expectedMessage = """
-        FACE MASK MANDATORY / MASKENPFLICHT
-
-        Wear mask before entering and maintain social distancing to stay safe!
-
-        """
-        let expected = EventFaceMaskMessageViewModel(message: expectedMessage)
+        let expected = EventFaceMaskMessageViewModel(message: "Face masks are mandatory for this event")
 
         XCTAssertEqual(expected, visitor.visited(ofKind: EventFaceMaskMessageViewModel.self))
         XCTAssertTrue(

--- a/Packages/EurofurenceComponents/Tests/ScheduleComponentTests/Presenter Tests/Icon Presentation/SchedulePresenterFaceMaskRequiredBindingTests.swift
+++ b/Packages/EurofurenceComponents/Tests/ScheduleComponentTests/Presenter Tests/Icon Presentation/SchedulePresenterFaceMaskRequiredBindingTests.swift
@@ -1,0 +1,24 @@
+import EurofurenceModel
+import ScheduleComponent
+import XCTest
+import XCTScheduleComponent
+
+class SchedulePresenterFaceMaskRequiredBindingTests: XCTestCase {
+    
+    func testShowTheFaceMaskRequiredIndicator() {
+        let eventViewModel = StubScheduleEventViewModel.random
+        eventViewModel.isFaceMaskRequired = true
+        let component = SchedulePresenterTestBuilder.buildForTestingBindingOfEvent(eventViewModel)
+
+        XCTAssertEqual(component.faceMaskIconVisibility, .visible)
+    }
+    
+    func testHideTheFaceMaskRequiredIndicator() {
+        let eventViewModel = StubScheduleEventViewModel.random
+        eventViewModel.isFaceMaskRequired = false
+        let component = SchedulePresenterTestBuilder.buildForTestingBindingOfEvent(eventViewModel)
+
+        XCTAssertEqual(component.faceMaskIconVisibility, .hidden)
+    }
+
+}

--- a/Packages/EurofurenceComponents/Tests/ScheduleComponentTests/View Model Tests/ScheduleEventViewModelAssertion.swift
+++ b/Packages/EurofurenceComponents/Tests/ScheduleComponentTests/View Model Tests/ScheduleEventViewModelAssertion.swift
@@ -30,6 +30,7 @@ class ScheduleEventViewModelAssertion: Assertion {
         assert(viewModel.isMainStageEvent, isEqualTo: event.isMainStage)
         assert(viewModel.isPhotoshootEvent, isEqualTo: event.isPhotoshoot)
         assert(viewModel.isAcceptingFeedback, isEqualTo: event.isAcceptingFeedback)
+        assert(viewModel.isFaceMaskRequired, isEqualTo: event.isFaceMaskRequired)
     }
 
 }

--- a/Packages/EurofurenceModel/Sources/EurofurenceModel/Private/Objects/Entities/EventImpl.swift
+++ b/Packages/EurofurenceModel/Sources/EurofurenceModel/Private/Objects/Entities/EventImpl.swift
@@ -89,7 +89,7 @@ class EventImpl: Event {
     }
     
     var isFaceMaskRequired: Bool {
-        false
+        containsTag("mask_required")
     }
     
     var isAcceptingFeedback: Bool {

--- a/Packages/EurofurenceModel/Sources/EurofurenceModel/Private/Objects/Entities/EventImpl.swift
+++ b/Packages/EurofurenceModel/Sources/EurofurenceModel/Private/Objects/Entities/EventImpl.swift
@@ -88,6 +88,10 @@ class EventImpl: Event {
         containsTag("photoshoot")
     }
     
+    var isFaceMaskRequired: Bool {
+        false
+    }
+    
     var isAcceptingFeedback: Bool {
         characteristics.isAcceptingFeedback
     }

--- a/Packages/EurofurenceModel/Sources/EurofurenceModel/Public/Objects/Entities/Event/Event.swift
+++ b/Packages/EurofurenceModel/Sources/EurofurenceModel/Public/Objects/Entities/Event/Event.swift
@@ -23,6 +23,7 @@ public protocol Event {
     var isDealersDen: Bool { get }
     var isMainStage: Bool { get }
     var isPhotoshoot: Bool { get }
+    var isFaceMaskRequired: Bool { get }
     var isAcceptingFeedback: Bool { get }
     var isFavourite: Bool { get }
     var contentURL: URL { get }

--- a/Packages/EurofurenceModel/Sources/XCTEurofurenceModel/Entity Test Doubles/FakeEvent.swift
+++ b/Packages/EurofurenceModel/Sources/XCTEurofurenceModel/Entity Test Doubles/FakeEvent.swift
@@ -31,6 +31,7 @@ public final class FakeEvent: Event {
     public var isPhotoshoot: Bool
     public var isAcceptingFeedback: Bool
     public var isFavourite: Bool
+    public var isFaceMaskRequired: Bool
 
     public init(
         identifier: EventIdentifier,
@@ -53,7 +54,8 @@ public final class FakeEvent: Event {
         isMainStage: Bool,
         isPhotoshoot: Bool,
         isAcceptingFeedback: Bool,
-        isFavourite: Bool
+        isFavourite: Bool,
+        isFaceMaskRequired: Bool
     ) {
         self.identifier = identifier
         self.title = title
@@ -76,6 +78,7 @@ public final class FakeEvent: Event {
         self.isPhotoshoot = isPhotoshoot
         self.isAcceptingFeedback = isAcceptingFeedback
         self.isFavourite = isFavourite
+        self.isFaceMaskRequired = isFaceMaskRequired
 
         favouritedState = .unset
     }
@@ -185,7 +188,8 @@ extension FakeEvent: RandomValueProviding {
             isMainStage: .random,
             isPhotoshoot: .random,
             isAcceptingFeedback: .random,
-            isFavourite: .random
+            isFavourite: .random,
+            isFaceMaskRequired: .random
         )
     }
     

--- a/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Events/Tag Adaption/InOrderToSupportFaceMaskTag_ApplicationShould.swift
+++ b/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Events/Tag Adaption/InOrderToSupportFaceMaskTag_ApplicationShould.swift
@@ -1,0 +1,36 @@
+import EurofurenceModel
+import XCTest
+
+class InOrderToSupportFaceMaskTag_ApplicationShould: XCTestCase {
+    
+    func testIndicateItRequiresFaceMaskWhenTagPresent() {
+        var syncResponse = ModelCharacteristics.randomWithoutDeletions
+        let randomEvent = syncResponse.events.changed.randomElement()
+        var event = randomEvent.element
+        event.tags = ["mask_required"]
+        syncResponse.events.changed = [event]
+        let context = EurofurenceSessionTestBuilder().build()
+        context.performSuccessfulSync(response: syncResponse)
+        let eventsObserver = CapturingScheduleRepositoryObserver()
+        context.eventsService.add(eventsObserver)
+        let observedEvent = eventsObserver.allEvents.first
+
+        XCTAssertEqual(true, observedEvent?.isFaceMaskRequired)
+    }
+
+    func testNotIndicateRequiresFaceMaskWhenTagNotPresent() {
+        var syncResponse = ModelCharacteristics.randomWithoutDeletions
+        let randomEvent = syncResponse.events.changed.randomElement()
+        var event = randomEvent.element
+        event.tags = []
+        syncResponse.events.changed = [event]
+        let context = EurofurenceSessionTestBuilder().build()
+        context.performSuccessfulSync(response: syncResponse)
+        let eventsObserver = CapturingScheduleRepositoryObserver()
+        context.eventsService.add(eventsObserver)
+        let observedEvent = eventsObserver.allEvents.first
+
+        XCTAssertEqual(false, observedEvent?.isFaceMaskRequired)
+    }
+
+}


### PR DESCRIPTION
On the presence of the `mask_required` flag in the event:

- Event table view cells will display the face mask icon
- Event detail pages will include the associated slug:

<img width="531" alt="Screenshot 2022-07-29 at 09 12 57" src="https://user-images.githubusercontent.com/12624320/181715181-72bb648e-38b8-44c8-9b89-03f4bd7ddb75.png">