### PR TITLE
Fix margin and fullscreen issues with map popovers

### DIFF
--- a/Eurofurence.xcodeproj/project.pbxproj
+++ b/Eurofurence.xcodeproj/project.pbxproj
@@ -1227,7 +1227,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "#!/bin/bash\n\nif which swiftlint >/dev/null; then\n  swiftlint --path ${SRCROOT}/ --config ${SRCROOT}/.swiftlint.yml\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi \n";
+			shellScript = "#!/bin/bash\n\nif which swiftlint >/dev/null; then\n  swiftlint --config ${SRCROOT}/.swiftlint.yml ${SRCROOT}/\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi \n";
 		};
 		CA8950F522B4452F00AF4875 /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1245,7 +1245,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "#!/bin/bash\n\nif which swiftlint >/dev/null; then\n  swiftlint --path ${SRCROOT}/ --config ${SRCROOT}/.swiftlint.yml\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi \n";
+			shellScript = "#!/bin/bash\n\nif which swiftlint >/dev/null; then\n  swiftlint --config ${SRCROOT}/.swiftlint.yml ${SRCROOT}/\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi \n";
 		};
 		CA8950F722B44DB200AF4875 /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Map Detail/View/UIKit/MapContextualContentViewController.swift
+++ b/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Map Detail/View/UIKit/MapContextualContentViewController.swift
@@ -3,10 +3,6 @@ import UIKit
 class MapContextualContentViewController: UIViewController {
 
     @IBOutlet private weak var titleLabel: UILabel!
-    @IBOutlet private weak var leftConstraint: NSLayoutConstraint!
-    @IBOutlet private weak var rightConstraint: NSLayoutConstraint!
-    @IBOutlet private weak var topConstraint: NSLayoutConstraint!
-    @IBOutlet private weak var bottomConstraint: NSLayoutConstraint!
 
     func setContextualContent(_ content: String) {
         titleLabel.text = content
@@ -17,47 +13,6 @@ class MapContextualContentViewController: UIViewController {
         
         let preferredSize = view.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
         preferredContentSize = preferredSize
-        
-        // Deactivate the priority of the constraint on the opposite side of the arrow.
-        // This allows us to maintain a preferred size while maintaining said size with the inclusion of the arrow.
-        
-        guard let popover = popoverPresentationController else { return }
-        guard leftConstraint != nil,
-              rightConstraint != nil,
-              topConstraint != nil,
-              bottomConstraint != nil else { return }
-        
-        var constraintsToActivate: [NSLayoutConstraint] = [
-            leftConstraint,
-            rightConstraint,
-            topConstraint,
-            bottomConstraint
-        ]
-        
-        var constraintToDeactivate: NSLayoutConstraint?
-        switch popover.arrowDirection {
-        case .left:
-            constraintToDeactivate = leftConstraint
-            
-        case .right:
-            constraintToDeactivate = rightConstraint
-            
-        case .up:
-            constraintToDeactivate = topConstraint
-            
-        case .down:
-            constraintToDeactivate = bottomConstraint
-            
-        default:
-            break
-        }
-        
-        if let constraintToDeactivate = constraintToDeactivate {
-            constraintsToActivate.removeAll(where: { $0 === constraintToDeactivate })
-            NSLayoutConstraint.deactivate([constraintToDeactivate])
-        }
-        
-        NSLayoutConstraint.activate(constraintsToActivate)
     }
 
 }

--- a/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Map Detail/View/UIKit/MapDetail.storyboard
+++ b/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Map Detail/View/UIKit/MapDetail.storyboard
@@ -70,10 +70,10 @@
                                 </subviews>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
-                                    <constraint firstItem="A5a-fB-zLf" firstAttribute="leading" secondItem="doP-77-91S" secondAttribute="leading" constant="20" symbolic="YES" id="6rf-B0-oqc"/>
-                                    <constraint firstAttribute="trailing" secondItem="A5a-fB-zLf" secondAttribute="trailing" constant="20" symbolic="YES" id="CSg-Ia-BMa"/>
-                                    <constraint firstItem="A5a-fB-zLf" firstAttribute="top" secondItem="doP-77-91S" secondAttribute="top" constant="20" symbolic="YES" id="jX6-tA-CPb"/>
-                                    <constraint firstAttribute="bottom" secondItem="A5a-fB-zLf" secondAttribute="bottom" constant="20" symbolic="YES" id="kRS-cH-dCE"/>
+                                    <constraint firstItem="A5a-fB-zLf" firstAttribute="leading" secondItem="doP-77-91S" secondAttribute="leadingMargin" constant="12" id="6rf-B0-oqc"/>
+                                    <constraint firstAttribute="trailingMargin" secondItem="A5a-fB-zLf" secondAttribute="trailing" constant="12" id="CSg-Ia-BMa"/>
+                                    <constraint firstItem="A5a-fB-zLf" firstAttribute="top" secondItem="doP-77-91S" secondAttribute="topMargin" constant="12" id="jX6-tA-CPb"/>
+                                    <constraint firstAttribute="bottomMargin" secondItem="A5a-fB-zLf" secondAttribute="bottom" constant="12" id="kRS-cH-dCE"/>
                                 </constraints>
                             </view>
                         </subviews>
@@ -88,11 +88,7 @@
                     </view>
                     <size key="freeformSize" width="375" height="100"/>
                     <connections>
-                        <outlet property="bottomConstraint" destination="kRS-cH-dCE" id="nA6-7G-iks"/>
-                        <outlet property="leftConstraint" destination="6rf-B0-oqc" id="DLY-Aw-pJ0"/>
-                        <outlet property="rightConstraint" destination="CSg-Ia-BMa" id="Orq-Go-r5d"/>
                         <outlet property="titleLabel" destination="A5a-fB-zLf" id="xhF-Kx-mGb"/>
-                        <outlet property="topConstraint" destination="jX6-tA-CPb" id="WmV-UD-ck2"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="awv-bg-9dx" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Map Detail/View/UIKit/MapDetailViewController.swift
+++ b/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Map Detail/View/UIKit/MapDetailViewController.swift
@@ -57,6 +57,10 @@ class MapDetailViewController: UIViewController,
     func adaptivePresentationStyle(for controller: UIPresentationController) -> UIModalPresentationStyle {
         return .none
     }
+    
+    func adaptivePresentationStyle(for controller: UIPresentationController, traitCollection: UITraitCollection) -> UIModalPresentationStyle {
+        return .none
+    }
 
     // MARK: MapDetailScene
 

--- a/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Map Detail/View/UIKit/MapDetailViewController.swift
+++ b/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Map Detail/View/UIKit/MapDetailViewController.swift
@@ -58,7 +58,8 @@ class MapDetailViewController: UIViewController,
         return .none
     }
     
