### PR TITLE
Fix first launch showing all events in schedule

### DIFF
--- a/Packages/EurofurenceModel/Sources/EurofurenceModel/Private/Services/Events/EventsScheduleAdapter.swift
+++ b/Packages/EurofurenceModel/Sources/EurofurenceModel/Private/Services/Events/EventsScheduleAdapter.swift
@@ -168,6 +168,7 @@ class EventsScheduleAdapter: Schedule, CustomStringConvertible {
         if days != schedule.dayModels {
             self.days = schedule.dayModels
             updateDelegateWithAllDays()
+            updateCurrentDay()
         }
     }
 

--- a/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Days/WhenSyncCompletesWithConferenceDays_ApplicationShould.swift
+++ b/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Days/WhenSyncCompletesWithConferenceDays_ApplicationShould.swift
@@ -15,6 +15,18 @@ class WhenSyncCompletesWithConferenceDays_ApplicationShould: XCTestCase {
         DayAssertion()
             .assertDays(delegate.allDays, characterisedBy: syncResponse.conferenceDays.changed)
     }
+    
+    func testUpdateDelegateWithTheCurrentDayAfterRefreshConcludes() {
+        let context = EurofurenceSessionTestBuilder().build()
+        let syncResponse = ModelCharacteristics.randomWithoutDeletions
+        let delegate = CapturingScheduleDelegate()
+        let schedule = context.eventsService.loadSchedule(tag: "Test")
+        schedule.setDelegate(delegate)
+        delegate.toldChangedToNilDay = false
+        context.performSuccessfulSync(response: syncResponse)
+
+        XCTAssertTrue(delegate.toldChangedToNilDay)
+    }
 
     func testNotUpdateTheDelegateIfTheDaysHaveNotChangedBetweenSyncs() {
         let context = EurofurenceSessionTestBuilder().build()

--- a/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Test Doubles/CapturingEventsScheduleDelegate.swift
+++ b/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Test Doubles/CapturingEventsScheduleDelegate.swift
@@ -8,7 +8,7 @@ class CapturingScheduleDelegate: ScheduleDelegate {
         self.events = events
     }
 
-    private(set) var toldChangedToNilDay = false
+    var toldChangedToNilDay = false
     private(set) var capturedCurrentDay: Day?
     func currentEventDayDidChange(to day: Day?) {
         toldChangedToNilDay = day == nil


### PR DESCRIPTION
Missing an update on the current day when the schedule is updated from the remote