### PR TITLE
Remove wine icon to solve a few layout issues

### DIFF
--- a/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/News/Widgets/Events/View/EventsNewsWidgetTableViewDataSourceTests.swift
+++ b/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/News/Widgets/Events/View/EventsNewsWidgetTableViewDataSourceTests.swift
@@ -255,20 +255,6 @@ class EventsNewsWidgetTableViewDataSourceTests: XCTestCase {
             setsIsHiddenForViewWithAccessibilityIdentifier: "Event_KageBug",
             to: true
         )
-        
-        try assertViewModel(
-            with: \.isKageEvent,
-            as: true,
-            setsIsHiddenForViewWithAccessibilityIdentifier: "Event_KageWineGlass",
-            to: false
-        )
-        
-        try assertViewModel(
-            with: \.isKageEvent,
-            as: false,
-            setsIsHiddenForViewWithAccessibilityIdentifier: "Event_KageWineGlass",
-            to: true
-        )
     }
     
     func testBindsFaceMaskRequiredStateToEventTableViewCell() throws {

--- a/Packages/EurofurenceComponents/Sources/ComponentBase/Views/IconView.swift
+++ b/Packages/EurofurenceComponents/Sources/ComponentBase/Views/IconView.swift
@@ -9,7 +9,6 @@ public class IconView: UIImageView {
         case mainStage
         case sponsor
         case superSponsor
-        case wine
         case bug
         case dealersDen
         case photoshoot
@@ -33,9 +32,6 @@ public class IconView: UIImageView {
                 
             case .superSponsor:
                 return makeSymbolView(symbolName: "star.fill", symbolWeight: .semibold)
-                
-            case .wine:
-                return makeAwesomeFontIcon(code: "\u{f000}")
                 
             case .bug:
                 return makeAwesomeFontIcon(code: "\u{f188}")

--- a/Packages/EurofurenceComponents/Sources/EventDetailComponent/View/UIKit/EventDetailViewController.swift
+++ b/Packages/EurofurenceComponents/Sources/EventDetailComponent/View/UIKit/EventDetailViewController.swift
@@ -127,7 +127,7 @@ class EventDetailViewController: UIViewController, EventDetailScene {
         func makeKageBannerComponent(
             configuringUsing block: (EventInformationBannerComponent) -> Void
         ) -> UITableViewCell {
-            return makeBannerComponent(icons: .wine, .bug, configuration: block)
+            return makeBannerComponent(icons: .bug, configuration: block)
         }
 
         func makeDealersDenBannerComponent(

--- a/Packages/EurofurenceComponents/Sources/ScheduleComponent/View/UIKit/Event/EventTableViewCell.swift
+++ b/Packages/EurofurenceComponents/Sources/ScheduleComponent/View/UIKit/Event/EventTableViewCell.swift
@@ -42,7 +42,6 @@ public class EventTableViewCell: UITableViewCell, ScheduleEventComponent {
     private var superSponsorEventIndicator: UIView!
     private var artShowIndicatorView: UIView!
     private var kageBugIndicatorView: UIView!
-    private var kageWineGlassIndicatorView: UIView!
     private var dealersDenIndicatorView: UIView!
     private var mainStageIndicatorView: UIView!
     private var photoshootIndicatorView: UIView!
@@ -71,9 +70,6 @@ public class EventTableViewCell: UITableViewCell, ScheduleEventComponent {
         kageBugIndicatorView = IconView(icon: .bug)
         kageBugIndicatorView.accessibilityIdentifier = "Event_KageBug"
         
-        kageWineGlassIndicatorView = IconView(icon: .wine)
-        kageWineGlassIndicatorView.accessibilityIdentifier = "Event_KageWineGlass"
-        
         dealersDenIndicatorView = IconView(icon: .dealersDen)
         dealersDenIndicatorView.accessibilityIdentifier = "Event_IsDealersDen"
         
@@ -92,7 +88,6 @@ public class EventTableViewCell: UITableViewCell, ScheduleEventComponent {
             superSponsorEventIndicator,
             artShowIndicatorView,
             kageBugIndicatorView,
-            kageWineGlassIndicatorView,
             dealersDenIndicatorView,
             mainStageIndicatorView,
             photoshootIndicatorView,
@@ -169,12 +164,10 @@ public class EventTableViewCell: UITableViewCell, ScheduleEventComponent {
 
     public func showKageEventIndicator() {
         kageBugIndicatorView.isHidden = false
-        kageWineGlassIndicatorView.isHidden = false
     }
 
     public func hideKageEventIndicator() {
         kageBugIndicatorView.isHidden = true
-        kageWineGlassIndicatorView.isHidden = true
     }
 
     public func showDealersDenEventIndicator() {


### PR DESCRIPTION
Having two icons mean the same thing is a bit weird, causes layout issues on a couple screens, and isn't consistent with the rest of the iconography. Keeping the bug given it has better defined meaning for the intent than a wine glass. Fixes #468.