### PR TITLE
Sort maps by dedicated comparator value

### DIFF
--- a/Packages/EurofurenceModel/Sources/EurofurenceModel/Private/Services/ConcreteMapsService.swift
+++ b/Packages/EurofurenceModel/Sources/EurofurenceModel/Private/Services/ConcreteMapsService.swift
@@ -44,9 +44,7 @@ class ConcreteMapsService: MapsService {
     private func reloadMapsFromDataStore() {
         guard let maps = dataStore.fetchMaps() else { return }
 
-        models = maps.map(makeMap).sorted(by: { (first, second) -> Bool in
-            return first.location < second.location
-        })
+        models = maps.sorted(by: { $0.order < $1.order }).map(makeMap)
     }
     
     private func makeMap(from characteristics: MapCharacteristics) -> MapImpl {

--- a/Packages/EurofurenceModel/Sources/EurofurenceModel/Public/Default Dependency Implementations/Core Data Store/EurofurenceApplicationModel.xcdatamodeld/EF26.xcdatamodel/contents
+++ b/Packages/EurofurenceModel/Sources/EurofurenceModel/Public/Default Dependency Implementations/Core Data Store/EurofurenceApplicationModel.xcdatamodeld/EF26.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="17709" systemVersion="20D91" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="20086" systemVersion="21F79" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="AnnouncementEntity" representedClassName="AnnouncementEntity" syncable="YES" codeGenerationType="class">
         <attribute name="content" optional="YES" attributeType="String"/>
         <attribute name="identifier" optional="YES" attributeType="String"/>
@@ -86,6 +86,7 @@
         <attribute name="identifier" optional="YES" attributeType="String"/>
         <attribute name="imageIdentifier" optional="YES" attributeType="String"/>
         <attribute name="mapDescription" optional="YES" attributeType="String"/>
+        <attribute name="order" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <relationship name="entries" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="MapEntryEntity" inverseName="map" inverseEntity="MapEntryEntity"/>
     </entity>
     <entity name="MapEntryEntity" representedClassName="MapEntryEntity" syncable="YES" codeGenerationType="class">
@@ -124,7 +125,7 @@
         <element name="KnowledgeGroupEntity" positionX="-63" positionY="-18" width="128" height="120"/>
         <element name="LastRefreshEntity" positionX="-45" positionY="63" width="128" height="60"/>
         <element name="LinkEntity" positionX="-54" positionY="36" width="128" height="120"/>
-        <element name="MapEntity" positionX="-36" positionY="135" width="128" height="105"/>
+        <element name="MapEntity" positionX="-36" positionY="135" width="128" height="104"/>
         <element name="MapEntryEntity" positionX="-27" positionY="144" width="128" height="135"/>
         <element name="MapEntryLinkEntity" positionX="-18" positionY="153" width="128" height="105"/>
         <element name="ReadAnnouncementEntity" positionX="-36" positionY="135" width="128" height="60"/>

--- a/Packages/EurofurenceModel/Sources/EurofurenceModel/Public/Default Dependency Implementations/Core Data Store/Model Adaptation/MapEntity+Adaptation.swift
+++ b/Packages/EurofurenceModel/Sources/EurofurenceModel/Public/Default Dependency Implementations/Core Data Store/Model Adaptation/MapEntity+Adaptation.swift
@@ -20,6 +20,7 @@ extension MapEntity: EntityAdapting {
             identifier: identifier,
             imageIdentifier: imageIdentifier,
             mapDescription: mapDescription,
+            order: Int(order),
             entries: entries.map({ $0.asAdaptedType() })
         )
     }
@@ -28,6 +29,7 @@ extension MapEntity: EntityAdapting {
         identifier = value.identifier
         imageIdentifier = value.imageIdentifier
         mapDescription = value.mapDescription
+        order = Int64(value.order)
     }
 
 }

