### PR TITLE
Fix font size and colour for `code` in Markdown on Dark Mode

### DIFF
--- a/Packages/EurofurenceComponents/Sources/ComponentBase/Markdown Rendering/Down/DefaultDownMarkdownRenderer.swift
+++ b/Packages/EurofurenceComponents/Sources/ComponentBase/Markdown Rendering/Down/DefaultDownMarkdownRenderer.swift
@@ -17,13 +17,14 @@ public struct DefaultDownMarkdownRenderer: MarkdownRenderer {
         var colorCollection = StaticColorCollection()
         
         let textColor: UIColor = .label
+        colorCollection.body = textColor
+        colorCollection.code = textColor
         colorCollection.heading1 = textColor
         colorCollection.heading2 = textColor
         colorCollection.heading3 = textColor
         colorCollection.heading4 = textColor
         colorCollection.heading5 = textColor
         colorCollection.heading6 = textColor
-        colorCollection.body = textColor
         colorCollection.listItemPrefix = textColor
         
         return colorCollection

--- a/Packages/EurofurenceComponents/Sources/ComponentBase/Markdown Rendering/Down/SubtleDownMarkdownRenderer.swift
+++ b/Packages/EurofurenceComponents/Sources/ComponentBase/Markdown Rendering/Down/SubtleDownMarkdownRenderer.swift
@@ -9,6 +9,7 @@ public struct SubtleDownMarkdownRenderer: MarkdownRenderer {
         var fontCollection = StaticFontCollection()
         let sharedFont = UIFont.preferredFont(forTextStyle: .caption1)
         fontCollection.body = sharedFont
+        fontCollection.code = fontCollection.code.withSize(sharedFont.pointSize)
         fontCollection.heading1 = sharedFont
         fontCollection.heading2 = sharedFont
         fontCollection.heading3 = sharedFont
@@ -23,12 +24,14 @@ public struct SubtleDownMarkdownRenderer: MarkdownRenderer {
         var colorCollection = StaticColorCollection()
         let sharedColor = UIColor(red: 0.498, green: 0.498, blue: 0.498, alpha: 1)
         colorCollection.body = sharedColor
+        colorCollection.code = sharedColor
         colorCollection.heading1 = sharedColor
         colorCollection.heading2 = sharedColor
         colorCollection.heading3 = sharedColor
         colorCollection.heading4 = sharedColor
         colorCollection.heading5 = sharedColor
         colorCollection.heading6 = sharedColor
+        colorCollection.listItemPrefix = sharedColor
         colorCollection.quote = sharedColor
         colorCollection.quoteStripe = sharedColor
         
@@ -42,6 +45,7 @@ public struct SubtleDownMarkdownRenderer: MarkdownRenderer {
         sharedParagraphStyle.paragraphSpacing = 0
         sharedParagraphStyle.lineSpacing = 3
         paragraphStyles.body = sharedParagraphStyle
+        paragraphStyles.code = sharedParagraphStyle
         paragraphStyles.heading1 = sharedParagraphStyle
         paragraphStyles.heading2 = sharedParagraphStyle
         paragraphStyles.heading3 = sharedParagraphStyle


### PR DESCRIPTION
`code` in Markdown-enabled views would render as black on black in Dark Mode and would also display in too big a font when using the SubtleDownMarkdownRenderer.