### PR TITLE
Filter events to days based on day identifier

### DIFF
--- a/Packages/EurofurenceComponents/Tests/ScheduleComponentTests/View Model Tests/WhenViewModelIsToldToShowEventsForSpecificDay_ScheduleViewModelFactoryShould.swift
+++ b/Packages/EurofurenceComponents/Tests/ScheduleComponentTests/View Model Tests/WhenViewModelIsToldToShowEventsForSpecificDay_ScheduleViewModelFactoryShould.swift
@@ -9,6 +9,7 @@ class WhenViewModelIsToldToShowEventsForSpecificDay_ScheduleViewModelFactoryShou
         let days: [Day] = .random
         let randomDay = days.randomElement()
         let event = FakeEvent.random
+        event.day = randomDay.element
         event.startDate = randomDay.element.date.addingTimeInterval(-10)
         event.endDate = randomDay.element.date.addingTimeInterval(10)
         

--- a/Packages/EurofurenceModel/Sources/EurofurenceModel/Private/Objects/Entities/EventImpl.swift
+++ b/Packages/EurofurenceModel/Sources/EurofurenceModel/Private/Objects/Entities/EventImpl.swift
@@ -16,7 +16,7 @@ class EventImpl: Event {
     }
     
     let identifier: EventIdentifier
-    let day: ConferenceDayCharacteristics
+    let dayCharacteristics: ConferenceDayCharacteristics
     let room: Room
     let track: Track
 
