### PR TITLE
Apply Markdown formatting to messages

### DIFF
--- a/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Message Detail/Component/MessageDetailComponentBuilder.swift
+++ b/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Message Detail/Component/MessageDetailComponentBuilder.swift
@@ -1,13 +1,16 @@
+import ComponentBase
 import EurofurenceModel
 
 public class MessageDetailComponentBuilder {
     
     private let messagesService: PrivateMessagesService
+    private var markdownRenderer: MarkdownRenderer
     private var sceneFactory: MessageDetailSceneFactory
     
     public init(messagesService: PrivateMessagesService) {
         self.messagesService = messagesService
-        sceneFactory = StoryboardMessageDetailSceneFactory()
+        self.sceneFactory = StoryboardMessageDetailSceneFactory()
+        self.markdownRenderer = DefaultDownMarkdownRenderer()
     }
     
     @discardableResult
@@ -16,10 +19,17 @@ public class MessageDetailComponentBuilder {
         return self
     }
     
+    @discardableResult
+    public func with(_ markdownRenderer: MarkdownRenderer) -> Self {
+        self.markdownRenderer = markdownRenderer
+        return self
+    }
+    
     public func build() -> MessageDetailComponentFactory {
         MessageDetailComponentFactoryImpl(
             sceneFactory: sceneFactory,
-            messagesService: messagesService
+            messagesService: messagesService,
+            markdownRenderer: markdownRenderer
         )
     }
     

--- a/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Message Detail/Component/MessageDetailModule.swift
+++ b/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Message Detail/Component/MessageDetailModule.swift
@@ -1,3 +1,4 @@
+import ComponentBase
 import EurofurenceModel
 import UIKit
 
@@ -5,11 +6,17 @@ struct MessageDetailComponentFactoryImpl: MessageDetailComponentFactory {
     
     var sceneFactory: MessageDetailSceneFactory
     var messagesService: PrivateMessagesService
+    var markdownRenderer: MarkdownRenderer
     
     func makeMessageDetailComponent(for message: MessageIdentifier) -> UIViewController {
         let scene = sceneFactory.makeMessageDetailScene()
         
-        _ = MessageDetailPresenter(message: message, scene: scene, messagesService: messagesService)
+        _ = MessageDetailPresenter(
+            message: message,
+            scene: scene,
+            messagesService: messagesService,
+            markdownRenderer: markdownRenderer
+        )
         
         return scene
     }

--- a/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Message Detail/Presenter/MessageDetailPresenter.swift
+++ b/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Message Detail/Presenter/MessageDetailPresenter.swift
@@ -1,4 +1,5 @@
 import EurofurenceModel
+import Foundation
 
 class MessageDetailPresenter: MessageDetailSceneDelegate {
     
@@ -50,8 +51,8 @@ class MessageDetailPresenter: MessageDetailSceneDelegate {
             message.subject
         }
         
-        var contents: String {
-            message.contents
+        var contents: NSAttributedString {
+            NSAttributedString(string: message.contents)
         }
         
     }

--- a/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Message Detail/Presenter/MessageDetailPresenter.swift
+++ b/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Message Detail/Presenter/MessageDetailPresenter.swift
@@ -1,3 +1,4 @@
+import ComponentBase
 import EurofurenceModel
 import Foundation
 
@@ -6,11 +7,18 @@ class MessageDetailPresenter: MessageDetailSceneDelegate {
     private let message: MessageIdentifier
     private weak var scene: MessageDetailScene?
     private let messagesService: PrivateMessagesService
+    private let markdownRenderer: MarkdownRenderer
     
-    init(message: MessageIdentifier, scene: MessageDetailScene, messagesService: PrivateMessagesService) {
+    init(
+        message: MessageIdentifier,
+        scene: MessageDetailScene,
+        messagesService: PrivateMessagesService,
+        markdownRenderer: MarkdownRenderer
+    ) {
         self.message = message
         self.scene = scene
         self.messagesService = messagesService
+        self.markdownRenderer = markdownRenderer
         
         scene.delegate = self
     }
@@ -22,14 +30,15 @@ class MessageDetailPresenter: MessageDetailSceneDelegate {
     private func loadMessageForPresentation() {
         scene?.showLoadingIndicator()
         
-        messagesService.fetchMessage(identifiedBy: message) { (result) in
+        messagesService.fetchMessage(identifiedBy: message) { [markdownRenderer] (result) in
             self.scene?.hideLoadingIndicator()
             
             switch result {
             case .success(let message):
                 message.markAsRead()
+                
                 self.scene?.setMessageDetailTitle(message.authorName)
-                self.scene?.showMessage(viewModel: MessageViewModel(message: message))
+                self.scene?.showMessage(viewModel: MessageViewModel(message: message, markdownRenderer: markdownRenderer))
                 
             case .failure(let error):
                 self.scene?.showError(
@@ -41,19 +50,13 @@ class MessageDetailPresenter: MessageDetailSceneDelegate {
     
     private struct MessageViewModel: MessageDetailViewModel {
         
-        private let message: Message
-        
-        init(message: Message) {
-            self.message = message
+        init(message: Message, markdownRenderer: MarkdownRenderer) {
+            self.subject = message.subject
+            self.contents = markdownRenderer.render(message.contents)
         }
         
-        var subject: String {
-            message.subject
-        }
-        
-        var contents: NSAttributedString {
-            NSAttributedString(string: message.contents)
-        }
+        let subject: String
+        let contents: NSAttributedString
         
     }
     

--- a/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Message Detail/View/MessageDetail.storyboard
+++ b/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Message Detail/View/MessageDetail.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -25,10 +25,10 @@
                                 <rect key="frame" x="0.0" y="44" width="375" height="734"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="S01-Zq-Sk4">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="218.33333333333334"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="175"/>
                                         <subviews>
-                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" contentInsetAdjustmentBehavior="never" editable="NO" textAlignment="natural" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DF7-Xx-9ya">
-                                                <rect key="frame" x="20" y="48.333333333333314" width="335" height="170"/>
+                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" contentInsetAdjustmentBehavior="never" editable="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="DF7-Xx-9ya">
+                                                <rect key="frame" x="20" y="45" width="335" height="130"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</string>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
@@ -36,7 +36,7 @@
                                                 <dataDetectorType key="dataDetectorTypes" phoneNumber="YES" link="YES" address="YES" calendarEvent="YES"/>
                                             </textView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yWm-9F-LGv">
-                                                <rect key="frame" x="24" y="20" width="327" height="20.333333333333329"/>
+                                                <rect key="frame" x="24" y="20" width="327" height="17"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -68,23 +68,23 @@
                                 <rect key="frame" x="0.0" y="44" width="375" height="734"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="Au0-cq-Nyd">
-                                        <rect key="frame" x="67.666666666666686" y="327" width="240" height="80.333333333333314"/>
+                                        <rect key="frame" x="67.666666666666686" y="328.66666666666669" width="240" height="77"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2or-Cd-ULd">
-                                                <rect key="frame" x="99.333333333333329" y="0.0" width="41.333333333333329" height="20.333333333333332"/>
+                                                <rect key="frame" x="102.33333333333333" y="0.0" width="35.333333333333329" height="17"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Xrl-cx-DOh">
-                                                <rect key="frame" x="0.0" y="28.333333333333314" width="240" height="14"/>
+                                                <rect key="frame" x="0.0" y="25" width="240" height="14"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="14" id="EFo-oA-8AS"/>
                                                 </constraints>
                                             </view>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8vU-UD-XPh" customClass="RoundedCornerButton" customModule="ComponentBase">
-                                                <rect key="frame" x="96.999999999999986" y="50.333333333333314" width="46.000000000000014" height="30"/>
+                                                <rect key="frame" x="96.999999999999986" y="47" width="46.000000000000014" height="30"/>
                                                 <state key="normal" title="Button"/>
                                                 <connections>
                                                     <action selector="tryLoadingMessageAgain:" destination="8l9-eO-7S5" eventType="touchUpInside" id="vrZ-qH-Ueu"/>

--- a/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Message Detail/View/MessageDetailScene.swift
+++ b/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Message Detail/View/MessageDetailScene.swift
@@ -1,3 +1,5 @@
+import Foundation.NSAttributedString
+
 public protocol MessageDetailScene: AnyObject {
 
     var delegate: MessageDetailSceneDelegate? { get set }
@@ -13,7 +15,7 @@ public protocol MessageDetailScene: AnyObject {
 public protocol MessageDetailViewModel {
     
     var subject: String { get }
-    var contents: String { get }
+    var contents: NSAttributedString { get }
     
 }
 

--- a/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Message Detail/View/MessageDetailViewController.swift
+++ b/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Message Detail/View/MessageDetailViewController.swift
@@ -58,7 +58,7 @@ class MessageDetailViewController: UIViewController, MessageDetailScene {
             self.hideError()
             self.showDetail()
             self.messageSubjectLabel.text = viewModel.subject
-            self.messageContentsTextView.text = viewModel.contents
+            self.messageContentsTextView.attributedText = viewModel.contents
         }
     }
     

--- a/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Messages/Component/MessagesComponentBuilder.swift
+++ b/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Messages/Component/MessagesComponentBuilder.swift
@@ -8,12 +8,14 @@ public class MessagesComponentBuilder {
     private let authenticationService: AuthenticationService
     private let privateMessagesService: PrivateMessagesService
     private var dateFormatter: DateFormatterProtocol
+    private var markdownRenderer: MarkdownRenderer
 
     public init(authenticationService: AuthenticationService, privateMessagesService: PrivateMessagesService) {
         self.authenticationService = authenticationService
         self.privateMessagesService = privateMessagesService
-        sceneFactory = StoryboardMessagesSceneFactory()
-        dateFormatter = EurofurenceDateFormatter()
+        self.sceneFactory = StoryboardMessagesSceneFactory()
+        self.dateFormatter = EurofurenceDateFormatter()
+        self.markdownRenderer = SubtleDownMarkdownRenderer()
     }
 
     public func with(_ sceneFactory: MessagesSceneFactory) -> Self {
@@ -25,13 +27,20 @@ public class MessagesComponentBuilder {
         self.dateFormatter = dateFormatter
         return self
     }
+    
+    @discardableResult
+    public func with(_ markdownRenderer: MarkdownRenderer) -> Self {
+        self.markdownRenderer = markdownRenderer
+        return self
+    }
 
     public func build() -> MessagesComponentFactory {
         MessagesComponentFactoryImpl(
             sceneFactory: sceneFactory,
             authenticationService: authenticationService,
             privateMessagesService: privateMessagesService,
-            dateFormatter: dateFormatter
+            dateFormatter: dateFormatter,
+            markdownRenderer: markdownRenderer
         )
     }
 

--- a/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Messages/Component/MessagesComponentFactoryImpl.swift
+++ b/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Messages/Component/MessagesComponentFactoryImpl.swift
@@ -1,3 +1,4 @@
+import ComponentBase
 import EurofurenceModel
 import UIKit.UIViewController
 
@@ -7,6 +8,7 @@ struct MessagesComponentFactoryImpl: MessagesComponentFactory {
     var authenticationService: AuthenticationService
     var privateMessagesService: PrivateMessagesService
     var dateFormatter: DateFormatterProtocol
+    var markdownRenderer: MarkdownRenderer
 
     func makeMessagesModule(_ delegate: MessagesComponentDelegate) -> UIViewController {
         let scene = sceneFactory.makeMessagesScene()
@@ -15,6 +17,7 @@ struct MessagesComponentFactoryImpl: MessagesComponentFactory {
             authenticationService: authenticationService,
             privateMessagesService: privateMessagesService,
             dateFormatter: dateFormatter,
+            markdownRenderer: markdownRenderer,
             delegate: delegate
         )
 

--- a/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Messages/Presenter/MessagesPresenter.swift
+++ b/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Messages/Presenter/MessagesPresenter.swift
@@ -144,7 +144,7 @@ class MessagesPresenter: MessagesSceneDelegate, PrivateMessagesObserver {
             
             scene.setAuthor(message.authorName)
             scene.setSubject(message.subject)
-            scene.setContents(message.contents)
+            scene.setContents(NSAttributedString(string: message.contents))
 
             let formattedDateTime = dateFormatter.string(from: message.receivedDateTime)
             scene.setReceivedDateTime(formattedDateTime)

--- a/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Messages/View/MessageTableViewCell.swift
+++ b/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Messages/View/MessageTableViewCell.swift
@@ -37,8 +37,8 @@ class MessageTableViewCell: UITableViewCell, MessageItemScene {
         messageSubjectLabel.text = subject
     }
 
-    func setContents(_ contents: String) {
-        messageSynopsisLabel.text = contents
+    func setContents(_ contents: NSAttributedString) {
+        messageSynopsisLabel.attributedText = contents
     }
 
     func setReceivedDateTime(_ dateTime: String) {

--- a/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Messages/View/MessagesScene.swift
+++ b/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Messages/View/MessagesScene.swift
@@ -46,7 +46,7 @@ public protocol MessageItemScene {
 
     func setAuthor(_ author: String)
     func setSubject(_ subject: String)
-    func setContents(_ contents: String)
+    func setContents(_ contents: NSAttributedString)
     func setReceivedDateTime(_ dateTime: String)
     func showUnreadIndicator()
     func hideUnreadIndicator()

--- a/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/Message Detail/MessageDetailPresenterTests.swift
+++ b/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/Message Detail/MessageDetailPresenterTests.swift
@@ -38,7 +38,7 @@ class MessageDetailPresenterTests: XCTestCase {
         XCTAssertEqual(.hidden, sceneFactory.scene.loadingIndicatorVisibility)
         XCTAssertEqual(message.authorName, sceneFactory.scene.capturedMessageDetailTitle)
         XCTAssertEqual(message.subject, sceneFactory.scene.viewModel?.subject)
-        XCTAssertEqual(message.contents, sceneFactory.scene.viewModel?.contents)
+        XCTAssertEqual(NSAttributedString(string: message.contents), sceneFactory.scene.viewModel?.contents)
     }
     
     func testMessageLoadFailure() throws {
@@ -78,7 +78,7 @@ class MessageDetailPresenterTests: XCTestCase {
         XCTAssertEqual(.hidden, sceneFactory.scene.loadingIndicatorVisibility)
         XCTAssertEqual(message.authorName, sceneFactory.scene.capturedMessageDetailTitle)
         XCTAssertEqual(message.subject, sceneFactory.scene.viewModel?.subject)
-        XCTAssertEqual(message.contents, sceneFactory.scene.viewModel?.contents)
+        XCTAssertEqual(NSAttributedString(string: message.contents), sceneFactory.scene.viewModel?.contents)
     }
 
 }

--- a/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/Message Detail/MessageDetailPresenterTests.swift
+++ b/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/Message Detail/MessageDetailPresenterTests.swift
@@ -1,6 +1,7 @@
 import EurofurenceApplication
 import EurofurenceModel
 import XCTest
+import XCTComponentBase
 import XCTEurofurenceModel
 
 class MessageDetailPresenterTests: XCTestCase {
@@ -27,18 +28,25 @@ class MessageDetailPresenterTests: XCTestCase {
             providingMessage: message
         )
         
-        let module = MessageDetailComponentBuilder(messagesService: messagesService).with(sceneFactory).build()
+        let markdownRenderer = StubMarkdownRenderer()
+        let module = MessageDetailComponentBuilder(messagesService: messagesService)
+            .with(sceneFactory)
+            .with(markdownRenderer)
+            .build()
+        
         _ = module.makeMessageDetailComponent(for: messageIdentifier)
         
         XCTAssertFalse(message.markedRead)
         
         sceneFactory.scene.simulateSceneReady()
         
+        let expectedContents = markdownRenderer.stubbedContents(for: message.contents)
+        
         XCTAssertTrue(message.markedRead)
         XCTAssertEqual(.hidden, sceneFactory.scene.loadingIndicatorVisibility)
         XCTAssertEqual(message.authorName, sceneFactory.scene.capturedMessageDetailTitle)
         XCTAssertEqual(message.subject, sceneFactory.scene.viewModel?.subject)
-        XCTAssertEqual(NSAttributedString(string: message.contents), sceneFactory.scene.viewModel?.contents)
+        XCTAssertEqual(expectedContents, sceneFactory.scene.viewModel?.contents)
     }
     
     func testMessageLoadFailure() throws {
@@ -64,7 +72,13 @@ class MessageDetailPresenterTests: XCTestCase {
         let messageIdentifier = MessageIdentifier.random
         let sceneFactory = StubMessageDetailSceneFactory()
         let messagesService = ControllablePrivateMessagesService()
-        let module = MessageDetailComponentBuilder(messagesService: messagesService).with(sceneFactory).build()
+        let markdownRenderer = StubMarkdownRenderer()
+        
+        let module = MessageDetailComponentBuilder(messagesService: messagesService)
+            .with(sceneFactory)
+            .with(markdownRenderer)
+            .build()
+        
         _ = module.makeMessageDetailComponent(for: messageIdentifier)
         sceneFactory.scene.simulateSceneReady()
         messagesService.failNow(error: .loadingMessagesFailed)
@@ -75,10 +89,12 @@ class MessageDetailPresenterTests: XCTestCase {
         let message = StubMessage.random
         messagesService.succeedNow(message: message)
         
+        let expectedContents = markdownRenderer.stubbedContents(for: message.contents)
+        
         XCTAssertEqual(.hidden, sceneFactory.scene.loadingIndicatorVisibility)
         XCTAssertEqual(message.authorName, sceneFactory.scene.capturedMessageDetailTitle)
         XCTAssertEqual(message.subject, sceneFactory.scene.viewModel?.subject)
-        XCTAssertEqual(NSAttributedString(string: message.contents), sceneFactory.scene.viewModel?.contents)
+        XCTAssertEqual(expectedContents, sceneFactory.scene.viewModel?.contents)
     }
 
 }

--- a/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/Messages/MessagesPresenterTestContext.swift
+++ b/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/Messages/MessagesPresenterTestContext.swift
@@ -1,5 +1,6 @@
 import EurofurenceApplication
 import EurofurenceModel
+import XCTComponentBase
 import XCTEurofurenceModel
 
 class CapturingMessagesComponentDelegate: MessagesComponentDelegate {
@@ -35,6 +36,7 @@ struct MessagesPresenterTestContext {
     var privateMessagesService = CapturingPrivateMessagesService()
     let dateFormatter = CapturingDateFormatter()
     let authenticationService: FakeAuthenticationService
+    let markdownRenderer = StubMarkdownRenderer()
 
     var scene: CapturingMessagesScene {
         return sceneFactory.scene
@@ -69,6 +71,7 @@ struct MessagesPresenterTestContext {
         )
         .with(sceneFactory)
         .with(dateFormatter)
+        .with(markdownRenderer)
         .build()
         .makeMessagesModule(delegate)
     }

--- a/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/Messages/WhenBindingMessage_MessagesPresenterShould.swift
+++ b/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/Messages/WhenBindingMessage_MessagesPresenterShould.swift
@@ -19,10 +19,12 @@ class MessagesPresenterTestsWhenBindingMessages: XCTestCase {
         let capturingMessageScene = CapturingMessageItemScene()
         context.scene.capturedMessageItemBinder?.bind(capturingMessageScene, toMessageAt: randomIndexPath)
         
+        let expectedMessageContents = context.markdownRenderer.stubbedContents(for: message.contents)
+        
         XCTAssertEqual(allMessages.count, context.scene.boundMessageCount)
         XCTAssertEqual(message.authorName, capturingMessageScene.capturedAuthor)
         XCTAssertEqual(message.subject, capturingMessageScene.capturedSubject)
-        XCTAssertEqual(NSAttributedString(string: message.contents), capturingMessageScene.capturedContents)
+        XCTAssertEqual(expectedMessageContents, capturingMessageScene.capturedContents)
         XCTAssertEqual(message.receivedDateTime, context.dateFormatter.capturedDate)
         XCTAssertEqual(context.dateFormatter.stubString, capturingMessageScene.capturedReceivedDateTime)
     }

--- a/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/Messages/WhenBindingMessage_MessagesPresenterShould.swift
+++ b/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/Messages/WhenBindingMessage_MessagesPresenterShould.swift
@@ -22,7 +22,7 @@ class MessagesPresenterTestsWhenBindingMessages: XCTestCase {
         XCTAssertEqual(allMessages.count, context.scene.boundMessageCount)
         XCTAssertEqual(message.authorName, capturingMessageScene.capturedAuthor)
         XCTAssertEqual(message.subject, capturingMessageScene.capturedSubject)
-        XCTAssertEqual(message.contents, capturingMessageScene.capturedContents)
+        XCTAssertEqual(NSAttributedString(string: message.contents), capturingMessageScene.capturedContents)
         XCTAssertEqual(message.receivedDateTime, context.dateFormatter.capturedDate)
         XCTAssertEqual(context.dateFormatter.stubString, capturingMessageScene.capturedReceivedDateTime)
     }

--- a/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Test Doubles/Scenes/CapturingMessagesScene.swift
+++ b/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Test Doubles/Scenes/CapturingMessagesScene.swift
@@ -75,8 +75,8 @@ class CapturingMessageItemScene: MessageItemScene {
         capturedSubject = subject
     }
 
-    private(set) var capturedContents: String?
-    func setContents(_ contents: String) {
+    private(set) var capturedContents: NSAttributedString?
+    func setContents(_ contents: NSAttributedString) {
         capturedContents = contents
     }
 


### PR DESCRIPTION
Also applies to the message listing using the subtle format.

![Simulator Screen Shot - iPhone 13 - 2022-08-16 at 12 59 59](https://user-images.githubusercontent.com/12624320/184874770-9451b915-0e81-405e-a417-aa4071f276c3.png)

![Simulator Screen Shot - iPhone 13 - 2022-08-16 at 12 45 40](https://user-images.githubusercontent.com/12624320/184874801-e73842be-7da0-4450-a04d-f8825e81c0b0.png)