--- a/Packages/EurofurenceModel/Sources/EurofurenceModel/Public/Server Client/JSON/JSONSyncResponse.swift
+++ b/Packages/EurofurenceModel/Sources/EurofurenceModel/Public/Server Client/JSON/JSONSyncResponse.swift
@@ -290,6 +290,7 @@ struct JSONSyncResponse: Decodable {
         var Id: String
         var ImageId: String
         var Description: String
+        var Order: Int
         var Entries: [JSONMapEntry]
         
         var modelValue: MapCharacteristics {
@@ -297,6 +298,7 @@ struct JSONSyncResponse: Decodable {
                 identifier: Id,
                 imageIdentifier: ImageId,
                 mapDescription: Description,
+                order: Order,
                 entries: Entries.map(\.modelValue)
             )
         }

--- a/Packages/EurofurenceModel/Sources/EurofurenceModel/Public/Server Client/Response/MapCharacteristics.swift
+++ b/Packages/EurofurenceModel/Sources/EurofurenceModel/Public/Server Client/Response/MapCharacteristics.swift
@@ -7,6 +7,7 @@ public struct MapCharacteristics: Equatable, Identifyable {
         return lhs.identifier == rhs.identifier &&
                lhs.imageIdentifier == rhs.imageIdentifier &&
                lhs.mapDescription == rhs.mapDescription &&
+               lhs.order == rhs.order &&
                lhs.entries.count == rhs.entries.count &&
                lhs.entries.contains(elementsFrom: rhs.entries)
     }
@@ -63,12 +64,14 @@ public struct MapCharacteristics: Equatable, Identifyable {
     
     public var imageIdentifier: String
     public var mapDescription: String
+    public var order: Int
     public var entries: [Entry]
 
-    public init(identifier: String, imageIdentifier: String, mapDescription: String, entries: [Entry]) {
+    public init(identifier: String, imageIdentifier: String, mapDescription: String, order: Int, entries: [Entry]) {
         self.identifier = identifier
         self.imageIdentifier = imageIdentifier
         self.mapDescription = mapDescription
+        self.order = order
         self.entries = entries
     }
 

--- a/Packages/EurofurenceModel/Sources/XCTEurofurenceModel/Random Value Generation/Characteristics/MapCharacteristics+RandomValueProviding.swift
+++ b/Packages/EurofurenceModel/Sources/XCTEurofurenceModel/Random Value Generation/Characteristics/MapCharacteristics+RandomValueProviding.swift
@@ -5,7 +5,13 @@ import TestUtilities
 extension MapCharacteristics: RandomValueProviding {
     
     public static var random: MapCharacteristics {
-        MapCharacteristics(identifier: .random, imageIdentifier: .random, mapDescription: .random, entries: .random)
+        MapCharacteristics(
+            identifier: .random,
+            imageIdentifier: .random,
+            mapDescription: .random,
+            order: .random,
+            entries: .random
+        )
     }
     
 }

--- a/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Client API/Sync/WhenSyncSucceeds_SyncAPIShould.swift
+++ b/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Client API/Sync/WhenSyncSucceeds_SyncAPIShould.swift
@@ -114,12 +114,33 @@ class WhenSyncSucceeds_SyncAPIShould: XCTestCase {
                                                        deleted: ["d53e6f6b-fdcb-4754-a4b9-6892e8d317d7"],
                                                        removeAllBeforeInsert: true)
 
-        let maps = ModelCharacteristics.Update<MapCharacteristics>(changed: [MapCharacteristics(identifier: "d6f1c9b4-6d03-41cc-ae5d-ee278e5121f0",
-                                                                  imageIdentifier: "28c15af7-6d82-4ee7-bf3b-2603076e785e",
-                                                                  mapDescription: "Dealers Den",
-                                                                  entries: [MapCharacteristics.Entry(identifier: "651ab75e-d87f-40a6-bcad-669432ee7a86", x: 747, y: 201, tapRadius: 50, links: [MapCharacteristics.Entry.Link(type: .dealerDetail, name: "Mirri", target: "b2166372-3b76-45d3-b3f9-e1675cade2db")])])],
-                                                 deleted: ["157e1849-d6fc-46ab-9d47-1b785cd867c7"],
-                                                 removeAllBeforeInsert: true)
+        let maps = ModelCharacteristics.Update<MapCharacteristics>(
+            changed: [
+                MapCharacteristics(
+                    identifier: "d6f1c9b4-6d03-41cc-ae5d-ee278e5121f0",
+                    imageIdentifier: "28c15af7-6d82-4ee7-bf3b-2603076e785e",
+                    mapDescription: "Dealers Den",
+                    order: 10,
+                    entries: [
+                        MapCharacteristics.Entry(
+                            identifier: "651ab75e-d87f-40a6-bcad-669432ee7a86",
+                            x: 747,
+                            y: 201,
+                            tapRadius: 50,
+                            links: [
+                                MapCharacteristics.Entry.Link(
+                                    type: .dealerDetail,
+                                    name: "Mirri",
+                                    target: "b2166372-3b76-45d3-b3f9-e1675cade2db"
+                                )
+                            ]
+                        )
+                    ]
+                )
+            ],
+            deleted: ["157e1849-d6fc-46ab-9d47-1b785cd867c7"],
+            removeAllBeforeInsert: true
+        )
 
         let images = ModelCharacteristics.Update<ImageCharacteristics>(changed: [ImageCharacteristics(identifier: "8ae7d323-b56d-4155-8a88-6b418bcfd057",
                                                                         internalReference: "knowledge:1b9f7858-454d-0a68-824b-359e5bbfa5b0",

--- a/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Maps/MapEntityAssertion.swift
+++ b/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Maps/MapEntityAssertion.swift
@@ -9,7 +9,7 @@ class MapEntityAssertion: Assertion {
             return
         }
 
-        let orderedCharacteristics = characteristics.sorted(by: { $0.mapDescription < $1.mapDescription })
+        let orderedCharacteristics = characteristics.sorted(by: { $0.order < $1.order })
         for (idx, map) in maps.enumerated() {
             let characteristic = orderedCharacteristics[idx]
 

--- a/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Resources/V2SyncAPIResponse.json
+++ b/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Resources/V2SyncAPIResponse.json
@@ -171,6 +171,7 @@
                             "Id": "d6f1c9b4-6d03-41cc-ae5d-ee278e5121f0",
                             "ImageId": "28c15af7-6d82-4ee7-bf3b-2603076e785e",
                             "Description": "Dealers Den",
+                            "Order": 10,
                             "IsBrowseable": true,
                             "Entries": [
                                         {


### PR DESCRIPTION
Using the comparator sourced from the backend to control the displayed ordering in the maps tab in place of using the description.