@@ -46,6 +46,10 @@ class EventImpl: Event {
     
     var hosts: String {
         characteristics.panelHosts
+    }
+    
+    var day: Day {
+        Day(date: self.dayCharacteristics.date, identifier: self.dayCharacteristics.identifier)
     }
     
     var startDate: Date {
@@ -117,7 +121,7 @@ class EventImpl: Event {
         self.room = room
         self.track = track
         
-        self.day = day
+        self.dayCharacteristics = day
     }
     
     var contentURL: URL {

--- a/Packages/EurofurenceModel/Sources/EurofurenceModel/Private/Services/Events/ConcreteEventsService.swift
+++ b/Packages/EurofurenceModel/Sources/EurofurenceModel/Private/Services/Events/ConcreteEventsService.swift
@@ -223,7 +223,7 @@ class ConcreteScheduleRepository: ClockDelegate, ScheduleRepository {
     }
 
     private func makeDay(from model: ConferenceDayCharacteristics) -> Day {
-        return Day(date: model.date)
+        return Day(date: model.date, identifier: model.identifier)
     }
 
     private func favouriteEvent(identifier: EventIdentifier) {

--- a/Packages/EurofurenceModel/Sources/EurofurenceModel/Private/Services/Events/EventsScheduleAdapter.swift
+++ b/Packages/EurofurenceModel/Sources/EurofurenceModel/Private/Services/Events/EventsScheduleAdapter.swift
@@ -118,7 +118,7 @@ class EventsScheduleAdapter: Schedule, CustomStringConvertible {
 
     private func updateCurrentDay() {
         if let day = findDay(for: clock.currentDate) {
-            let conferenceDay = Day(date: day.date)
+            let conferenceDay = Day(date: day.date, identifier: "UNTESTED")
             if conferenceDay != currentDay {
                 currentDay = conferenceDay
             }

--- a/Packages/EurofurenceModel/Sources/EurofurenceModel/Public/Objects/Day.swift
+++ b/Packages/EurofurenceModel/Sources/EurofurenceModel/Public/Objects/Day.swift
@@ -3,9 +3,11 @@ import Foundation
 public struct Day {
 
     public var date: Date
+    public var identifier: String
 
-    public init(date: Date) {
+    public init(date: Date, identifier: String) {
         self.date = date
+        self.identifier = identifier
     }
 
 }

--- a/Packages/EurofurenceModel/Sources/EurofurenceModel/Public/Objects/Entities/Event/Event.swift
+++ b/Packages/EurofurenceModel/Sources/EurofurenceModel/Public/Objects/Entities/Event/Event.swift
@@ -11,6 +11,7 @@ public protocol Event {
     var room: Room { get }
     var track: Track { get }
     var hosts: String { get }
+    var day: Day { get }
     var startDate: Date { get }
     var endDate: Date { get }
     var eventDescription: String { get }

--- a/Packages/EurofurenceModel/Sources/EurofurenceModel/Public/Objects/Entities/Event/Specifications/EventsOccurringOnDaySpecification.swift
+++ b/Packages/EurofurenceModel/Sources/EurofurenceModel/Public/Objects/Entities/Event/Specifications/EventsOccurringOnDaySpecification.swift
@@ -17,12 +17,7 @@ extension EventsOccurringOnDaySpecification: Specification {
     public typealias Element = Event
     
     public func isSatisfied(by element: Element) -> Bool {
-        let calendar = Calendar.current
-        let dayComponents: Set<Calendar.Component> = [.day, .month, .year]
-        let theDay = calendar.dateComponents(dayComponents, from: day.date)
-        let eventDay = calendar.dateComponents(dayComponents, from: element.startDate)
-        
-        return theDay == eventDay
+        day.identifier == element.day.identifier
     }
     
 }

--- a/Packages/EurofurenceModel/Sources/XCTEurofurenceModel/Entity Test Doubles/FakeEvent.swift
+++ b/Packages/EurofurenceModel/Sources/XCTEurofurenceModel/Entity Test Doubles/FakeEvent.swift
@@ -17,6 +17,7 @@ public final class FakeEvent: Event {
     public var room: Room
     public var track: Track
     public var hosts: String
+    public var day: Day
     public var startDate: Date
     public var endDate: Date
     public var eventDescription: String
@@ -41,6 +42,7 @@ public final class FakeEvent: Event {
         room: Room,
         track: Track,
         hosts: String,
+        day: Day,
         startDate: Date,
         endDate: Date,
         eventDescription: String,
@@ -64,6 +66,7 @@ public final class FakeEvent: Event {
         self.room = room
         self.track = track
         self.hosts = hosts
+        self.day = day
         self.startDate = startDate
         self.endDate = endDate
         self.eventDescription = eventDescription
@@ -175,6 +178,7 @@ extension FakeEvent: RandomValueProviding {
             room: .random,
             track: .random,
             hosts: .random,
+            day: .random,
             startDate: startDate,
             endDate: startDate.addingTimeInterval(.random),
             eventDescription: .random,

--- a/Packages/EurofurenceModel/Sources/XCTEurofurenceModel/Random Value Generation/Entities/Day+RandomValueProviding.swift
+++ b/Packages/EurofurenceModel/Sources/XCTEurofurenceModel/Random Value Generation/Entities/Day+RandomValueProviding.swift
@@ -5,7 +5,7 @@ import TestUtilities
 extension Day: RandomValueProviding {
 
     public static var random: Day {
-        return Day(date: .random)
+        return Day(date: .random, identifier: .random)
     }
 
 }

--- a/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Events/Specifications/EventsOccurringOnDaySpecificationTests.swift
+++ b/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Events/Specifications/EventsOccurringOnDaySpecificationTests.swift
@@ -4,113 +4,28 @@ import XCTEurofurenceModel
 
 class EventsOccurringOnDaySpecificationTests: XCTestCase {
     
-    func testEventOccursTodayAndIsHappeningRightNow() {
-        let now = Date()
-        let inHalfAnHour = now.addingTimeInterval(1800)
-        let inOneHour = now.addingTimeInterval(3600)
+    func testEventOccursOnSameDay() {
+        let day = Day(date: Date(), identifier: "ID")
         let event = FakeEvent.random
-        event.startDate = now
-        event.endDate = inOneHour
-        let day = Day(date: inHalfAnHour)
+        event.startDate = day.date
+        event.day = day
+        
         let specification = EventsOccurringOnDaySpecification(day: day)
         
-        XCTAssertTrue(
-            specification.isSatisfied(by: event),
-            "The event is straddling when the day begins, satisfying the specification"
-        )
+        XCTAssertTrue(specification.isSatisfied(by: event), "Event occurs on the same day")
     }
     
-    func testEventDoesNotOccurToday() {
-        let now = Date()
-        let inJustOverOneDay = now.addingTimeInterval((3600 * 24) + 10)
+    func testEventDoesNotOccursOnSameDay() {
+        let eventDay = Day(date: Date(), identifier: "ID")
         let event = FakeEvent.random
-        event.startDate = inJustOverOneDay
-        event.endDate = inJustOverOneDay.addingTimeInterval(1)
-        let day = Day(date: now)
-        let specification = EventsOccurringOnDaySpecification(day: day)
+        event.startDate = eventDay.date
+        event.day = eventDay
         
-        XCTAssertFalse(
-            specification.isSatisfied(by: event),
-            "The event starts in over 24 hours from the day provided to the specification"
-        )
-    }
-    
-    func testEventHasOccurredToday() throws {
-        let now = Date()
-        let components = Calendar.current.dateComponents(in: .current, from: now)
-        var earlyTodayComponents = components
-        earlyTodayComponents.hour = 1
-        let earlyToday = try XCTUnwrap(earlyTodayComponents.date)
+        let criteriaDay = Day(date: Date(), identifier: "ID 2")
         
-        var middayComponents = components
-        middayComponents.hour = 12
-        let midday = try XCTUnwrap(middayComponents.date)
+        let specification = EventsOccurringOnDaySpecification(day: criteriaDay)
         
-        let event = FakeEvent.random
-        event.startDate = earlyToday
-        event.endDate = earlyToday.addingTimeInterval(3600)
-        let day = Day(date: midday)
-        let specification = EventsOccurringOnDaySpecification(day: day)
-        
-        XCTAssertTrue(
-            specification.isSatisfied(by: event),
-            "The event started on the specified day, ignoring hours and minutes"
-        )
-    }
-    
-    func testEventHasOccurredToday_SpecificToMonth() throws {
-        let now = Date()
-        let components = Calendar.current.dateComponents(in: .current, from: now)
-        var earlyTodayComponents = components
-        earlyTodayComponents.hour = 1
-        earlyTodayComponents.day = 1
-        earlyTodayComponents.month = 1
-        let earlyToday = try XCTUnwrap(earlyTodayComponents.date)
-        
-        var middayComponents = components
-        middayComponents.hour = 12
-        middayComponents.day = 1
-        middayComponents.month = 2
-        let midday = try XCTUnwrap(middayComponents.date)
-        
-        let event = FakeEvent.random
-        event.startDate = earlyToday
-        event.endDate = earlyToday.addingTimeInterval(3600)
-        let day = Day(date: midday)
-        let specification = EventsOccurringOnDaySpecification(day: day)
-        
-        XCTAssertFalse(
-            specification.isSatisfied(by: event),
-            "The event started on the same day but in a different month"
-        )
-    }
-    
-    func testEventHasOccurredToday_SpecificToYear() throws {
-        let now = Date()
-        let components = Calendar.current.dateComponents(in: .current, from: now)
-        var earlyTodayComponents = components
-        earlyTodayComponents.year = 2022
-        earlyTodayComponents.month = 1
-        earlyTodayComponents.day = 1
-        earlyTodayComponents.hour = 1
-        let earlyToday = try XCTUnwrap(earlyTodayComponents.date)
-        
-        var middayComponents = earlyTodayComponents
-        middayComponents.year = 2021
-        middayComponents.yearForWeekOfYear = 2021
-        middayComponents.hour = 12
-        let midday = try XCTUnwrap(middayComponents.date)
-        
-        let event = FakeEvent.random
-        event.startDate = earlyToday
-        event.endDate = earlyToday.addingTimeInterval(3600)
-        let day = Day(date: midday)
-        let specification = EventsOccurringOnDaySpecification(day: day)
-        
-        XCTAssertFalse(
-            specification.isSatisfied(by: event),
-            "The event started on the same day in the same month but in different years"
-        )
+        XCTAssertFalse(specification.isSatisfied(by: event), "Event does not occur on the same day")
     }
     
 }

--- a/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Schedule/WhenRestrictingEventsToSpecificDay_ScheduleShould.swift
+++ b/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Schedule/WhenRestrictingEventsToSpecificDay_ScheduleShould.swift
@@ -11,9 +11,13 @@ class WhenRestrictingEventsToSpecificDay_ScheduleShould: XCTestCase {
         let schedule = context.eventsService.loadSchedule(tag: "Test")
         let delegate = CapturingScheduleDelegate()
         schedule.setDelegate(delegate)
-        let randomDay = response.conferenceDays.changed.randomElement()
-        let expectedEvents = response.events.changed.filter({ $0.dayIdentifier == randomDay.element.identifier })
-        schedule.filterSchedule(to: EventsOccurringOnDaySpecification(day: Day(date: randomDay.element.date)))
+        let randomDay = response.conferenceDays.changed.randomElement().element
+        let expectedEvents = response.events.changed.filter({ $0.dayIdentifier == randomDay.identifier })
+        let specification = EventsOccurringOnDaySpecification(
+            day: Day(date: randomDay.date, identifier: randomDay.identifier)
+        )
+        
+        schedule.filterSchedule(to: specification)
 
         try EventAssertion(context: context, modelCharacteristics: response)
             .assertEvents(delegate.events, characterisedBy: expectedEvents)
@@ -25,9 +29,13 @@ class WhenRestrictingEventsToSpecificDay_ScheduleShould: XCTestCase {
         let context = EurofurenceSessionTestBuilder().with(dataStore).build()
         let schedule = context.eventsService.loadSchedule(tag: "Test")
         let delegate = CapturingScheduleDelegate()
-        let randomDay = response.conferenceDays.changed.randomElement()
-        let expectedEvents = response.events.changed.filter({ $0.dayIdentifier == randomDay.element.identifier })
-        schedule.filterSchedule(to: EventsOccurringOnDaySpecification(day: Day(date: randomDay.element.date)))
+        let randomDay = response.conferenceDays.changed.randomElement().element
+        let expectedEvents = response.events.changed.filter({ $0.dayIdentifier == randomDay.identifier })
+        let specification = EventsOccurringOnDaySpecification(
+            day: Day(date: randomDay.date, identifier: randomDay.identifier)
+        )
+        
+        schedule.filterSchedule(to: specification)
         context.refreshLocalStore()
         context.api.simulateSuccessfulSync(response)
         schedule.setDelegate(delegate)
@@ -43,11 +51,20 @@ class WhenRestrictingEventsToSpecificDay_ScheduleShould: XCTestCase {
         let schedule = context.eventsService.loadSchedule(tag: "Test")
         let delegate = CapturingScheduleDelegate()
         schedule.setDelegate(delegate)
-        let randomDay = response.conferenceDays.changed.randomElement()
-        let anotherRandomDay = response.conferenceDays.changed.randomElement()
-        let expectedEvents = response.events.changed.filter({ $0.dayIdentifier == randomDay.element.identifier })
-        schedule.filterSchedule(to: EventsOccurringOnDaySpecification(day: Day(date: anotherRandomDay.element.date)))
-        schedule.filterSchedule(to: EventsOccurringOnDaySpecification(day: Day(date: randomDay.element.date)))
+        let randomDay = response.conferenceDays.changed.randomElement().element
+        let anotherRandomDay = response.conferenceDays.changed.randomElement().element
+        let expectedEvents = response.events.changed.filter({ $0.dayIdentifier == randomDay.identifier })
+        let firstSpecification = EventsOccurringOnDaySpecification(
+            day: Day(date: anotherRandomDay.date, identifier: anotherRandomDay.identifier)
+        )
+        
+        schedule.filterSchedule(to: firstSpecification)
+        
+        let secondSpecification = EventsOccurringOnDaySpecification(
+            day: Day(date: randomDay.date, identifier: randomDay.identifier)
+        )
+        
+        schedule.filterSchedule(to: secondSpecification)
 
         try EventAssertion(context: context, modelCharacteristics: response)
             .assertEvents(delegate.events, characterisedBy: expectedEvents)


### PR DESCRIPTION
Avoids using relative temporal comparisons that may shift when the device’s time zone does not align with the convention’s time zone.

Fixes #473