### PR TITLE
Add favourites toggle to the schedule tab

### DIFF
--- a/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/News/Widgets/Events/Model/FilteredScheduleWidgetDataSource.swift
+++ b/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/News/Widgets/Events/Model/FilteredScheduleWidgetDataSource.swift
@@ -29,6 +29,10 @@ public struct FilteredScheduleWidgetDataSource<S>: EventsWidgetDataSource where 
             
         }
         
+        func scheduleSpecificationChanged(to newSpecification: AnySpecification<Event>) {
+            
+        }
+        
     }
     
 }

--- a/Packages/EurofurenceComponents/Sources/ScheduleComponent/Presenter/SchedulePresenter.swift
+++ b/Packages/EurofurenceComponents/Sources/ScheduleComponent/Presenter/SchedulePresenter.swift
@@ -311,6 +311,14 @@ class SchedulePresenter: ScheduleSceneDelegate, ScheduleViewModelDelegate, Sched
         scene.bindSearchResults(numberOfItemsPerSection: numberOfItemsPerGroup, using: binder)
     }
     
+    func scheduleViewModelDidFilterToFavourites() {
+        scene.showFilterToAllEventsButton()
+    }
+    
+    func scheduleViewModelDidRemoveFavouritesFilter() {
+        scene.showFilterToFavouritesButton()
+    }
+    
     private func leaveFeedbackForEvent(at indexPath: IndexPath) {
         guard let identifier = viewModel?.identifierForEvent(at: indexPath) else { return }
         delegate.scheduleComponentDidRequestPresentationToLeaveFeedback(for: identifier)

--- a/Packages/EurofurenceComponents/Sources/ScheduleComponent/Presenter/SchedulePresenter.swift
+++ b/Packages/EurofurenceComponents/Sources/ScheduleComponent/Presenter/SchedulePresenter.swift
@@ -252,6 +252,10 @@ class SchedulePresenter: ScheduleSceneDelegate, ScheduleViewModelDelegate, Sched
     func scheduleSceneDidSelectEvent(at indexPath: IndexPath) {
         viewModel?.identifierForEvent(at: indexPath).map(delegate.scheduleComponentDidSelectEvent)
     }
+    
+    func scheduleSceneDidToggleFavouriteFilterState() {
+        viewModel?.toggleFavouriteFilteringState()
+    }
 
     func scheduleSceneDidSelectSearchResult(at indexPath: IndexPath) {
         searchViewModel?.identifierForEvent(at: indexPath).map(delegate.scheduleComponentDidSelectEvent)

--- a/Packages/EurofurenceComponents/Sources/ScheduleComponent/View Model/DefaultScheduleViewModelFactory.swift
+++ b/Packages/EurofurenceComponents/Sources/ScheduleComponent/View Model/DefaultScheduleViewModelFactory.swift
@@ -155,7 +155,13 @@ public class DefaultScheduleViewModelFactory: ScheduleViewModelFactory {
         }
         
         func scheduleSpecificationChanged(to newSpecification: AnySpecification<Event>) {
+            isFilteringToFavourites = newSpecification.contains(IsFavouriteEventSpecification.self)
             
+            if isFilteringToFavourites {
+                delegate?.scheduleViewModelDidFilterToFavourites()
+            } else {
+                delegate?.scheduleViewModelDidRemoveFavouritesFilter()
+            }
         }
 
         func setDelegate(_ delegate: ScheduleViewModelDelegate) {
@@ -190,8 +196,7 @@ public class DefaultScheduleViewModelFactory: ScheduleViewModelFactory {
         }
         
         func toggleFavouriteFilteringState() {
-            isFilteringToFavourites = true
-            
+            isFilteringToFavourites.toggle()
             updateScheduleSpecification()
         }
 
@@ -208,10 +213,19 @@ public class DefaultScheduleViewModelFactory: ScheduleViewModelFactory {
         
         private func updateScheduleSpecification() {
             if let currentDay = currentDay {
-                let spec = EventsOccurringOnDaySpecification(day: currentDay) && IsFavouriteEventSpecification()
-                schedule.filterSchedule(to: spec)
+                if isFilteringToFavourites {
+                    let spec = EventsOccurringOnDaySpecification(day: currentDay) && IsFavouriteEventSpecification()
+                    schedule.filterSchedule(to: spec)
+                } else {
+                    let spec = EventsOccurringOnDaySpecification(day: currentDay)
+                    schedule.filterSchedule(to: spec)
+                }
             } else {
-                schedule.filterSchedule(to: IsFavouriteEventSpecification())
+                if isFilteringToFavourites {
+                    schedule.filterSchedule(to: IsFavouriteEventSpecification())
+                } else {
+                    schedule.filterSchedule(to: AllEventsSpecification())
+                }
             }
         }
 

--- a/Packages/EurofurenceComponents/Sources/ScheduleComponent/View Model/DefaultScheduleViewModelFactory.swift
+++ b/Packages/EurofurenceComponents/Sources/ScheduleComponent/View Model/DefaultScheduleViewModelFactory.swift
@@ -180,6 +180,10 @@ public class DefaultScheduleViewModelFactory: ScheduleViewModelFactory {
             let event = group.events[indexPath.row]
             return event.identifier
         }
+        
+        func toggleFavouriteFilteringState() {
+            
+        }
 
         func refreshServiceDidBeginRefreshing() {
             delegate?.scheduleViewModelDidBeginRefreshing()

--- a/Packages/EurofurenceComponents/Sources/ScheduleComponent/View Model/DefaultScheduleViewModelFactory.swift
+++ b/Packages/EurofurenceComponents/Sources/ScheduleComponent/View Model/DefaultScheduleViewModelFactory.swift
@@ -180,8 +180,8 @@ public class DefaultScheduleViewModelFactory: ScheduleViewModelFactory {
         func showEventsForDay(at index: Int) {
             guard days.count > index else { return }
             
-            let day = days[index]
-            schedule.filterSchedule(to: EventsOccurringOnDaySpecification(day: day))
+            currentDay = days[index]
+            updateScheduleSpecification()
         }
 
         func identifierForEvent(at indexPath: IndexPath) -> EventIdentifier? {

--- a/Packages/EurofurenceComponents/Sources/ScheduleComponent/View Model/DefaultScheduleViewModelFactory.swift
+++ b/Packages/EurofurenceComponents/Sources/ScheduleComponent/View Model/DefaultScheduleViewModelFactory.swift
@@ -150,6 +150,10 @@ public class DefaultScheduleViewModelFactory: ScheduleViewModelFactory {
             guard let idx = days.firstIndex(where: { $0.date == day.date }) else { return }
             selectedDayIndex = idx
         }
+        
+        func scheduleSpecificationChanged(to newSpecification: AnySpecification<Event>) {
+            
+        }
 
         func setDelegate(_ delegate: ScheduleViewModelDelegate) {
             self.delegate = delegate
@@ -273,6 +277,10 @@ public class DefaultScheduleViewModelFactory: ScheduleViewModelFactory {
         func eventDaysDidChange(to days: [Day]) { }
         
         func currentEventDayDidChange(to day: Day?) { }
+        
+        func scheduleSpecificationChanged(to newSpecification: AnySpecification<Event>) {
+            
+        }
 
         private func regenerateViewModel() {
             let groupedByDate = Dictionary(grouping: searchResults, by: { $0.startDate })

--- a/Packages/EurofurenceComponents/Sources/ScheduleComponent/View Model/ScheduleSpecificationController.swift
+++ b/Packages/EurofurenceComponents/Sources/ScheduleComponent/View Model/ScheduleSpecificationController.swift
@@ -1,0 +1,45 @@
+import EurofurenceModel
+
+class ScheduleSpecificationController {
+    
+    private let schedule: Schedule
+    private var currentDay: Day?
+    private(set) var isFilteringToFavourites = false
+    
+    init(schedule: Schedule) {
+        self.schedule = schedule
+    }
+    
+    func scheduleSpecificationDidChange(newSpecification: AnySpecification<Event>) {
+        isFilteringToFavourites = newSpecification.contains(IsFavouriteEventSpecification.self)
+    }
+    
+    func toggleFavouritesFiltering() {
+        isFilteringToFavourites.toggle()
+        updateScheduleSpecification()
+    }
+    
+    func filterToEvents(occurringOn day: Day?) {
+        currentDay = day
+        updateScheduleSpecification()
+    }
+    
+    private func updateScheduleSpecification() {
+        if let currentDay = currentDay {
+            if isFilteringToFavourites {
+                let spec = EventsOccurringOnDaySpecification(day: currentDay) && IsFavouriteEventSpecification()
+                schedule.filterSchedule(to: spec)
+            } else {
+                let spec = EventsOccurringOnDaySpecification(day: currentDay)
+                schedule.filterSchedule(to: spec)
+            }
+        } else {
+            if isFilteringToFavourites {
+                schedule.filterSchedule(to: IsFavouriteEventSpecification())
+            } else {
+                schedule.filterSchedule(to: AllEventsSpecification())
+            }
+        }
+    }
+    
+}

--- a/Packages/EurofurenceComponents/Sources/ScheduleComponent/View Model/ScheduleViewModel.swift
+++ b/Packages/EurofurenceComponents/Sources/ScheduleComponent/View Model/ScheduleViewModel.swift
@@ -17,5 +17,7 @@ public protocol ScheduleViewModelDelegate {
     func scheduleViewModelDidUpdateDays(_ days: [ScheduleDayViewModel])
     func scheduleViewModelDidUpdateCurrentDayIndex(to index: Int)
     func scheduleViewModelDidUpdateEvents(_ events: [ScheduleEventGroupViewModel])
+    func scheduleViewModelDidFilterToFavourites()
+    func scheduleViewModelDidRemoveFavouritesFilter()
 
 }

--- a/Packages/EurofurenceComponents/Sources/ScheduleComponent/View Model/ScheduleViewModel.swift
+++ b/Packages/EurofurenceComponents/Sources/ScheduleComponent/View Model/ScheduleViewModel.swift
@@ -7,6 +7,7 @@ public protocol ScheduleViewModel {
     func refresh()
     func showEventsForDay(at index: Int)
     func identifierForEvent(at indexPath: IndexPath) -> EventIdentifier?
+    func toggleFavouriteFilteringState()
 
 }
 

--- a/Packages/EurofurenceComponents/Sources/ScheduleComponent/View/Abstraction/ScheduleScene.swift
+++ b/Packages/EurofurenceComponents/Sources/ScheduleComponent/View/Abstraction/ScheduleScene.swift
@@ -24,8 +24,9 @@ public protocol ScheduleSceneDelegate {
     func scheduleSceneDidPerformRefreshAction()
     func scheduleSceneDidSelectDay(at index: Int)
     func scheduleSceneDidSelectEvent(at indexPath: IndexPath)
+    func scheduleSceneDidToggleFavouriteFilterState()
+    
     func scheduleSceneDidSelectSearchResult(at indexPath: IndexPath)
-
     func scheduleSceneDidUpdateSearchQuery(_ query: String)
     func scheduleSceneDidChangeSearchScopeToAllEvents()
     func scheduleSceneDidChangeSearchScopeToFavouriteEvents()

--- a/Packages/EurofurenceComponents/Sources/ScheduleComponent/View/Abstraction/ScheduleScene.swift
+++ b/Packages/EurofurenceComponents/Sources/ScheduleComponent/View/Abstraction/ScheduleScene.swift
@@ -12,6 +12,9 @@ public protocol ScheduleScene {
     func selectDay(at index: Int)
     func showSearchResults()
     func hideSearchResults()
+    
+    func showFilterToFavouritesButton()
+    func showFilterToAllEventsButton()
 
 }
 

--- a/Packages/EurofurenceComponents/Sources/ScheduleComponent/View/UIKit/ScheduleViewController.swift
+++ b/Packages/EurofurenceComponents/Sources/ScheduleComponent/View/UIKit/ScheduleViewController.swift
@@ -22,9 +22,11 @@ public class ScheduleViewController: UIViewController,
     
     private var tableController: TableController? {
         didSet {
-            tableView.dataSource = tableController
-            tableView.delegate = tableController
-            tableView.reloadData()
+            UIView.transition(with: tableView, duration: 0.25, options: [.transitionCrossDissolve]) { [self] in
+                tableView.dataSource = tableController
+                tableView.delegate = tableController
+                tableView.reloadData()
+            }
         }
     }
     

--- a/Packages/EurofurenceComponents/Sources/ScheduleComponent/View/UIKit/ScheduleViewController.swift
+++ b/Packages/EurofurenceComponents/Sources/ScheduleComponent/View/UIKit/ScheduleViewController.swift
@@ -35,6 +35,22 @@ public class ScheduleViewController: UIViewController,
         searchController?.isActive = true
     }
     
+    private lazy var favouritesToggleButton: UIButton = {
+        let toggleButton = UIButton(frame: .zero)
+        toggleButton.addTarget(self, action: #selector(favouritesToggleButtonTapped(_:)), for: .touchUpInside)
+        toggleButton.setImage(UIImage(systemName: "heart.circle"), for: .normal)
+        toggleButton.setImage(UIImage(systemName: "heart.circle.fill"), for: .selected)
+        toggleButton.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        toggleButton.tintColor = .white
+        toggleButton.accessibilityLabel = "Favourites Only"
+        
+        return toggleButton
+    }()
+    
+    @objc private func favouritesToggleButtonTapped(_ sender: UIButton) {
+        
+    }
+    
     // MARK: Overrides
     
     override public func viewDidLoad() {
@@ -56,6 +72,7 @@ public class ScheduleViewController: UIViewController,
         refreshControl.addTarget(self, action: #selector(refreshControlDidChangeValue), for: .valueChanged)
         
         prepareSearchController()
+        navigationItem.rightBarButtonItem = UIBarButtonItem(customView: favouritesToggleButton)
         
         let cellName = String(describing: EventTableViewCell.self)
         let cellNib = UINib(nibName: cellName, bundle: .module)
@@ -177,11 +194,11 @@ public class ScheduleViewController: UIViewController,
     }
     
     public func showFilterToFavouritesButton() {
-        
+        favouritesToggleButton.isSelected = false
     }
     
     public func showFilterToAllEventsButton() {
-        
+        favouritesToggleButton.isSelected = true
     }
     
     // MARK: DaysHorizontalPickerViewDelegate

--- a/Packages/EurofurenceComponents/Sources/ScheduleComponent/View/UIKit/ScheduleViewController.swift
+++ b/Packages/EurofurenceComponents/Sources/ScheduleComponent/View/UIKit/ScheduleViewController.swift
@@ -48,7 +48,7 @@ public class ScheduleViewController: UIViewController,
     }()
     
     @objc private func favouritesToggleButtonTapped(_ sender: UIButton) {
-        
+        delegate?.scheduleSceneDidToggleFavouriteFilterState()
     }
     
     // MARK: Overrides

--- a/Packages/EurofurenceComponents/Sources/ScheduleComponent/View/UIKit/ScheduleViewController.swift
+++ b/Packages/EurofurenceComponents/Sources/ScheduleComponent/View/UIKit/ScheduleViewController.swift
@@ -176,6 +176,14 @@ public class ScheduleViewController: UIViewController,
         daysHorizontalPickerView.selectDay(at: index)
     }
     
+    public func showFilterToFavouritesButton() {
+        
+    }
+    
+    public func showFilterToAllEventsButton() {
+        
+    }
+    
     // MARK: DaysHorizontalPickerViewDelegate
     
     func daysHorizontalPickerView(_ pickerView: DaysHorizontalPickerView, didSelectDayAt index: Int) {

--- a/Packages/EurofurenceComponents/Sources/ScheduleComponent/View/UIKit/ScheduleViewController.swift
+++ b/Packages/EurofurenceComponents/Sources/ScheduleComponent/View/UIKit/ScheduleViewController.swift
@@ -18,6 +18,38 @@ public class ScheduleViewController: UIViewController,
         }
     }
     
+    private lazy var showFavouritesOnlyBarButtonItem: UIBarButtonItem = {
+        let showFavouritesOnlyBarButtonItem = UIBarButtonItem(
+            image: UIImage(systemName: "heart.circle"),
+            style: .plain,
+            target: self,
+            action: #selector(favouritesToggleButtonTapped(_:))
+        )
+        
+        showFavouritesOnlyBarButtonItem.accessibilityLabel = "Favourites Only"
+        showFavouritesOnlyBarButtonItem.tintColor = .white
+        
+        return showFavouritesOnlyBarButtonItem
+    }()
+    
+    private lazy var showAllEventsBarButtonItem: UIBarButtonItem = {
+        let showAllEventsBarButtonItem = UIBarButtonItem(
+            image: UIImage(systemName: "heart.circle.fill"),
+            style: .plain,
+            target: self,
+            action: #selector(favouritesToggleButtonTapped(_:))
+        )
+        
+        showAllEventsBarButtonItem.accessibilityLabel = "All Events"
+        showAllEventsBarButtonItem.tintColor = .white
+        
+        return showAllEventsBarButtonItem
+    }()
+    
+    @objc private func favouritesToggleButtonTapped(_ sender: UIButton) {
+        delegate?.scheduleSceneDidToggleFavouriteFilterState()
+    }
+    
     private let refreshControl = UIRefreshControl(frame: .zero)
     
     private var tableController: TableController? {
@@ -35,22 +67,6 @@ public class ScheduleViewController: UIViewController,
     
     @IBAction private func openSearch(_ sender: Any) {
         searchController?.isActive = true
-    }
-    
-    private lazy var favouritesToggleButton: UIButton = {
-        let toggleButton = UIButton(frame: .zero)
-        toggleButton.addTarget(self, action: #selector(favouritesToggleButtonTapped(_:)), for: .touchUpInside)
-        toggleButton.setImage(UIImage(systemName: "heart.circle"), for: .normal)
-        toggleButton.setImage(UIImage(systemName: "heart.circle.fill"), for: .selected)
-        toggleButton.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        toggleButton.tintColor = .white
-        toggleButton.accessibilityLabel = "Favourites Only"
-        
-        return toggleButton
-    }()
-    
-    @objc private func favouritesToggleButtonTapped(_ sender: UIButton) {
-        delegate?.scheduleSceneDidToggleFavouriteFilterState()
     }
     
     // MARK: Overrides
@@ -74,7 +90,6 @@ public class ScheduleViewController: UIViewController,
         refreshControl.addTarget(self, action: #selector(refreshControlDidChangeValue), for: .valueChanged)
         
         prepareSearchController()
-        navigationItem.rightBarButtonItem = UIBarButtonItem(customView: favouritesToggleButton)
         
         let cellName = String(describing: EventTableViewCell.self)
         let cellNib = UINib(nibName: cellName, bundle: .module)
@@ -196,11 +211,11 @@ public class ScheduleViewController: UIViewController,
     }
     
     public func showFilterToFavouritesButton() {
-        favouritesToggleButton.isSelected = false
+        navigationItem.setRightBarButton(showFavouritesOnlyBarButtonItem, animated: view.window != nil)
     }
     
     public func showFilterToAllEventsButton() {
-        favouritesToggleButton.isSelected = true
+        navigationItem.setRightBarButton(showAllEventsBarButtonItem, animated: view.window != nil)
     }
     
     // MARK: DaysHorizontalPickerViewDelegate

--- a/Packages/EurofurenceComponents/Sources/XCTScheduleComponent/StubScheduleViewModel.swift
+++ b/Packages/EurofurenceComponents/Sources/XCTScheduleComponent/StubScheduleViewModel.swift
@@ -82,5 +82,13 @@ extension CapturingScheduleViewModel {
     public func simulateScheduleRefreshDidFinish() {
         delegate?.scheduleViewModelDidFinishRefreshing()
     }
+    
+    public func simulateShowingFavourites() {
+        delegate?.scheduleViewModelDidFilterToFavourites()
+    }
+    
+    public func simulateShowingAllEvents() {
+        delegate?.scheduleViewModelDidRemoveFavouritesFilter()
+    }
 
 }

--- a/Packages/EurofurenceComponents/Sources/XCTScheduleComponent/StubScheduleViewModel.swift
+++ b/Packages/EurofurenceComponents/Sources/XCTScheduleComponent/StubScheduleViewModel.swift
@@ -58,6 +58,11 @@ public final class CapturingScheduleViewModel: ScheduleViewModel {
     func unfavouriteEvent(at indexPath: IndexPath) {
         indexPathForUnfavouritedEvent = indexPath
     }
+    
+    public private(set) var didToggleFavouriteFilteringState = false
+    public func toggleFavouriteFilteringState() {
+        didToggleFavouriteFilteringState = true
+    }
 
 }
 

--- a/Packages/EurofurenceComponents/Tests/ScheduleComponentTests/Presenter Tests/Test Doubles/CapturingScheduleScene.swift
+++ b/Packages/EurofurenceComponents/Tests/ScheduleComponentTests/Presenter Tests/Test Doubles/CapturingScheduleScene.swift
@@ -1,6 +1,7 @@
 import EurofurenceModel
 import ScheduleComponent
 import UIKit.UIViewController
+import XCTComponentBase
 
 class CapturingScheduleScene: UIViewController, ScheduleScene {
 
@@ -60,6 +61,21 @@ class CapturingScheduleScene: UIViewController, ScheduleScene {
     private(set) var didHideSearchResults = false
     func hideSearchResults() {
         didHideSearchResults = true
+    }
+    
+    enum VisibleFilterButton: Equatable {
+        case unknown
+        case filterToFavourites
+        case filterToAllEvents
+    }
+    
+    private(set) var visibleFilterButton: VisibleFilterButton = .unknown
+    func showFilterToFavouritesButton() {
+        visibleFilterButton = .filterToFavourites
+    }
+    
+    func showFilterToAllEventsButton() {
+        visibleFilterButton = .filterToAllEvents
     }
 
 }

--- a/Packages/EurofurenceComponents/Tests/ScheduleComponentTests/Presenter Tests/WhenSceneTogglesFavouriteFilteringState_SchedulePresenterShould.swift
+++ b/Packages/EurofurenceComponents/Tests/ScheduleComponentTests/Presenter Tests/WhenSceneTogglesFavouriteFilteringState_SchedulePresenterShould.swift
@@ -1,0 +1,18 @@
+import EurofurenceModel
+import ScheduleComponent
+import XCTest
+import XCTScheduleComponent
+
+class WhenSceneTogglesFavouriteFilteringState_SchedulePresenterShould: XCTestCase {
+    
+    func testTellViewModelToToggleActiveFavouritesFilteringState() {
+        let viewModel = CapturingScheduleViewModel.random
+        let viewModelFactory = FakeScheduleViewModelFactory(viewModel: viewModel)
+        let context = SchedulePresenterTestBuilder().with(viewModelFactory).build()
+        context.simulateSceneDidLoad()
+        context.scene.delegate?.scheduleSceneDidToggleFavouriteFilterState()
+        
+        XCTAssertTrue(viewModel.didToggleFavouriteFilteringState)
+    }
+    
+}

--- a/Packages/EurofurenceComponents/Tests/ScheduleComponentTests/Presenter Tests/WhenScheduleFiltersToAllEvents_SchedulePresenterShould.swift
+++ b/Packages/EurofurenceComponents/Tests/ScheduleComponentTests/Presenter Tests/WhenScheduleFiltersToAllEvents_SchedulePresenterShould.swift
@@ -1,0 +1,18 @@
+import EurofurenceModel
+import ScheduleComponent
+import XCTest
+import XCTScheduleComponent
+
+class WhenScheduleFiltersToAllEvents_SchedulePresenterShould: XCTestCase {
+    
+    func testTellSceneToShowFavouritesFilterButton() {
+        let viewModel = CapturingScheduleViewModel.random
+        let viewModelFactory = FakeScheduleViewModelFactory(viewModel: viewModel)
+        let context = SchedulePresenterTestBuilder().with(viewModelFactory).build()
+        context.simulateSceneDidLoad()
+        viewModel.simulateShowingAllEvents()
+        
+        XCTAssertEqual(.filterToFavourites, context.scene.visibleFilterButton)
+    }
+    
+}

--- a/Packages/EurofurenceComponents/Tests/ScheduleComponentTests/Presenter Tests/WhenScheduleFiltersToFavourites_SchedulePresenterShould.swift
+++ b/Packages/EurofurenceComponents/Tests/ScheduleComponentTests/Presenter Tests/WhenScheduleFiltersToFavourites_SchedulePresenterShould.swift
@@ -1,0 +1,18 @@
+import EurofurenceModel
+import ScheduleComponent
+import XCTest
+import XCTScheduleComponent
+
+class WhenScheduleFiltersToFavourites_SchedulePresenterShould: XCTestCase {
+    
+    func testTellSceneToShowAllEventsFilterButton() {
+        let viewModel = CapturingScheduleViewModel.random
+        let viewModelFactory = FakeScheduleViewModelFactory(viewModel: viewModel)
+        let context = SchedulePresenterTestBuilder().with(viewModelFactory).build()
+        context.simulateSceneDidLoad()
+        viewModel.simulateShowingFavourites()
+        
+        XCTAssertEqual(.filterToAllEvents, context.scene.visibleFilterButton)
+    }
+    
+}

--- a/Packages/EurofurenceComponents/Tests/ScheduleComponentTests/View Model Tests/Favourites toggle/WhenScheduleConfiguredForFavourites_ScheduleViewModelShould.swift
+++ b/Packages/EurofurenceComponents/Tests/ScheduleComponentTests/View Model Tests/Favourites toggle/WhenScheduleConfiguredForFavourites_ScheduleViewModelShould.swift
@@ -1,0 +1,70 @@
+import EurofurenceModel
+import ScheduleComponent
+import XCTest
+import XCTEurofurenceModel
+
+class WhenScheduleConfiguredForFavourites_ScheduleViewModelShould: XCTestCase {
+    
+    func testNotifyDelegateViewingAllEvents() throws {
+        let eventsService = FakeScheduleRepository()
+        eventsService.stubSomeFavouriteEvents()
+        let context = ScheduleViewModelFactoryTestBuilder().with(eventsService).build()
+        context.makeViewModel()
+        
+        let schedule = try XCTUnwrap(context.eventsService.schedule(for: "Schedule"))
+        schedule.filterSchedule(to: IsFavouriteEventSpecification())
+
+        XCTAssertEqual(.favouritesOnly, context.viewModelDelegate.favouritesfilter)
+    }
+    
+    func testRemoveFavouriteEventsSpecificationWhenTogglingFavourites() throws {
+        let eventsService = FakeScheduleRepository()
+        eventsService.stubSomeFavouriteEvents()
+        let context = ScheduleViewModelFactoryTestBuilder().with(eventsService).build()
+        let viewModel = context.makeViewModel()
+        
+        let schedule = try XCTUnwrap(context.eventsService.schedule(for: "Schedule"))
+        schedule.filterSchedule(to: IsFavouriteEventSpecification())
+        
+        viewModel?.toggleFavouriteFilteringState()
+        
+        XCTAssertEqual(
+            AllEventsSpecification().eraseToAnySpecification(),
+            schedule.specification,
+            "Toggling from favourites to all events should remove the favourite event specification"
+        )
+    }
+    
+    func testDoesNotRemoveDaySpecificationWhenTogglingFavourites() throws {
+        let eventsService = FakeScheduleRepository()
+        eventsService.stubSomeFavouriteEvents()
+        let days = [Day].random
+        let currentDay = days.randomElement()
+        eventsService.simulateDaysChanged(days)
+        eventsService.simulateDayChanged(to: currentDay.element)
+        let context = ScheduleViewModelFactoryTestBuilder().with(eventsService).build()
+        let viewModel = context.makeViewModel()
+        viewModel?.toggleFavouriteFilteringState()
+        viewModel?.toggleFavouriteFilteringState()
+        
+        let schedule = try XCTUnwrap(context.eventsService.schedule(for: "Schedule"))
+        let scheduleSpecification = try XCTUnwrap(schedule.specification)
+        let expected = EventsOccurringOnDaySpecification(day: currentDay.element)
+        XCTAssertEqual(expected.eraseToAnySpecification(), scheduleSpecification)
+    }
+    
+    func testNotifiesDelegateViewingAllEventsWhenTogglingFilter() throws {
+        let eventsService = FakeScheduleRepository()
+        eventsService.stubSomeFavouriteEvents()
+        let context = ScheduleViewModelFactoryTestBuilder().with(eventsService).build()
+        let viewModel = context.makeViewModel()
+        
+        let schedule = try XCTUnwrap(context.eventsService.schedule(for: "Schedule"))
+        schedule.filterSchedule(to: IsFavouriteEventSpecification())
+        
+        viewModel?.toggleFavouriteFilteringState()
+        
+        XCTAssertEqual(.allEvents, context.viewModelDelegate.favouritesfilter)
+    }
+    
+}

--- a/Packages/EurofurenceComponents/Tests/ScheduleComponentTests/View Model Tests/Favourites toggle/WhenScheduleNotConfiguredForFavourites_ScheduleViewModelShould.swift
+++ b/Packages/EurofurenceComponents/Tests/ScheduleComponentTests/View Model Tests/Favourites toggle/WhenScheduleNotConfiguredForFavourites_ScheduleViewModelShould.swift
@@ -1,0 +1,66 @@
+import EurofurenceModel
+import ScheduleComponent
+import XCTest
+import XCTEurofurenceModel
+
+class WhenScheduleNotConfiguredForFavourites_ScheduleViewModelShould: XCTestCase {
+
+    func testNotifyDelegateViewingAllEvents() {
+        let eventsService = FakeScheduleRepository()
+        eventsService.stubSomeFavouriteEvents()
+        let context = ScheduleViewModelFactoryTestBuilder().with(eventsService).build()
+        context.makeViewModel()
+
+        XCTAssertEqual(.allEvents, context.viewModelDelegate.favouritesfilter)
+    }
+    
+    func testApplyFavouriteEventsSpecificationWhenTogglingFavourites() throws {
+        let eventsService = FakeScheduleRepository()
+        eventsService.stubSomeFavouriteEvents()
+        let context = ScheduleViewModelFactoryTestBuilder().with(eventsService).build()
+        let viewModel = context.makeViewModel()
+        viewModel?.toggleFavouriteFilteringState()
+        
+        let schedule = try XCTUnwrap(context.eventsService.schedule(for: "Schedule"))
+        let scheduleSpecification = try XCTUnwrap(schedule.specification)
+        XCTAssertTrue(
+            scheduleSpecification.contains(IsFavouriteEventSpecification.self),
+            "Toggling from all events to favourites should apply favourite event specification"
+        )
+    }
+    
+    func testDoesNotRemoveDaySpecificationWhenTogglingFavourites() throws {
+        let eventsService = FakeScheduleRepository()
+        eventsService.stubSomeFavouriteEvents()
+        let days = [Day].random
+        let currentDay = days.randomElement()
+        eventsService.simulateDaysChanged(days)
+        eventsService.simulateDayChanged(to: currentDay.element)
+        let context = ScheduleViewModelFactoryTestBuilder().with(eventsService).build()
+        let viewModel = context.makeViewModel()
+        viewModel?.toggleFavouriteFilteringState()
+        
+        let schedule = try XCTUnwrap(context.eventsService.schedule(for: "Schedule"))
+        let scheduleSpecification = try XCTUnwrap(schedule.specification)
+        let expected = EventsOccurringOnDaySpecification(day: currentDay.element) && IsFavouriteEventSpecification()
+        XCTAssertEqual(expected.eraseToAnySpecification(), scheduleSpecification)
+    }
+    
+    func testRetainFavouriteSpecificationFilteringWhenCurrentDayChanges() throws {
+        let eventsService = FakeScheduleRepository()
+        eventsService.stubSomeFavouriteEvents()
+        let days = [Day].random
+        let currentDay = days.randomElement()
+        eventsService.simulateDaysChanged(days)
+        let context = ScheduleViewModelFactoryTestBuilder().with(eventsService).build()
+        let viewModel = context.makeViewModel()
+        viewModel?.toggleFavouriteFilteringState()
+        eventsService.simulateDayChanged(to: currentDay.element)
+        
+        let schedule = try XCTUnwrap(context.eventsService.schedule(for: "Schedule"))
+        let scheduleSpecification = try XCTUnwrap(schedule.specification)
+        let expected = EventsOccurringOnDaySpecification(day: currentDay.element) && IsFavouriteEventSpecification()
+        XCTAssertEqual(expected.eraseToAnySpecification(), scheduleSpecification)
+    }
+
+}

--- a/Packages/EurofurenceComponents/Tests/ScheduleComponentTests/View Model Tests/Favourites toggle/WhenViewingOnlyFavourites_ThenDifferentDaySelected_ScheduleViewModelShould.swift
+++ b/Packages/EurofurenceComponents/Tests/ScheduleComponentTests/View Model Tests/Favourites toggle/WhenViewingOnlyFavourites_ThenDifferentDaySelected_ScheduleViewModelShould.swift
@@ -1,0 +1,24 @@
+import EurofurenceModel
+import ScheduleComponent
+import XCTest
+import XCTEurofurenceModel
+
+class WhenViewingOnlyFavourites_ThenDifferentDaySelected_ScheduleViewModelShould: XCTestCase {
+    
+    func testMaintainFavouritesSubspecificationWithNewDay() throws {
+        let days: [Day] = .random
+        let randomDay = days.randomElement()
+        let eventsService = FakeScheduleRepository()
+        let context = ScheduleViewModelFactoryTestBuilder().with(eventsService).build()
+        eventsService.simulateDaysChanged(days)
+        let viewModel = context.makeViewModel()
+        viewModel?.toggleFavouriteFilteringState()
+        viewModel?.showEventsForDay(at: randomDay.index)
+        
+        let schedule = try XCTUnwrap(context.eventsService.schedule(for: "Schedule"))
+        let expected = EventsOccurringOnDaySpecification(day: randomDay.element) && IsFavouriteEventSpecification()
+        
+        XCTAssertEqual(expected.eraseToAnySpecification(), schedule.specification)
+    }
+    
+}

--- a/Packages/EurofurenceComponents/Tests/ScheduleComponentTests/View Model Tests/Test Doubles/CapturingScheduleViewModelDelegate.swift
+++ b/Packages/EurofurenceComponents/Tests/ScheduleComponentTests/View Model Tests/Test Doubles/CapturingScheduleViewModelDelegate.swift
@@ -28,5 +28,13 @@ class CapturingScheduleViewModelDelegate: ScheduleViewModelDelegate {
     func scheduleViewModelDidUpdateEvents(_ events: [ScheduleEventGroupViewModel]) {
         eventsViewModels = events
     }
+    
+    func scheduleViewModelDidFilterToFavourites() {
+        
+    }
+    
+    func scheduleViewModelDidRemoveFavouritesFilter() {
+        
+    }
 
 }

--- a/Packages/EurofurenceComponents/Tests/ScheduleComponentTests/View Model Tests/Test Doubles/CapturingScheduleViewModelDelegate.swift
+++ b/Packages/EurofurenceComponents/Tests/ScheduleComponentTests/View Model Tests/Test Doubles/CapturingScheduleViewModelDelegate.swift
@@ -29,12 +29,19 @@ class CapturingScheduleViewModelDelegate: ScheduleViewModelDelegate {
         eventsViewModels = events
     }
     
+    enum FavouritesFilter: Equatable {
+        case unset
+        case favouritesOnly
+        case allEvents
+    }
+    
+    private(set) var favouritesfilter: FavouritesFilter = .unset
     func scheduleViewModelDidFilterToFavourites() {
-        
+        favouritesfilter = .favouritesOnly
     }
     
     func scheduleViewModelDidRemoveFavouritesFilter() {
-        
+        favouritesfilter = .allEvents
     }
 
 }

--- a/Packages/EurofurenceModel/Sources/EurofurenceModel/Private/Services/Events/EventsScheduleAdapter.swift
+++ b/Packages/EurofurenceModel/Sources/EurofurenceModel/Private/Services/Events/EventsScheduleAdapter.swift
@@ -102,10 +102,6 @@ class EventsScheduleAdapter: Schedule, CustomStringConvertible {
         updateDelegateWithAllDays()
         delegate.currentEventDayDidChange(to: currentDay)
     }
-
-    func restrictEvents(to day: Day) {
-        
-    }
     
     private var specification: AnySpecification<Event>?
     

--- a/Packages/EurofurenceModel/Sources/EurofurenceModel/Private/Services/Events/EventsScheduleAdapter.swift
+++ b/Packages/EurofurenceModel/Sources/EurofurenceModel/Private/Services/Events/EventsScheduleAdapter.swift
@@ -101,15 +101,21 @@ class EventsScheduleAdapter: Schedule, CustomStringConvertible {
         delegate.scheduleEventsDidChange(to: events)
         updateDelegateWithAllDays()
         delegate.currentEventDayDidChange(to: currentDay)
+        
+        if let specification = specification {
+            delegate.scheduleSpecificationChanged(to: specification)
+        }
     }
     
     private var specification: AnySpecification<Event>?
     
     func filterSchedule<S>(to specification: S) where S: Specification, S.Element == Event {
-        self.specification = specification.eraseToAnySpecification()
+        let erased = specification.eraseToAnySpecification()
+        self.specification = erased
         
         events = schedule.eventModels.filter(specification.isSatisfied(by:))
         delegate?.scheduleEventsDidChange(to: events)
+        delegate?.scheduleSpecificationChanged(to: erased)
     }
 
     private func updateCurrentDay() {

--- a/Packages/EurofurenceModel/Sources/EurofurenceModel/Public/Criteria/AndSpecification.swift
+++ b/Packages/EurofurenceModel/Sources/EurofurenceModel/Public/Criteria/AndSpecification.swift
@@ -23,6 +23,10 @@ extension AndSpecification: Specification {
         first.isSatisfied(by: element) && second.isSatisfied(by: element)
     }
     
+    public func contains<S>(_ specification: S.Type) -> Bool {
+        first.contains(specification) || second.contains(specification)
+    }
+    
 }
 
 // MARK: Convenience Creation

--- a/Packages/EurofurenceModel/Sources/EurofurenceModel/Public/Criteria/Specification.swift
+++ b/Packages/EurofurenceModel/Sources/EurofurenceModel/Public/Criteria/Specification.swift
@@ -3,5 +3,14 @@ public protocol Specification: Equatable {
     associatedtype Element
     
     func isSatisfied(by element: Element) -> Bool
+    func contains<S>(_ other: S.Type) -> Bool where S: Specification
+    
+}
+
+extension Specification {
+    
+    public func contains<S>(_ specification: S.Type) -> Bool {
+        self is S
+    }
     
 }

--- a/Packages/EurofurenceModel/Sources/EurofurenceModel/Public/Objects/Entities/Event/Specifications/AllEventsSpecification.swift
+++ b/Packages/EurofurenceModel/Sources/EurofurenceModel/Public/Objects/Entities/Event/Specifications/AllEventsSpecification.swift
@@ -1,0 +1,13 @@
+public struct AllEventsSpecification: Specification {
+    
+    public init() {
+        
+    }
+    
+    public typealias Element = Event
+    
+    public func isSatisfied(by element: Element) -> Bool {
+        true
+    }
+    
+}

--- a/Packages/EurofurenceModel/Sources/EurofurenceModel/Public/Objects/Entities/Schedule/Schedule.swift
+++ b/Packages/EurofurenceModel/Sources/EurofurenceModel/Public/Objects/Entities/Schedule/Schedule.swift
@@ -2,7 +2,6 @@ public protocol Schedule {
 
     func loadEvent(identifier: EventIdentifier) -> Event?
     func setDelegate(_ delegate: ScheduleDelegate)
-    func restrictEvents(to day: Day)
     
     func filterSchedule<S>(to specification: S) where S: Specification, S.Element == Event
 

--- a/Packages/EurofurenceModel/Sources/EurofurenceModel/Public/Objects/Entities/Schedule/Schedule.swift
+++ b/Packages/EurofurenceModel/Sources/EurofurenceModel/Public/Objects/Entities/Schedule/Schedule.swift
@@ -12,5 +12,6 @@ public protocol ScheduleDelegate {
     func scheduleEventsDidChange(to events: [Event])
     func eventDaysDidChange(to days: [Day])
     func currentEventDayDidChange(to day: Day?)
+    func scheduleSpecificationChanged(to newSpecification: AnySpecification<Event>)
 
 }

--- a/Packages/EurofurenceModel/Sources/XCTEurofurenceModel/FakeEventsSchedule.swift
+++ b/Packages/EurofurenceModel/Sources/XCTEurofurenceModel/FakeEventsSchedule.swift
@@ -31,10 +31,12 @@ public class FakeEventsSchedule: Schedule {
     
     public private(set) var specification: AnySpecification<Event>?
     public func filterSchedule<S>(to specification: S) where S: Specification, S.Element == Event {
-        self.specification = specification.eraseToAnySpecification()
+        let erasedSpecification = specification.eraseToAnySpecification()
+        self.specification = erasedSpecification
         
         events = events.filter(specification.isSatisfied(by:))
         delegate?.scheduleEventsDidChange(to: events)
+        delegate?.scheduleSpecificationChanged(to: erasedSpecification)
     }
 
 }

--- a/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Criteria/AnySpecificationTests.swift
+++ b/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Criteria/AnySpecificationTests.swift
@@ -19,5 +19,31 @@ class AnySpecificationTests: XCTestCase {
         XCTAssertEqual(second, second)
         XCTAssertNotEqual(first, second)
     }
+    
+    func testContains_Match() {
+        let specification = AlwaysPassesSpecification<Int>().eraseToAnySpecification()
+        XCTAssertTrue(specification.contains(AlwaysPassesSpecification<Int>.self))
+    }
+    
+    func testContains_NoMatch() {
+        let specification = AlwaysPassesSpecification<Int>().eraseToAnySpecification()
+        XCTAssertFalse(specification.contains(AlwaysPassesSpecification<String>.self))
+    }
+    
+    func testContains_Match_ViaAggregate() {
+        let specification = AlwaysPassesSpecification<Int>()
+            .and(AlwaysFailsSpecification<Int>())
+            .eraseToAnySpecification()
+        
+        XCTAssertTrue(specification.contains(AlwaysFailsSpecification<Int>.self))
+    }
+    
+    func testContains_NoMatch_ViaAggregate() {
+        let specification = AlwaysPassesSpecification<Int>()
+            .and(AlwaysFailsSpecification<Int>())
+            .eraseToAnySpecification()
+        
+        XCTAssertFalse(specification.contains(AlwaysFailsSpecification<String>.self))
+    }
 
 }

--- a/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Criteria/Specification+ContainsTests.swift
+++ b/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Criteria/Specification+ContainsTests.swift
@@ -1,0 +1,26 @@
+import EurofurenceModel
+import XCTest
+
+class Specification_ContainsTests: XCTestCase {
+    
+    func testSpecificationIsCandidate() {
+        let specification = AlwaysPassesSpecification<Int>()
+        XCTAssertTrue(specification.contains(AlwaysPassesSpecification<Int>.self))
+    }
+    
+    func testSpecificationIsNotCandidate() {
+        let specification = AlwaysPassesSpecification<Int>()
+        XCTAssertFalse(specification.contains(AlwaysPassesSpecification<Bool>.self))
+    }
+    
+    func testSpecificationIsComposite_ContainsCandidate() {
+        let composite = AlwaysFailsSpecification<Int>().and(AlwaysPassesSpecification<Int>())
+        XCTAssertTrue(composite.contains(AlwaysPassesSpecification<Int>.self))
+    }
+    
+    func testSpecificationIsComposide_DoesNotContainCandidate() {
+        let composite = AlwaysFailsSpecification<Int>().and(AlwaysPassesSpecification<Int>())
+        XCTAssertFalse(composite.contains(AlwaysPassesSpecification<Bool>.self))
+    }
+    
+}

--- a/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Events/Schedule/ScheduleWithSpecificationShould.swift
+++ b/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Events/Schedule/ScheduleWithSpecificationShould.swift
@@ -119,6 +119,36 @@ class ScheduleWithSpecificationShould: XCTestCase {
         XCTAssertEqual(currentNumberOfUpdates, delegate.numberOfCurrentDayUpdates)
     }
     
+    func testNotifyDelegateWhenSpecificationChanged() {
+        let response = ModelCharacteristics.randomWithoutDeletions
+        let randomDay = response.conferenceDays.changed.randomElement().element
+        let dataStore = InMemoryDataStore(response: response)
+        let context = EurofurenceSessionTestBuilder().with(dataStore).with(randomDay.date).build()
+        let schedule = context.eventsService.loadSchedule(tag: "Test")
+        let delegate = JournallingScheduleDelegate()
+        schedule.setDelegate(delegate)
+        
+        let specification = AlwaysPassesSpecification<Event>()
+        schedule.filterSchedule(to: specification)
+        
+        XCTAssertEqual(specification.eraseToAnySpecification(), delegate.latestScheduleSpecification)
+    }
+    
+    func testNotifyDelegateOfOriginalSpecification() {
+        let response = ModelCharacteristics.randomWithoutDeletions
+        let randomDay = response.conferenceDays.changed.randomElement().element
+        let dataStore = InMemoryDataStore(response: response)
+        let context = EurofurenceSessionTestBuilder().with(dataStore).with(randomDay.date).build()
+        let schedule = context.eventsService.loadSchedule(tag: "Test")
+        let specification = AlwaysPassesSpecification<Event>()
+        schedule.filterSchedule(to: specification)
+        
+        let delegate = JournallingScheduleDelegate()
+        schedule.setDelegate(delegate)
+        
+        XCTAssertEqual(specification.eraseToAnySpecification(), delegate.latestScheduleSpecification)
+    }
+    
     private struct SpecificEventSpecification: Specification {
         
         let identifier: EventIdentifier

--- a/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Sync/WhenSyncSucceeds_ForEmptyDataStore_ApplicationShould.swift
+++ b/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Sync/WhenSyncSucceeds_ForEmptyDataStore_ApplicationShould.swift
@@ -122,6 +122,10 @@ extension EmitsAllContentBeforeSessionStateChangeObserver: ScheduleDelegate {
         events.append(.scheduleDay)
     }
     
+    func scheduleSpecificationChanged(to newSpecification: AnySpecification<Event>) {
+        
+    }
+    
 }
 
 extension EmitsAllContentBeforeSessionStateChangeObserver: KnowledgeServiceObserver {

--- a/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Test Doubles/CapturingEventsScheduleDelegate.swift
+++ b/Packages/EurofurenceModel/Tests/EurofurenceModelTests/Test Doubles/CapturingEventsScheduleDelegate.swift
@@ -19,5 +19,10 @@ class CapturingScheduleDelegate: ScheduleDelegate {
     func eventDaysDidChange(to days: [Day]) {
         self.allDays = days
     }
+    
+    private(set) var latestScheduleSpecification: AnySpecification<Event>?
+    func scheduleSpecificationChanged(to newSpecification: AnySpecification<Event>) {
+        latestScheduleSpecification = newSpecification
+    }
 
 }


### PR DESCRIPTION
Allows filtering the non-searching schedule to just favourites.

This can only be merged after #483 