-    func adaptivePresentationStyle(for controller: UIPresentationController, traitCollection: UITraitCollection) -> UIModalPresentationStyle {
+    func adaptivePresentationStyle(for controller: UIPresentationController,
+                                   traitCollection: UITraitCollection) -> UIModalPresentationStyle {
         return .none
     }
 

--- a/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Message Detail/Presenter/MessageDetailPresenter.swift
+++ b/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/Message Detail/Presenter/MessageDetailPresenter.swift
@@ -38,7 +38,8 @@ class MessageDetailPresenter: MessageDetailSceneDelegate {
                 message.markAsRead()
                 
                 self.scene?.setMessageDetailTitle(message.authorName)
-                self.scene?.showMessage(viewModel: MessageViewModel(message: message, markdownRenderer: markdownRenderer))
+                self.scene?.showMessage(viewModel: MessageViewModel(message: message,
+                                                                    markdownRenderer: markdownRenderer))
                 
             case .failure(let error):
                 self.scene?.showError(

--- a/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/Message Detail/MessageDetailPresenterTests.swift
+++ b/Packages/EurofurenceApplication/Tests/EurofurenceApplicationTests/Application/Components/Message Detail/MessageDetailPresenterTests.swift
@@ -1,7 +1,7 @@
 import EurofurenceApplication
 import EurofurenceModel
-import XCTest
 import XCTComponentBase
+import XCTest
 import XCTEurofurenceModel
 
 class MessageDetailPresenterTests: XCTestCase {

--- a/Packages/EurofurenceModel/Tests/EurofurenceModelAdapterTests/Network/Network Layer Stubbing/JournallingURLRequestLogger.swift
+++ b/Packages/EurofurenceModel/Tests/EurofurenceModelAdapterTests/Network/Network Layer Stubbing/JournallingURLRequestLogger.swift
@@ -39,11 +39,9 @@ class JournallingURLRequestLogger {
 
     func record(_ request: URLRequest) {
         var requestsToRemove = [ExpectedRequest]()
-        for (expectedRequest, expectation) in expectations {
-            if expectedRequest.expected(request) {
-                expectation.fulfill()
-                requestsToRemove.append(expectedRequest)
-            }
+        for (expectedRequest, expectation) in expectations where expectedRequest.expected(request) {
+            expectation.fulfill()
+            requestsToRemove.append(expectedRequest)
         }
 
         for request in requestsToRemove {


### PR DESCRIPTION
The usable area of the view for the map popovers becomes asymmetric due to the arrow sticking out to one side. Since this is reflected by its safe area insets, making the constraints of the label inside relative to the superview's margins automagically corrects its alignment.
This PR also fixes an issue with map popovers rendering fullscreen on compact size classes.