### PR TITLE
Support delta deletions in Core Data model

### DIFF
--- a/Packages/EurofurenceKit/Sources/EurofurenceKit/App Group/AppGroupModelProperties.swift
+++ b/Packages/EurofurenceKit/Sources/EurofurenceKit/App Group/AppGroupModelProperties.swift
@@ -61,4 +61,8 @@ public class AppGroupModelProperties: EurofurenceModelProperties {
         }
     }
     
+    public func removeContainerResource(at url: URL) throws {
+        try FileManager.default.removeItem(at: url)
+    }
+    
 }

--- a/Packages/EurofurenceKit/Sources/EurofurenceKit/Entities/Entity.swift
+++ b/Packages/EurofurenceKit/Sources/EurofurenceKit/Entities/Entity.swift
@@ -16,15 +16,21 @@ public class Entity: NSManagedObject {
 
 extension Entity {
     
-    class func entity(identifiedBy identifier: String, in managedObjectContext: NSManagedObjectContext) throws -> Self {
-        let entityDescription: NSEntityDescription = Self.entity()
+    class func fetchRequestForExistingEntity<E>(identifier: String) -> NSFetchRequest<E> where E: Entity {
+        let entityDescription = E.entity()
         guard let entityName = entityDescription.name else {
-            fatalError("Entity \(String(describing: Self.self)) does not possess a name in its NSEntityDescription!")
+            fatalError("Could not resolve name for \(E.self) from NSEntityDescription")
         }
         
-        let fetchRequest: NSFetchRequest<Self> = NSFetchRequest(entityName: entityName)
+        let fetchRequest: NSFetchRequest<E> = NSFetchRequest(entityName: entityName)
         fetchRequest.predicate = NSPredicate(format: "identifier == %@", identifier)
         fetchRequest.fetchLimit = 1
+        
+        return fetchRequest
+    }
+    
+    class func entity(identifiedBy identifier: String, in managedObjectContext: NSManagedObjectContext) throws -> Self {
+        let fetchRequest: NSFetchRequest<Self> = fetchRequestForExistingEntity(identifier: identifier)
         
         let fetchResults: [Self] = try managedObjectContext.fetch(fetchRequest)
         if let existingEntity = fetchResults.first {

--- a/Packages/EurofurenceKit/Sources/EurofurenceKit/Entities/Image.swift
+++ b/Packages/EurofurenceKit/Sources/EurofurenceKit/Entities/Image.swift
@@ -15,8 +15,29 @@ public class Image: Entity {
     @NSManaged public var cachedImageURL: URL?
     @NSManaged var width: Int32
     @NSManaged var height: Int32
+    
+    public override func prepareForDeletion() {
+        super.prepareForDeletion()
+        notifyWillDeleteImage()
+    }
+    
+    private func notifyWillDeleteImage() {
+        NotificationCenter.default.post(name: .EFKWillDeleteImage, object: self)
+    }
 
 }
+
+// MARK: - Entity Change Notifications
+
+extension Notification.Name {
+    
+    /// A notification that an `Image` will be deleted.
+    ///
+    /// The notification object is the `Image` entity. There is no corresponding `userInfo` dictionary.
+    static let EFKWillDeleteImage = Notification.Name("EurofurenceKit.EFKWillDeleteImage")
+    
+}
+
 
 // MARK: - Sizing
 

--- a/Packages/EurofurenceKit/Sources/EurofurenceKit/EurofurenceError.swift
+++ b/Packages/EurofurenceKit/Sources/EurofurenceKit/EurofurenceError.swift
@@ -3,5 +3,6 @@ public enum EurofurenceError: Error, Equatable {
     case syncFailure
     case conventionIdentifierMismatch
     case invalidAnnouncement(String)
+    case invalidEvent(String)
     
 }

--- a/Packages/EurofurenceKit/Sources/EurofurenceKit/EurofurenceError.swift
+++ b/Packages/EurofurenceKit/Sources/EurofurenceKit/EurofurenceError.swift
@@ -4,5 +4,6 @@ public enum EurofurenceError: Error, Equatable {
     case conventionIdentifierMismatch
     case invalidAnnouncement(String)
     case invalidEvent(String)
+    case invalidDealer(String)
     
 }

--- a/Packages/EurofurenceKit/Sources/EurofurenceKit/EurofurenceError.swift
+++ b/Packages/EurofurenceKit/Sources/EurofurenceKit/EurofurenceError.swift
@@ -2,5 +2,6 @@ public enum EurofurenceError: Error, Equatable {
     
     case syncFailure
     case conventionIdentifierMismatch
+    case invalidAnnouncement(String)
     
 }

--- a/Packages/EurofurenceKit/Sources/EurofurenceKit/EurofurenceModel.swift
+++ b/Packages/EurofurenceKit/Sources/EurofurenceKit/EurofurenceModel.swift
@@ -136,28 +136,28 @@ extension EurofurenceModel {
 extension EurofurenceModel {
     
     public func announcement(identifiedBy identifier: String) throws -> Announcement {
-        let fetchRequest: NSFetchRequest<Announcement> = Announcement.fetchRequest()
-        fetchRequest.predicate = NSPredicate(format: "identifier == %@", identifier)
-        fetchRequest.fetchLimit = 1
-        
-        let results = try viewContext.fetch(fetchRequest)
-        if let announcement = results.first {
-            return announcement
-        } else {
-            throw EurofurenceError.invalidAnnouncement(identifier)
-        }
+        try entity(identifiedBy: identifier, throwWhenMissing: .invalidAnnouncement(identifier))
     }
     
     public func event(identifiedBy identifier: String) throws -> Event {
-        let fetchRequest: NSFetchRequest<Event> = Event.fetchRequest()
-        fetchRequest.predicate = NSPredicate(format: "identifier == %@", identifier)
-        fetchRequest.fetchLimit = 1
+        try entity(identifiedBy: identifier, throwWhenMissing: .invalidEvent(identifier))
+    }
+    
+    public func dealer(identifiedBy identifier: String) throws -> Dealer {
+        try entity(identifiedBy: identifier, throwWhenMissing: .invalidDealer(identifier))
+    }
+    
+    private func entity<E>(
+        identifiedBy identifier: String,
+        throwWhenMissing: @autoclosure () -> EurofurenceError
+    ) throws -> E where E: Entity {
+        let fetchRequest: NSFetchRequest<E> = E.fetchRequestForExistingEntity(identifier: identifier)
         
         let results = try viewContext.fetch(fetchRequest)
-        if let event = results.first {
-            return event
+        if let entity = results.first {
+            return entity
         } else {
-            throw EurofurenceError.invalidEvent(identifier)
+            throw throwWhenMissing()
         }
     }
     

--- a/Packages/EurofurenceKit/Sources/EurofurenceKit/EurofurenceModel.swift
+++ b/Packages/EurofurenceKit/Sources/EurofurenceKit/EurofurenceModel.swift
@@ -128,3 +128,22 @@ extension EurofurenceModel {
     }
     
 }
+        
+// MARK: - Fetching Entities
+
+extension EurofurenceModel {
+    
+    public func announcement(identifiedBy identifier: String) throws -> Announcement {
+        let fetchRequest: NSFetchRequest<Announcement> = Announcement.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "identifier == %@", identifier)
+        fetchRequest.fetchLimit = 1
+        
+        let results = try viewContext.fetch(fetchRequest)
+        if let announcement = results.first {
+            return announcement
+        } else {
+            throw EurofurenceError.invalidAnnouncement(identifier)
+        }
+    }
+    
+}

--- a/Packages/EurofurenceKit/Sources/EurofurenceKit/EurofurenceModel.swift
+++ b/Packages/EurofurenceKit/Sources/EurofurenceKit/EurofurenceModel.swift
@@ -146,4 +146,17 @@ extension EurofurenceModel {
         }
     }
     
+    public func event(identifiedBy identifier: String) throws -> Event {
+        let fetchRequest: NSFetchRequest<Event> = Event.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "identifier == %@", identifier)
+        fetchRequest.fetchLimit = 1
+        
+        let results = try viewContext.fetch(fetchRequest)
+        if let event = results.first {
+            return event
+        } else {
+            throw EurofurenceError.invalidEvent(identifier)
+        }
+    }
+    
 }

--- a/Packages/EurofurenceKit/Sources/EurofurenceKit/EurofurenceModelProperties.swift
+++ b/Packages/EurofurenceKit/Sources/EurofurenceKit/EurofurenceModelProperties.swift
@@ -7,6 +7,7 @@ public protocol EurofurenceModelProperties: AnyObject {
     var synchronizationChangeToken: SynchronizationPayload.GenerationToken? { get set }
     
     func proposedURL(forImageIdentifier identifier: String) -> URL
+    func removeContainerResource(at url: URL) throws
     
 }
 

--- a/Packages/EurofurenceKit/Sources/EurofurenceKit/EurofurenceModelProperties.swift
+++ b/Packages/EurofurenceKit/Sources/EurofurenceKit/EurofurenceModelProperties.swift
@@ -6,6 +6,8 @@ public protocol EurofurenceModelProperties: AnyObject {
     var containerDirectoryURL: URL { get }
     var synchronizationChangeToken: SynchronizationPayload.GenerationToken? { get set }
     
+    func proposedURL(forImageIdentifier identifier: String) -> URL
+    
 }
 
 extension EurofurenceModelProperties {
@@ -20,6 +22,10 @@ extension EurofurenceModelProperties {
     
     public var imagesDirectory: URL {
         eurofurenceKitDirectory.appendingPathComponent("Images")
+    }
+    
+    public func proposedURL(forImageIdentifier identifier: String) -> URL {
+        imagesDirectory.appendingPathComponent(identifier)
     }
     
 }

--- a/Packages/EurofurenceKit/Sources/EurofurenceKit/Model.xcdatamodeld/Model.xcdatamodel/contents
+++ b/Packages/EurofurenceKit/Sources/EurofurenceKit/Model.xcdatamodeld/Model.xcdatamodel/contents
@@ -22,7 +22,7 @@
     <entity name="Day" representedClassName="Day" parentEntity="Entity" syncable="YES">
         <attribute name="date" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="name" attributeType="String" defaultValueString=""/>
-        <relationship name="events" toMany="YES" deletionRule="Nullify" destinationEntity="Event" inverseName="day" inverseEntity="Event"/>
+        <relationship name="events" toMany="YES" deletionRule="Cascade" destinationEntity="Event" inverseName="day" inverseEntity="Event"/>
     </entity>
     <entity name="Dealer" representedClassName="Dealer" parentEntity="Entity" syncable="YES">
         <attribute name="aboutTheArt" attributeType="String"/>
@@ -160,7 +160,7 @@
         <element name="AnnouncementImage" positionX="45" positionY="189" width="128" height="58"/>
         <element name="ArtistImage" positionX="54" positionY="171" width="128" height="58"/>
         <element name="ArtPreview" positionX="0" positionY="117" width="128" height="73"/>
-        <element name="Day" positionX="-36" positionY="27" width="128" height="88"/>
+        <element name="Day" positionX="-36" positionY="27" width="128" height="74"/>
         <element name="Dealer" positionX="36" positionY="162" width="128" height="299"/>
         <element name="DealerCategory" positionX="27" positionY="171" width="128" height="73"/>
         <element name="DealerLink" positionX="18" positionY="162" width="128" height="58"/>

--- a/Packages/EurofurenceKit/Sources/EurofurenceKit/Model.xcdatamodeld/Model.xcdatamodel/contents
+++ b/Packages/EurofurenceKit/Sources/EurofurenceKit/Model.xcdatamodeld/Model.xcdatamodel/contents
@@ -145,7 +145,7 @@
     <entity name="Room" representedClassName="Room" parentEntity="Entity" syncable="YES">
         <attribute name="name" attributeType="String"/>
         <attribute name="shortName" attributeType="String"/>
-        <relationship name="events" toMany="YES" deletionRule="Nullify" destinationEntity="Event" inverseName="room" inverseEntity="Event"/>
+        <relationship name="events" toMany="YES" deletionRule="Cascade" destinationEntity="Event" inverseName="room" inverseEntity="Event"/>
     </entity>
     <entity name="Tag" representedClassName="Tag" syncable="YES">
         <attribute name="name" attributeType="String"/>
@@ -180,7 +180,7 @@
         <element name="MapEntryLink" positionX="18" positionY="162" width="128" height="58"/>
         <element name="MapGraphic" positionX="0" positionY="144" width="128" height="58"/>
         <element name="PanelHost" positionX="27" positionY="171" width="128" height="73"/>
-        <element name="Room" positionX="0" positionY="45" width="128" height="88"/>
+        <element name="Room" positionX="0" positionY="45" width="128" height="74"/>
         <element name="Tag" positionX="0" positionY="144" width="128" height="59"/>
         <element name="Track" positionX="-18" positionY="36" width="128" height="73"/>
     </elements>

--- a/Packages/EurofurenceKit/Sources/EurofurenceKit/Model.xcdatamodeld/Model.xcdatamodel/contents
+++ b/Packages/EurofurenceKit/Sources/EurofurenceKit/Model.xcdatamodeld/Model.xcdatamodel/contents
@@ -71,7 +71,7 @@
         <relationship name="banner" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="EventBanner" inverseName="events" inverseEntity="EventBanner"/>
         <relationship name="day" maxCount="1" deletionRule="Nullify" destinationEntity="Day" inverseName="events" inverseEntity="Day"/>
         <relationship name="panelHosts" toMany="YES" deletionRule="Nullify" destinationEntity="PanelHost" inverseName="hostingEvents" inverseEntity="PanelHost"/>
-        <relationship name="poster" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="EventPoster" inverseName="events" inverseEntity="EventPoster"/>
+        <relationship name="poster" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="EventPoster" inverseName="events" inverseEntity="EventPoster"/>
         <relationship name="room" maxCount="1" deletionRule="Nullify" destinationEntity="Room" inverseName="events" inverseEntity="Room"/>
         <relationship name="tags" toMany="YES" deletionRule="Nullify" destinationEntity="Tag" inverseName="events" inverseEntity="Tag"/>
         <relationship name="track" maxCount="1" deletionRule="Nullify" destinationEntity="Track" inverseName="events" inverseEntity="Track"/>

--- a/Packages/EurofurenceKit/Sources/EurofurenceKit/Model.xcdatamodeld/Model.xcdatamodel/contents
+++ b/Packages/EurofurenceKit/Sources/EurofurenceKit/Model.xcdatamodeld/Model.xcdatamodel/contents
@@ -7,7 +7,7 @@
         <attribute name="title" attributeType="String"/>
         <attribute name="validFrom" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="validUntil" attributeType="Date" usesScalarValueType="NO"/>
-        <relationship name="image" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="AnnouncementImage" inverseName="announcement" inverseEntity="AnnouncementImage"/>
+        <relationship name="image" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="AnnouncementImage" inverseName="announcement" inverseEntity="AnnouncementImage"/>
     </entity>
     <entity name="AnnouncementImage" representedClassName="AnnouncementImage" parentEntity="Image" syncable="YES">
         <relationship name="announcement" maxCount="1" deletionRule="Nullify" destinationEntity="Announcement" inverseName="image" inverseEntity="Announcement"/>
@@ -156,7 +156,7 @@
         <relationship name="events" toMany="YES" deletionRule="Nullify" destinationEntity="Event" inverseName="track" inverseEntity="Event"/>
     </entity>
     <elements>
-        <element name="Announcement" positionX="36" positionY="180" width="128" height="148"/>
+        <element name="Announcement" positionX="36" positionY="180" width="128" height="134"/>
         <element name="AnnouncementImage" positionX="45" positionY="189" width="128" height="58"/>
         <element name="ArtistImage" positionX="54" positionY="171" width="128" height="58"/>
         <element name="ArtPreview" positionX="0" positionY="117" width="128" height="73"/>

--- a/Packages/EurofurenceKit/Sources/EurofurenceKit/Model.xcdatamodeld/Model.xcdatamodel/contents
+++ b/Packages/EurofurenceKit/Sources/EurofurenceKit/Model.xcdatamodeld/Model.xcdatamodel/contents
@@ -153,7 +153,7 @@
     </entity>
     <entity name="Track" representedClassName="Track" parentEntity="Entity" syncable="YES">
         <attribute name="name" attributeType="String"/>
-        <relationship name="events" toMany="YES" deletionRule="Nullify" destinationEntity="Event" inverseName="track" inverseEntity="Event"/>
+        <relationship name="events" toMany="YES" deletionRule="Cascade" destinationEntity="Event" inverseName="track" inverseEntity="Event"/>
     </entity>
     <elements>
         <element name="Announcement" positionX="36" positionY="180" width="128" height="134"/>
@@ -182,6 +182,6 @@
         <element name="PanelHost" positionX="27" positionY="171" width="128" height="73"/>
         <element name="Room" positionX="0" positionY="45" width="128" height="74"/>
         <element name="Tag" positionX="0" positionY="144" width="128" height="59"/>
-        <element name="Track" positionX="-18" positionY="36" width="128" height="73"/>
+        <element name="Track" positionX="-18" positionY="36" width="128" height="59"/>
     </elements>
 </model>

--- a/Packages/EurofurenceKit/Sources/EurofurenceKit/Model.xcdatamodeld/Model.xcdatamodel/contents
+++ b/Packages/EurofurenceKit/Sources/EurofurenceKit/Model.xcdatamodeld/Model.xcdatamodel/contents
@@ -107,7 +107,7 @@
         <attribute name="knowledgeGroupDescription" attributeType="String"/>
         <attribute name="name" attributeType="String"/>
         <attribute name="order" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
-        <relationship name="entries" toMany="YES" deletionRule="Nullify" destinationEntity="KnowledgeEntry" inverseName="group" inverseEntity="KnowledgeEntry"/>
+        <relationship name="entries" toMany="YES" deletionRule="Cascade" destinationEntity="KnowledgeEntry" inverseName="group" inverseEntity="KnowledgeEntry"/>
     </entity>
     <entity name="KnowledgeLink" representedClassName="KnowledgeLink" parentEntity="Link" syncable="YES">
         <relationship name="entry" maxCount="1" deletionRule="Nullify" destinationEntity="KnowledgeEntry" inverseName="links" inverseEntity="KnowledgeEntry"/>
@@ -172,7 +172,7 @@
         <element name="Image" positionX="9" positionY="144" width="128" height="134"/>
         <element name="KnowledgeEntry" positionX="-18" positionY="99" width="128" height="133"/>
         <element name="KnowledgeEntryImage" positionX="9" positionY="135" width="128" height="44"/>
-        <element name="KnowledgeGroup" positionX="27" positionY="153" width="128" height="118"/>
+        <element name="KnowledgeGroup" positionX="27" positionY="153" width="128" height="104"/>
         <element name="KnowledgeLink" positionX="-9" positionY="126" width="128" height="58"/>
         <element name="Link" positionX="9" positionY="153" width="128" height="74"/>
         <element name="Map" positionX="54" positionY="198" width="128" height="104"/>

--- a/Packages/EurofurenceKit/Sources/EurofurenceKit/Model.xcdatamodeld/Model.xcdatamodel/contents
+++ b/Packages/EurofurenceKit/Sources/EurofurenceKit/Model.xcdatamodeld/Model.xcdatamodel/contents
@@ -121,15 +121,15 @@
         <attribute name="isBrowsable" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
         <attribute name="mapDescription" attributeType="String"/>
         <attribute name="order" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
-        <relationship name="entries" toMany="YES" deletionRule="Nullify" destinationEntity="MapEntry" inverseName="map" inverseEntity="MapEntry"/>
-        <relationship name="graphic" maxCount="1" deletionRule="Nullify" destinationEntity="MapGraphic" inverseName="map" inverseEntity="MapGraphic"/>
+        <relationship name="entries" toMany="YES" deletionRule="Cascade" destinationEntity="MapEntry" inverseName="map" inverseEntity="MapEntry"/>
+        <relationship name="graphic" maxCount="1" deletionRule="Cascade" destinationEntity="MapGraphic" inverseName="map" inverseEntity="MapGraphic"/>
     </entity>
     <entity name="MapEntry" representedClassName="MapEntry" syncable="YES">
         <attribute name="identifier" attributeType="String"/>
         <attribute name="radius" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="x" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="y" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
-        <relationship name="links" toMany="YES" deletionRule="Nullify" destinationEntity="MapEntryLink" inverseName="mapEntry" inverseEntity="MapEntryLink"/>
+        <relationship name="links" toMany="YES" deletionRule="Cascade" destinationEntity="MapEntryLink" inverseName="mapEntry" inverseEntity="MapEntryLink"/>
         <relationship name="map" maxCount="1" deletionRule="Nullify" destinationEntity="Map" inverseName="entries" inverseEntity="Map"/>
     </entity>
     <entity name="MapEntryLink" representedClassName="MapEntryLink" parentEntity="Link" syncable="YES">
@@ -175,8 +175,8 @@
         <element name="KnowledgeGroup" positionX="27" positionY="153" width="128" height="118"/>
         <element name="KnowledgeLink" positionX="-9" positionY="126" width="128" height="58"/>
         <element name="Link" positionX="9" positionY="153" width="128" height="74"/>
-        <element name="Map" positionX="54" positionY="198" width="128" height="118"/>
-        <element name="MapEntry" positionX="9" positionY="153" width="128" height="133"/>
+        <element name="Map" positionX="54" positionY="198" width="128" height="104"/>
+        <element name="MapEntry" positionX="9" positionY="153" width="128" height="119"/>
         <element name="MapEntryLink" positionX="18" positionY="162" width="128" height="58"/>
         <element name="MapGraphic" positionX="0" positionY="144" width="128" height="58"/>
         <element name="PanelHost" positionX="27" positionY="171" width="128" height="73"/>

--- a/Packages/EurofurenceKit/Sources/EurofurenceKit/Operations/UpdateLocalStoreOperation.swift
+++ b/Packages/EurofurenceKit/Sources/EurofurenceKit/Operations/UpdateLocalStoreOperation.swift
@@ -136,8 +136,7 @@ struct UpdateLocalStoreOperation {
     }
     
     private func downloadImage(identifier: String, contentHashSHA1 hash: String) async -> DownloadImageResult {
-        let imagesDirectory = configuration.properties.imagesDirectory
-        let downloadDestination = imagesDirectory.appendingPathComponent(identifier)
+        let downloadDestination = configuration.properties.proposedURL(forImageIdentifier: identifier)
         let downloadRequest = DownloadImageRequest(
             imageIdentifier: identifier,
             lastKnownImageContentHashSHA1: hash,

--- a/Packages/EurofurenceKit/Sources/EurofurenceKit/Operations/UpdateLocalStoreOperation.swift
+++ b/Packages/EurofurenceKit/Sources/EurofurenceKit/Operations/UpdateLocalStoreOperation.swift
@@ -193,6 +193,11 @@ struct UpdateLocalStoreOperation {
                 
                 try correspondingEntity.update(context: updateContext)
             }
+            
+            for deletedObject in node.deletedObjectIdentifiers {
+                let correspondingEntity = try U.entity(identifiedBy: deletedObject, in: managedObjectContext)
+                managedObjectContext.delete(correspondingEntity)
+            }
         }
         
     }

--- a/Packages/EurofurenceKit/Sources/EurofurenceKit/Operations/UpdateLocalStoreOperation.swift
+++ b/Packages/EurofurenceKit/Sources/EurofurenceKit/Operations/UpdateLocalStoreOperation.swift
@@ -241,6 +241,7 @@ struct UpdateLocalStoreOperation {
         
         func cleanup() throws {
             try cleanupDealerCategories()
+            try cleanupPanelHosts()
         }
         
         private func cleanupDealerCategories() throws {
@@ -251,6 +252,17 @@ struct UpdateLocalStoreOperation {
             let emptyCategories = try managedObjectContext.fetch(emptyCategoriesFetchRequest)
             for category in emptyCategories {
                 managedObjectContext.delete(category)
+            }
+        }
+        
+        private func cleanupPanelHosts() throws {
+            // Remove any panel hosts no longer associated with an event.
+            let notHostingEventFetchRequest: NSFetchRequest<PanelHost> = PanelHost.fetchRequest()
+            notHostingEventFetchRequest.predicate = NSPredicate(format: "hostingEvents.@count == 0")
+            
+            let hostNoLongerHosting = try managedObjectContext.fetch(notHostingEventFetchRequest)
+            for host in hostNoLongerHosting {
+                managedObjectContext.delete(host)
             }
         }
         

--- a/Packages/EurofurenceKit/Sources/EurofurenceWebAPI/Responses/SynchronizationPayload.swift
+++ b/Packages/EurofurenceKit/Sources/EurofurenceWebAPI/Responses/SynchronizationPayload.swift
@@ -41,10 +41,12 @@ extension SynchronizationPayload {
         private enum CodingKeys: String, CodingKey {
             case changed = "ChangedEntities"
             case deletedObjectIdentifiers = "DeletedEntities"
+            case removeAllObjectsBeforeInsertion = "RemoveAllBeforeInsert"
         }
         
         public var changed: [E]
         public var deletedObjectIdentifiers: [String]
+        public var removeAllObjectsBeforeInsertion: Bool
         
     }
     

--- a/Packages/EurofurenceKit/Sources/EurofurenceWebAPI/Responses/SynchronizationPayload.swift
+++ b/Packages/EurofurenceKit/Sources/EurofurenceWebAPI/Responses/SynchronizationPayload.swift
@@ -40,9 +40,11 @@ extension SynchronizationPayload {
         
         private enum CodingKeys: String, CodingKey {
             case changed = "ChangedEntities"
+            case deletedObjectIdentifiers = "DeletedEntities"
         }
         
         public var changed: [E]
+        public var deletedObjectIdentifiers: [String]
         
     }
     

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Model Ingestion/Deletions/DeleteAllObjectsTest.swift
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Model Ingestion/Deletions/DeleteAllObjectsTest.swift
@@ -1,3 +1,4 @@
+import CoreData
 @testable import EurofurenceKit
 import EurofurenceWebAPI
 import XCTest

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Model Ingestion/Deletions/DeleteAllObjectsTest.swift
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Model Ingestion/Deletions/DeleteAllObjectsTest.swift
@@ -1,0 +1,40 @@
+import EurofurenceKit
+import EurofurenceWebAPI
+import XCTest
+
+class DeleteAllObjectsTest: XCTestCase {
+
+    func testDeletingAllEntities() async throws {
+        let scenario = EurofurenceModelTestBuilder().build()
+        let payload = try SampleResponse.ef26.loadResponse()
+        await scenario.stubSyncResponse(with: .success(payload))
+        try await scenario.updateLocalStore()
+        try await scenario.updateLocalStore(using: .deleteAll)
+        
+        let entityTypes: [Entity.Type] = [
+            Announcement.self,
+            Day.self,
+            Dealer.self,
+            Event.self,
+            Image.self,
+            KnowledgeEntry.self,
+            KnowledgeGroup.self,
+            Map.self,
+            Room.self,
+            Track.self
+        ]
+        
+        for entityType in entityTypes {
+            let entityName = try XCTUnwrap(entityType.entity().name)
+            let fetchRequest: NSFetchRequest<NSManagedObjectID> = NSFetchRequest(entityName: entityName)
+            fetchRequest.resultType = .managedObjectIDResultType
+            let objectsIDs = try scenario.viewContext.fetch(fetchRequest)
+            
+            XCTAssertTrue(
+                objectsIDs.isEmpty,
+                "Expected all \(String(describing: entityType)) entities to be deleted. Still present: \(objectsIDs)"
+            )
+        }
+    }
+
+}

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Model Ingestion/Deletions/DeleteDayTests.swift
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Model Ingestion/Deletions/DeleteDayTests.swift
@@ -13,9 +13,9 @@ class DeleteDayTests: XCTestCase {
         // Once the track has been deleted, any events that were part of the track should also be deleted.
         let deletedDayIdentifier = "db6e0b07-3300-4d58-adfd-84c145e36242"
         let eventIdentifiers = try autoreleasepool { () -> [NSManagedObjectID] in
-            let fetchRequest: NSFetchRequest<EurofurenceKit.Day> = EurofurenceKit.Day.fetchRequest()
-            fetchRequest.predicate = NSPredicate(format: "identifier == %@", deletedDayIdentifier)
-            fetchRequest.fetchLimit = 1
+            let fetchRequest: NSFetchRequest<EurofurenceKit.Day> = EurofurenceKit.Day.fetchRequestForExistingEntity(
+                identifier: deletedDayIdentifier
+            )
             
             let results = try scenario.viewContext.fetch(fetchRequest)
             let day = try XCTUnwrap(results.first)

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Model Ingestion/Deletions/DeleteDayTests.swift
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Model Ingestion/Deletions/DeleteDayTests.swift
@@ -1,3 +1,4 @@
+import CoreData
 @testable import EurofurenceKit
 import EurofurenceWebAPI
 import XCTest

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Model Ingestion/Deletions/DeleteDayTests.swift
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Model Ingestion/Deletions/DeleteDayTests.swift
@@ -1,0 +1,33 @@
+@testable import EurofurenceKit
+import EurofurenceWebAPI
+import XCTest
+
+class DeleteDayTests: XCTestCase {
+    
+    func testDeletingDatRemovesEventsThatOccurOnIt() async throws {
+        let scenario = EurofurenceModelTestBuilder().build()
+        let payload = try SampleResponse.ef26.loadResponse()
+        await scenario.stubSyncResponse(with: .success(payload))
+        try await scenario.updateLocalStore()
+        
+        // Once the track has been deleted, any events that were part of the track should also be deleted.
+        let deletedDayIdentifier = "db6e0b07-3300-4d58-adfd-84c145e36242"
+        let eventIdentifiers = try autoreleasepool { () -> [NSManagedObjectID] in
+            let fetchRequest: NSFetchRequest<EurofurenceKit.Day> = EurofurenceKit.Day.fetchRequest()
+            fetchRequest.predicate = NSPredicate(format: "identifier == %@", deletedDayIdentifier)
+            fetchRequest.fetchLimit = 1
+            
+            let results = try scenario.viewContext.fetch(fetchRequest)
+            let day = try XCTUnwrap(results.first)
+            
+            return day.events.map(\.objectID)
+        }
+        
+        try await scenario.updateLocalStore(using: .deletedDay)
+        
+        for eventIdentifier in eventIdentifiers {
+            XCTAssertThrowsError(try scenario.viewContext.existingObject(with: eventIdentifier))
+        }
+    }
+
+}

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Model Ingestion/Deletions/DeleteTrackTests.swift
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Model Ingestion/Deletions/DeleteTrackTests.swift
@@ -13,9 +13,9 @@ class DeleteTrackTests: XCTestCase {
         // Once the track has been deleted, any events that were part of the track should also be deleted.
         let deletedTrackIdentifier = "f23cc7f6-34c1-48d5-8acb-0ec10c353403"
         let eventIdentifiers = try autoreleasepool { () -> [NSManagedObjectID] in
-            let fetchRequest: NSFetchRequest<EurofurenceKit.Track> = EurofurenceKit.Track.fetchRequest()
-            fetchRequest.predicate = NSPredicate(format: "identifier == %@", deletedTrackIdentifier)
-            fetchRequest.fetchLimit = 1
+            let fetchRequest: NSFetchRequest<EurofurenceKit.Track> = EurofurenceKit.Track.fetchRequestForExistingEntity(
+                identifier: deletedTrackIdentifier
+            )
             
             let results = try scenario.viewContext.fetch(fetchRequest)
             let track = try XCTUnwrap(results.first)

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Model Ingestion/Deletions/DeleteTrackTests.swift
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Model Ingestion/Deletions/DeleteTrackTests.swift
@@ -1,0 +1,33 @@
+@testable import EurofurenceKit
+import EurofurenceWebAPI
+import XCTest
+
+class DeleteTrackTests: XCTestCase {
+    
+    func testDeletingTrackRemovesEventsThatArePartOfTrack() async throws {
+        let scenario = EurofurenceModelTestBuilder().build()
+        let payload = try SampleResponse.ef26.loadResponse()
+        await scenario.stubSyncResponse(with: .success(payload))
+        try await scenario.updateLocalStore()
+        
+        // Once the track has been deleted, any events that were part of the track should also be deleted.
+        let deletedTrackIdentifier = "f23cc7f6-34c1-48d5-8acb-0ec10c353403"
+        let eventIdentifiers = try autoreleasepool { () -> [NSManagedObjectID] in
+            let fetchRequest: NSFetchRequest<EurofurenceKit.Track> = EurofurenceKit.Track.fetchRequest()
+            fetchRequest.predicate = NSPredicate(format: "identifier == %@", deletedTrackIdentifier)
+            fetchRequest.fetchLimit = 1
+            
+            let results = try scenario.viewContext.fetch(fetchRequest)
+            let track = try XCTUnwrap(results.first)
+            
+            return track.events.map(\.objectID)
+        }
+        
+        try await scenario.updateLocalStore(using: .deletedTrack)
+        
+        for eventIdentifier in eventIdentifiers {
+            XCTAssertThrowsError(try scenario.viewContext.existingObject(with: eventIdentifier))
+        }
+    }
+
+}

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Model Ingestion/Deletions/DeleteTrackTests.swift
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Model Ingestion/Deletions/DeleteTrackTests.swift
@@ -1,3 +1,4 @@
+import CoreData
 @testable import EurofurenceKit
 import EurofurenceWebAPI
 import XCTest

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Model Ingestion/Deletions/DeletingAnnouncementTests.swift
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Model Ingestion/Deletions/DeletingAnnouncementTests.swift
@@ -1,0 +1,24 @@
+import EurofurenceKit
+import EurofurenceWebAPI
+import XCTest
+
+class DeletingAnnouncementTests: XCTestCase {
+    
+    func testDeletedAnnouncementRemovedFromStore() async throws {
+        let scenario = EurofurenceModelTestBuilder().build()
+        let payload = try SampleResponse.ef26.loadResponse()
+        await scenario.stubSyncResponse(with: .success(payload))
+        try await scenario.updateLocalStore()
+        
+        // Assert the corresponding announcement exists, then is deleted following the next ingestion.
+        let announcementIdentifier = "8822b105-a46c-441a-a8db-cd6c084d33c8"
+        XCTAssertNoThrow(try scenario.model.announcement(identifiedBy: announcementIdentifier))
+        
+        try await scenario.updateLocalStore(using: .deletedAnnouncement)
+        
+        XCTAssertThrowsSpecificError(EurofurenceError.invalidAnnouncement(announcementIdentifier)) {
+            _ = try scenario.model.announcement(identifiedBy: announcementIdentifier)
+        }
+    }
+
+}

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Model Ingestion/Deletions/DeletingDealerTests.swift
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Model Ingestion/Deletions/DeletingDealerTests.swift
@@ -1,3 +1,4 @@
+import CoreData
 @testable import EurofurenceKit
 import EurofurenceWebAPI
 import XCTest

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Model Ingestion/Deletions/DeletingDealerTests.swift
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Model Ingestion/Deletions/DeletingDealerTests.swift
@@ -1,0 +1,24 @@
+import EurofurenceKit
+import EurofurenceWebAPI
+import XCTest
+
+class DeletingDealerTests: XCTestCase {
+    
+    func testDeletedDealerRemovedFromStore() async throws {
+        let scenario = EurofurenceModelTestBuilder().build()
+        let payload = try SampleResponse.ef26.loadResponse()
+        await scenario.stubSyncResponse(with: .success(payload))
+        try await scenario.updateLocalStore()
+        
+        // Assert the corresponding dealer exists, then is deleted following the next ingestion.
+        let dealerIdentifier = "ddf3145c-81f3-4e97-840a-58f7f6683884"
+        XCTAssertNoThrow(try scenario.model.dealer(identifiedBy: dealerIdentifier))
+        
+        try await scenario.updateLocalStore(using: .deletedDealer)
+        
+        XCTAssertThrowsSpecificError(EurofurenceError.invalidDealer(dealerIdentifier)) {
+            _ = try scenario.model.dealer(identifiedBy: dealerIdentifier)
+        }
+    }
+
+}

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Model Ingestion/Deletions/DeletingEventTests.swift
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Model Ingestion/Deletions/DeletingEventTests.swift
@@ -1,0 +1,83 @@
+import EurofurenceKit
+import EurofurenceWebAPI
+import XCTest
+
+class DeletingEventTests: XCTestCase {
+    
+    func testDeletedEventRemovedFromStore_NoImages() async throws {
+        let scenario = EurofurenceModelTestBuilder().build()
+        let payload = try SampleResponse.ef26.loadResponse()
+        await scenario.stubSyncResponse(with: .success(payload))
+        try await scenario.updateLocalStore()
+        
+        // Assert the corresponding event exists, then is deleted following the next ingestion.
+        let eventIdentifier = "76430fe0-ece7-48c9-b8e6-fdbc3974ff64"
+        XCTAssertNoThrow(try scenario.model.event(identifiedBy: eventIdentifier))
+        
+        try await scenario.updateLocalStore(using: .deletedEvent)
+        
+        XCTAssertThrowsSpecificError(EurofurenceError.invalidEvent(eventIdentifier)) {
+            _ = try scenario.model.event(identifiedBy: eventIdentifier)
+        }
+    }
+    
+    func testDeletedEventRemovedFromStore_HasBanner() async throws {
+        let scenario = EurofurenceModelTestBuilder().build()
+        let payload = try SampleResponse.ef26.loadResponse()
+        await scenario.stubSyncResponse(with: .success(payload))
+        try await scenario.updateLocalStore()
+        
+        // Assert the corresponding event exists, then is deleted following the next ingestion.
+        let eventIdentifier = "d7676a70-bc1e-4fde-9891-8060cb9f291a"
+        XCTAssertNoThrow(try scenario.model.event(identifiedBy: eventIdentifier))
+        
+        try await scenario.updateLocalStore(using: .deletedEventWithBanner)
+        
+        XCTAssertThrowsSpecificError(EurofurenceError.invalidEvent(eventIdentifier)) {
+            _ = try scenario.model.event(identifiedBy: eventIdentifier)
+        }
+    }
+    
+    func testDeletedEventRemovedFromStore_HasPoster() async throws {
+        let scenario = EurofurenceModelTestBuilder().build()
+        let payload = try SampleResponse.ef26.loadResponse()
+        await scenario.stubSyncResponse(with: .success(payload))
+        try await scenario.updateLocalStore()
+        
+        // Assert the corresponding event exists, then is deleted following the next ingestion.
+        let eventIdentifier = "46c59831-012e-4e4b-8e15-a6de1aca3ad4"
+        XCTAssertNoThrow(try scenario.model.event(identifiedBy: eventIdentifier))
+        
+        try await scenario.updateLocalStore(using: .deletedEventWithPoster)
+        
+        XCTAssertThrowsSpecificError(EurofurenceError.invalidEvent(eventIdentifier)) {
+            _ = try scenario.model.event(identifiedBy: eventIdentifier)
+        }
+    }
+    
+    func testDeletedEventRemovedFromStore_MultipleEventsSharePoster() async throws {
+        let scenario = EurofurenceModelTestBuilder().build()
+        let payload = try SampleResponse.ef26.loadResponse()
+        await scenario.stubSyncResponse(with: .success(payload))
+        try await scenario.updateLocalStore()
+        
+        // Assert the corresponding event exists, then is deleted following the next ingestion.
+        // The poster should remain as it's still used by other events.
+        let deletedEventIdentifier = "4a90c95f-dac0-4ca0-9f6d-a7839845ba36"
+        let eventSharingPosterIdentifier = "46c59831-012e-4e4b-8e15-a6de1aca3ad4"
+        XCTAssertNoThrow(try scenario.model.event(identifiedBy: deletedEventIdentifier))
+        
+        try await scenario.updateLocalStore(using: .deletedEventWithSharedPoster)
+        
+        XCTAssertThrowsSpecificError(EurofurenceError.invalidEvent(deletedEventIdentifier)) {
+            _ = try scenario.model.event(identifiedBy: deletedEventIdentifier)
+        }
+        
+        let sharedPosterEvent = try scenario.model.event(identifiedBy: eventSharingPosterIdentifier)
+        XCTAssertNotNil(
+            sharedPosterEvent.poster,
+            "Deleting an event with a poster shared amongst multiple events should not delete the poster"
+        )
+    }
+
+}

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Model Ingestion/Deletions/DeletingEventTests.swift
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Model Ingestion/Deletions/DeletingEventTests.swift
@@ -1,3 +1,4 @@
+import CoreData
 import EurofurenceKit
 import EurofurenceWebAPI
 import XCTest

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Model Ingestion/Deletions/DeletingKnowledgeGroupTests.swift
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Model Ingestion/Deletions/DeletingKnowledgeGroupTests.swift
@@ -1,0 +1,34 @@
+@testable import EurofurenceKit
+import EurofurenceWebAPI
+import XCTest
+
+class DeletingKnowledgeGroupTests: XCTestCase {
+    
+    func testDeletingKnowledgeGroupDeletesEntriesAssociatedWithGroup() async throws {
+        let scenario = EurofurenceModelTestBuilder().build()
+        let payload = try SampleResponse.ef26.loadResponse()
+        await scenario.stubSyncResponse(with: .success(payload))
+        try await scenario.updateLocalStore()
+        
+        // Assert once the knowledge group has been deleted, the models invariants continue to be satisfied *and* the
+        // entries associated with the group have been deleted.
+        let deletedKnowledgeGroupIdentifier = "92cdf214-7e9f-6bfa-0370-dfadd5e76493"
+        let knowledgeEntryIdentifiers = try autoreleasepool { () -> [NSManagedObjectID] in
+            let fetchRequest: NSFetchRequest<EurofurenceKit.KnowledgeGroup> = EurofurenceKit.KnowledgeGroup.fetchRequest()
+            fetchRequest.predicate = NSPredicate(format: "identifier == %@", deletedKnowledgeGroupIdentifier)
+            fetchRequest.fetchLimit = 1
+            
+            let results = try scenario.viewContext.fetch(fetchRequest)
+            let knowledgeGroup = try XCTUnwrap(results.first)
+            
+            return knowledgeGroup.entries.map(\.objectID)
+        }
+        
+        try await scenario.updateLocalStore(using: .deletedKnowledgeGroup)
+        
+        for knowledgeEntryIdentifier in knowledgeEntryIdentifiers {
+            XCTAssertThrowsError(try scenario.viewContext.existingObject(with: knowledgeEntryIdentifier))
+        }
+    }
+
+}

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Model Ingestion/Deletions/DeletingKnowledgeGroupTests.swift
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Model Ingestion/Deletions/DeletingKnowledgeGroupTests.swift
@@ -14,9 +14,9 @@ class DeletingKnowledgeGroupTests: XCTestCase {
         // entries associated with the group have been deleted.
         let deletedKnowledgeGroupIdentifier = "92cdf214-7e9f-6bfa-0370-dfadd5e76493"
         let knowledgeEntryIdentifiers = try autoreleasepool { () -> [NSManagedObjectID] in
-            let fetchRequest: NSFetchRequest<EurofurenceKit.KnowledgeGroup> = EurofurenceKit.KnowledgeGroup.fetchRequest()
-            fetchRequest.predicate = NSPredicate(format: "identifier == %@", deletedKnowledgeGroupIdentifier)
-            fetchRequest.fetchLimit = 1
+            let fetchRequest: NSFetchRequest<EurofurenceKit.KnowledgeGroup> = EurofurenceKit
+                .KnowledgeGroup
+                .fetchRequestForExistingEntity(identifier: deletedKnowledgeGroupIdentifier)
             
             let results = try scenario.viewContext.fetch(fetchRequest)
             let knowledgeGroup = try XCTUnwrap(results.first)

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Model Ingestion/Deletions/DeletingKnowledgeGroupTests.swift
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Model Ingestion/Deletions/DeletingKnowledgeGroupTests.swift
@@ -1,3 +1,4 @@
+import CoreData
 @testable import EurofurenceKit
 import EurofurenceWebAPI
 import XCTest

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Model Ingestion/Deletions/DeletingRoomTests.swift
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Model Ingestion/Deletions/DeletingRoomTests.swift
@@ -1,0 +1,33 @@
+@testable import EurofurenceKit
+import EurofurenceWebAPI
+import XCTest
+
+class DeletingRoomTests: XCTestCase {
+    
+    func testDeletingRoomRemovesEventsOccurringInRoom() async throws {
+        let scenario = EurofurenceModelTestBuilder().build()
+        let payload = try SampleResponse.ef26.loadResponse()
+        await scenario.stubSyncResponse(with: .success(payload))
+        try await scenario.updateLocalStore()
+        
+        // Once the room has been deleted, any events that were taking place in it should also be deleted.
+        let deletedRoomIdentifier = "2d5d9a98-aaca-4434-959d-99d20e675d3a"
+        let eventIdentifiers = try autoreleasepool { () -> [NSManagedObjectID] in
+            let fetchRequest: NSFetchRequest<EurofurenceKit.Room> = EurofurenceKit.Room.fetchRequest()
+            fetchRequest.predicate = NSPredicate(format: "identifier == %@", deletedRoomIdentifier)
+            fetchRequest.fetchLimit = 1
+            
+            let results = try scenario.viewContext.fetch(fetchRequest)
+            let room = try XCTUnwrap(results.first)
+            
+            return room.events.map(\.objectID)
+        }
+        
+        try await scenario.updateLocalStore(using: .deletedRoom)
+        
+        for eventIdentifier in eventIdentifiers {
+            XCTAssertThrowsError(try scenario.viewContext.existingObject(with: eventIdentifier))
+        }
+    }
+
+}

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Model Ingestion/Deletions/DeletingRoomTests.swift
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Model Ingestion/Deletions/DeletingRoomTests.swift
@@ -13,9 +13,9 @@ class DeletingRoomTests: XCTestCase {
         // Once the room has been deleted, any events that were taking place in it should also be deleted.
         let deletedRoomIdentifier = "2d5d9a98-aaca-4434-959d-99d20e675d3a"
         let eventIdentifiers = try autoreleasepool { () -> [NSManagedObjectID] in
-            let fetchRequest: NSFetchRequest<EurofurenceKit.Room> = EurofurenceKit.Room.fetchRequest()
-            fetchRequest.predicate = NSPredicate(format: "identifier == %@", deletedRoomIdentifier)
-            fetchRequest.fetchLimit = 1
+            let fetchRequest: NSFetchRequest<EurofurenceKit.Room> = EurofurenceKit.Room.fetchRequestForExistingEntity(
+                identifier: deletedRoomIdentifier
+            )
             
             let results = try scenario.viewContext.fetch(fetchRequest)
             let room = try XCTUnwrap(results.first)

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Model Ingestion/Deletions/DeletingRoomTests.swift
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Model Ingestion/Deletions/DeletingRoomTests.swift
@@ -1,3 +1,4 @@
+import CoreData
 @testable import EurofurenceKit
 import EurofurenceWebAPI
 import XCTest

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Model Ingestion/Images Available/AfterIngestingRemoteModel_ImageFetchingTests.swift
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Model Ingestion/Images Available/AfterIngestingRemoteModel_ImageFetchingTests.swift
@@ -13,9 +13,8 @@ class AfterIngestingRemoteModel_ImageFetchingTests: XCTestCase {
         
         // We would expect to see exactly one request per image identifier. Each image should be downloaded to the
         // known location in the file system, identified by their ID.
-        let expectedImagesURL = scenario.modelProperties.imagesDirectory
         let expectedImageRequests = payload.images.changed.map { image -> DownloadImageRequest in
-            let expectedDownloadURL = expectedImagesURL.appendingPathComponent(image.id)
+            let expectedDownloadURL = scenario.modelProperties.proposedURL(forImageIdentifier: image.id)
             return DownloadImageRequest(
                 imageIdentifier: image.id,
                 lastKnownImageContentHashSHA1: image.contentHashSha1,
@@ -46,9 +45,8 @@ class AfterIngestingRemoteModel_ImageFetchingTests: XCTestCase {
         await scenario.stubSyncResponse(with: .success(payload))
         try await scenario.updateLocalStore()
         
-        let expectedImagesURL = scenario.modelProperties.imagesDirectory
         let expectedImageRequests = payload.images.changed.map { image -> DownloadImageRequest in
-            let expectedDownloadURL = expectedImagesURL.appendingPathComponent(image.id)
+            let expectedDownloadURL = scenario.modelProperties.proposedURL(forImageIdentifier: image.id)
             return DownloadImageRequest(
                 imageIdentifier: image.id,
                 lastKnownImageContentHashSHA1: image.contentHashSha1,
@@ -77,7 +75,7 @@ class AfterIngestingRemoteModel_ImageFetchingTests: XCTestCase {
             let results = try scenario.viewContext.fetch(fetchRequest)
             guard let entity = results.first else { continue }
             
-            let expectedURL = scenario.modelProperties.imagesDirectory.appendingPathComponent(image.id)
+            let expectedURL = scenario.modelProperties.proposedURL(forImageIdentifier: image.id)
             XCTAssertEqual(expectedURL, entity.cachedImageURL)
         }
     }
@@ -128,7 +126,7 @@ class AfterIngestingRemoteModel_ImageFetchingTests: XCTestCase {
         )
         
         let announcementImage = try XCTUnwrap(announcement.image)
-        let expectedURL = scenario.modelProperties.imagesDirectory.appendingPathComponent(announcementImageIdentifier)
+        let expectedURL = scenario.modelProperties.proposedURL(forImageIdentifier: announcementImageIdentifier)
         
         XCTAssertEqual(expectedURL, announcementImage.cachedImageURL)
     }

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Remote Responses/JSON/DeleteAll.json
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Remote Responses/JSON/DeleteAll.json
@@ -1,0 +1,76 @@
+{
+  "ConventionIdentifier": "EF26",
+  "Since": "2022-09-02T12:04:11.038+00:00",
+  "CurrentDateTimeUtc": "2022-09-02T12:04:20.632Z",
+  "State": "preview",
+  "Events": {
+    "StorageLastChangeDateTimeUtc": "2022-08-28T10:30:05.522Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.266Z",
+    "RemoveAllBeforeInsert": true,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "EventConferenceDays": {
+    "StorageLastChangeDateTimeUtc": "2022-06-23T08:18:09.436Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.334Z",
+    "RemoveAllBeforeInsert": true,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "EventConferenceRooms": {
+    "StorageLastChangeDateTimeUtc": "2022-08-27T01:30:05.243Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.339Z",
+    "RemoveAllBeforeInsert": true,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "EventConferenceTracks": {
+    "StorageLastChangeDateTimeUtc": "2022-08-21T23:00:05.813Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.343Z",
+    "RemoveAllBeforeInsert": true,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "KnowledgeGroups": {
+    "StorageLastChangeDateTimeUtc": "2022-08-26T11:31:36.176Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.347Z",
+    "RemoveAllBeforeInsert": true,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "KnowledgeEntries": {
+    "StorageLastChangeDateTimeUtc": "2022-08-31T20:03:51.531Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.351Z",
+    "RemoveAllBeforeInsert": true,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "Images": {
+    "StorageLastChangeDateTimeUtc": "2022-09-01T20:09:13.567Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.355Z",
+    "RemoveAllBeforeInsert": true,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "Dealers": {
+    "StorageLastChangeDateTimeUtc": "2022-08-21T21:00:10.138Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.359Z",
+    "RemoveAllBeforeInsert": true,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "Announcements": {
+    "StorageLastChangeDateTimeUtc": "2022-09-01T20:09:13.649Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-06-20T11:12:03.223Z",
+    "RemoveAllBeforeInsert": true,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "Maps": {
+    "StorageLastChangeDateTimeUtc": "2022-08-26T09:56:25.656Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.367Z",
+    "RemoveAllBeforeInsert": true,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  }
+}

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Remote Responses/JSON/EF26_DeleteAnnouncement.json
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Remote Responses/JSON/EF26_DeleteAnnouncement.json
@@ -1,0 +1,78 @@
+{
+  "ConventionIdentifier": "EF26",
+  "Since": "2022-09-02T12:04:11.038+00:00",
+  "CurrentDateTimeUtc": "2022-09-02T12:04:20.632Z",
+  "State": "preview",
+  "Events": {
+    "StorageLastChangeDateTimeUtc": "2022-08-28T10:30:05.522Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.266Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "EventConferenceDays": {
+    "StorageLastChangeDateTimeUtc": "2022-06-23T08:18:09.436Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.334Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "EventConferenceRooms": {
+    "StorageLastChangeDateTimeUtc": "2022-08-27T01:30:05.243Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.339Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "EventConferenceTracks": {
+    "StorageLastChangeDateTimeUtc": "2022-08-21T23:00:05.813Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.343Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "KnowledgeGroups": {
+    "StorageLastChangeDateTimeUtc": "2022-08-26T11:31:36.176Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.347Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "KnowledgeEntries": {
+    "StorageLastChangeDateTimeUtc": "2022-08-31T20:03:51.531Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.351Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "Images": {
+    "StorageLastChangeDateTimeUtc": "2022-09-01T20:09:13.567Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.355Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "Dealers": {
+    "StorageLastChangeDateTimeUtc": "2022-08-21T21:00:10.138Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.359Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "Announcements": {
+    "StorageLastChangeDateTimeUtc": "2022-09-01T20:09:13.649Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-06-20T11:12:03.223Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": [
+        "8822b105-a46c-441a-a8db-cd6c084d33c8"
+    ]
+  },
+  "Maps": {
+    "StorageLastChangeDateTimeUtc": "2022-08-26T09:56:25.656Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.367Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  }
+}

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Remote Responses/JSON/EF26_DeleteDay.json
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Remote Responses/JSON/EF26_DeleteDay.json
@@ -1,0 +1,78 @@
+{
+  "ConventionIdentifier": "EF26",
+  "Since": "2022-09-02T12:04:11.038+00:00",
+  "CurrentDateTimeUtc": "2022-09-02T12:04:20.632Z",
+  "State": "preview",
+  "Events": {
+    "StorageLastChangeDateTimeUtc": "2022-08-28T10:30:05.522Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.266Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "EventConferenceDays": {
+    "StorageLastChangeDateTimeUtc": "2022-06-23T08:18:09.436Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.334Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": [
+        "db6e0b07-3300-4d58-adfd-84c145e36242"
+    ]
+  },
+  "EventConferenceRooms": {
+    "StorageLastChangeDateTimeUtc": "2022-08-27T01:30:05.243Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.339Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "EventConferenceTracks": {
+    "StorageLastChangeDateTimeUtc": "2022-08-21T23:00:05.813Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.343Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "KnowledgeGroups": {
+    "StorageLastChangeDateTimeUtc": "2022-08-26T11:31:36.176Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.347Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "KnowledgeEntries": {
+    "StorageLastChangeDateTimeUtc": "2022-08-31T20:03:51.531Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.351Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "Images": {
+    "StorageLastChangeDateTimeUtc": "2022-09-01T20:09:13.567Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.355Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "Dealers": {
+    "StorageLastChangeDateTimeUtc": "2022-08-21T21:00:10.138Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.359Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "Announcements": {
+    "StorageLastChangeDateTimeUtc": "2022-09-01T20:09:13.649Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-06-20T11:12:03.223Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "Maps": {
+    "StorageLastChangeDateTimeUtc": "2022-08-26T09:56:25.656Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.367Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  }
+}

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Remote Responses/JSON/EF26_DeleteDealer.json
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Remote Responses/JSON/EF26_DeleteDealer.json
@@ -1,0 +1,80 @@
+{
+  "ConventionIdentifier": "EF26",
+  "Since": "2022-09-02T12:04:11.038+00:00",
+  "CurrentDateTimeUtc": "2022-09-02T12:04:20.632Z",
+  "State": "preview",
+  "Events": {
+    "StorageLastChangeDateTimeUtc": "2022-08-28T10:30:05.522Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.266Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "EventConferenceDays": {
+    "StorageLastChangeDateTimeUtc": "2022-06-23T08:18:09.436Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.334Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "EventConferenceRooms": {
+    "StorageLastChangeDateTimeUtc": "2022-08-27T01:30:05.243Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.339Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "EventConferenceTracks": {
+    "StorageLastChangeDateTimeUtc": "2022-08-21T23:00:05.813Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.343Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "KnowledgeGroups": {
+    "StorageLastChangeDateTimeUtc": "2022-08-26T11:31:36.176Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.347Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "KnowledgeEntries": {
+    "StorageLastChangeDateTimeUtc": "2022-08-31T20:03:51.531Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.351Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "Images": {
+    "StorageLastChangeDateTimeUtc": "2022-09-01T20:09:13.567Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.355Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "Dealers": {
+    "StorageLastChangeDateTimeUtc": "2022-08-21T21:00:10.138Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.359Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": [
+        "ddf3145c-81f3-4e97-840a-58f7f6683884"
+    ]
+  },
+  "Announcements": {
+    "StorageLastChangeDateTimeUtc": "2022-09-01T20:09:13.649Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-06-20T11:12:03.223Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": [
+        "8822b105-a46c-441a-a8db-cd6c084d33c8"
+    ]
+  },
+  "Maps": {
+    "StorageLastChangeDateTimeUtc": "2022-08-26T09:56:25.656Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.367Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  }
+}

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Remote Responses/JSON/EF26_DeleteDealer.json
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Remote Responses/JSON/EF26_DeleteDealer.json
@@ -66,9 +66,7 @@
     "StorageDeltaStartChangeDateTimeUtc": "2022-06-20T11:12:03.223Z",
     "RemoveAllBeforeInsert": false,
     "ChangedEntities": [],
-    "DeletedEntities": [
-        "8822b105-a46c-441a-a8db-cd6c084d33c8"
-    ]
+    "DeletedEntities": []
   },
   "Maps": {
     "StorageLastChangeDateTimeUtc": "2022-08-26T09:56:25.656Z",

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Remote Responses/JSON/EF26_DeleteDealers_FursuitCategoryOnly.json
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Remote Responses/JSON/EF26_DeleteDealers_FursuitCategoryOnly.json
@@ -1,0 +1,98 @@
+{
+  "ConventionIdentifier": "EF26",
+  "Since": "2022-09-02T12:04:11.038+00:00",
+  "CurrentDateTimeUtc": "2022-09-02T12:04:20.632Z",
+  "State": "preview",
+  "Events": {
+    "StorageLastChangeDateTimeUtc": "2022-08-28T10:30:05.522Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.266Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "EventConferenceDays": {
+    "StorageLastChangeDateTimeUtc": "2022-06-23T08:18:09.436Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.334Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "EventConferenceRooms": {
+    "StorageLastChangeDateTimeUtc": "2022-08-27T01:30:05.243Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.339Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "EventConferenceTracks": {
+    "StorageLastChangeDateTimeUtc": "2022-08-21T23:00:05.813Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.343Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "KnowledgeGroups": {
+    "StorageLastChangeDateTimeUtc": "2022-08-26T11:31:36.176Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.347Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "KnowledgeEntries": {
+    "StorageLastChangeDateTimeUtc": "2022-08-31T20:03:51.531Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.351Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "Images": {
+    "StorageLastChangeDateTimeUtc": "2022-09-01T20:09:13.567Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.355Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "Dealers": {
+    "StorageLastChangeDateTimeUtc": "2022-08-21T21:00:10.138Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.359Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": [
+        "ddf3145c-81f3-4e97-840a-58f7f6683884",
+        "18d8e68a-702f-4d4e-b3b4-369ad3f4d883",
+        "87f6669b-4f2b-4ec9-8e23-4aede54e771b",
+        "87f6669b-4f2b-4ec9-8e23-4aede54e771b",
+        "a58d5617-0239-4f73-820f-9ceee6dc6fe0",
+        "0d25206d-db8a-40bf-a3b7-c216f068e369",
+        "41918cc9-be8f-4e69-976b-308dcbb8c04d",
+        "b3a767ed-5da6-4228-88f0-579b38d69937",
+        "582e2f46-75a7-4074-81bd-3f09d53fff66",
+        "7aafdcde-88cf-494e-bd1a-26f0031bb5b6",
+        "151ec7bd-56dc-48ef-92db-c9ff3b3226f7",
+        "59ac8857-59a1-468b-8d25-1f5a1a497c1d",
+        "c9a6dc8a-4d29-4755-82e9-8e3b41b16b7b",
+        "8f284153-3e81-42b9-a2eb-2a911faeaa81",
+        "783c5a96-09be-4849-afdc-d93807283834",
+        "6f9e32f0-cf69-45e0-aacb-61ebb6aa1a4a",
+        "53c58b79-f1f8-4046-a6d5-c015af0a9671",
+        "aa9117b2-6290-43cf-85d6-deadf2251c87",
+        "9423e4f5-6aad-453b-9a6e-84bca367188d",
+        "717bfb01-a912-499d-9bc5-32ac3c449e98",
+        "665b3da0-e4d6-4c5a-9798-816a0be0eb0d"
+    ]
+  },
+  "Announcements": {
+    "StorageLastChangeDateTimeUtc": "2022-09-01T20:09:13.649Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-06-20T11:12:03.223Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "Maps": {
+    "StorageLastChangeDateTimeUtc": "2022-08-26T09:56:25.656Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.367Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  }
+}

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Remote Responses/JSON/EF26_DeleteEvent.json
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Remote Responses/JSON/EF26_DeleteEvent.json
@@ -1,0 +1,80 @@
+{
+  "ConventionIdentifier": "EF26",
+  "Since": "2022-09-02T12:04:11.038+00:00",
+  "CurrentDateTimeUtc": "2022-09-02T12:04:20.632Z",
+  "State": "preview",
+  "Events": {
+    "StorageLastChangeDateTimeUtc": "2022-08-28T10:30:05.522Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.266Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": [
+        "76430fe0-ece7-48c9-b8e6-fdbc3974ff64"
+    ]
+  },
+  "EventConferenceDays": {
+    "StorageLastChangeDateTimeUtc": "2022-06-23T08:18:09.436Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.334Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "EventConferenceRooms": {
+    "StorageLastChangeDateTimeUtc": "2022-08-27T01:30:05.243Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.339Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "EventConferenceTracks": {
+    "StorageLastChangeDateTimeUtc": "2022-08-21T23:00:05.813Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.343Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "KnowledgeGroups": {
+    "StorageLastChangeDateTimeUtc": "2022-08-26T11:31:36.176Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.347Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "KnowledgeEntries": {
+    "StorageLastChangeDateTimeUtc": "2022-08-31T20:03:51.531Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.351Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "Images": {
+    "StorageLastChangeDateTimeUtc": "2022-09-01T20:09:13.567Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.355Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "Dealers": {
+    "StorageLastChangeDateTimeUtc": "2022-08-21T21:00:10.138Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.359Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "Announcements": {
+    "StorageLastChangeDateTimeUtc": "2022-09-01T20:09:13.649Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-06-20T11:12:03.223Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": [
+        "8822b105-a46c-441a-a8db-cd6c084d33c8"
+    ]
+  },
+  "Maps": {
+    "StorageLastChangeDateTimeUtc": "2022-08-26T09:56:25.656Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.367Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  }
+}

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Remote Responses/JSON/EF26_DeleteEvent.json
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Remote Responses/JSON/EF26_DeleteEvent.json
@@ -66,9 +66,7 @@
     "StorageDeltaStartChangeDateTimeUtc": "2022-06-20T11:12:03.223Z",
     "RemoveAllBeforeInsert": false,
     "ChangedEntities": [],
-    "DeletedEntities": [
-        "8822b105-a46c-441a-a8db-cd6c084d33c8"
-    ]
+    "DeletedEntities": []
   },
   "Maps": {
     "StorageLastChangeDateTimeUtc": "2022-08-26T09:56:25.656Z",

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Remote Responses/JSON/EF26_DeleteEventHostedByBirdy.json
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Remote Responses/JSON/EF26_DeleteEventHostedByBirdy.json
@@ -1,0 +1,78 @@
+{
+  "ConventionIdentifier": "EF26",
+  "Since": "2022-09-02T12:04:11.038+00:00",
+  "CurrentDateTimeUtc": "2022-09-02T12:04:20.632Z",
+  "State": "preview",
+  "Events": {
+    "StorageLastChangeDateTimeUtc": "2022-08-28T10:30:05.522Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.266Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": [
+        "073fc7b1-8165-413c-b028-db802c360bcf"
+    ]
+  },
+  "EventConferenceDays": {
+    "StorageLastChangeDateTimeUtc": "2022-06-23T08:18:09.436Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.334Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "EventConferenceRooms": {
+    "StorageLastChangeDateTimeUtc": "2022-08-27T01:30:05.243Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.339Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "EventConferenceTracks": {
+    "StorageLastChangeDateTimeUtc": "2022-08-21T23:00:05.813Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.343Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "KnowledgeGroups": {
+    "StorageLastChangeDateTimeUtc": "2022-08-26T11:31:36.176Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.347Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "KnowledgeEntries": {
+    "StorageLastChangeDateTimeUtc": "2022-08-31T20:03:51.531Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.351Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "Images": {
+    "StorageLastChangeDateTimeUtc": "2022-09-01T20:09:13.567Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.355Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "Dealers": {
+    "StorageLastChangeDateTimeUtc": "2022-08-21T21:00:10.138Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.359Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "Announcements": {
+    "StorageLastChangeDateTimeUtc": "2022-09-01T20:09:13.649Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-06-20T11:12:03.223Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "Maps": {
+    "StorageLastChangeDateTimeUtc": "2022-08-26T09:56:25.656Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.367Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  }
+}

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Remote Responses/JSON/EF26_DeleteEvent_WithBanner.json
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Remote Responses/JSON/EF26_DeleteEvent_WithBanner.json
@@ -1,0 +1,80 @@
+{
+  "ConventionIdentifier": "EF26",
+  "Since": "2022-09-02T12:04:11.038+00:00",
+  "CurrentDateTimeUtc": "2022-09-02T12:04:20.632Z",
+  "State": "preview",
+  "Events": {
+    "StorageLastChangeDateTimeUtc": "2022-08-28T10:30:05.522Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.266Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": [
+        "d7676a70-bc1e-4fde-9891-8060cb9f291a"
+    ]
+  },
+  "EventConferenceDays": {
+    "StorageLastChangeDateTimeUtc": "2022-06-23T08:18:09.436Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.334Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "EventConferenceRooms": {
+    "StorageLastChangeDateTimeUtc": "2022-08-27T01:30:05.243Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.339Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "EventConferenceTracks": {
+    "StorageLastChangeDateTimeUtc": "2022-08-21T23:00:05.813Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.343Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "KnowledgeGroups": {
+    "StorageLastChangeDateTimeUtc": "2022-08-26T11:31:36.176Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.347Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "KnowledgeEntries": {
+    "StorageLastChangeDateTimeUtc": "2022-08-31T20:03:51.531Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.351Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "Images": {
+    "StorageLastChangeDateTimeUtc": "2022-09-01T20:09:13.567Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.355Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "Dealers": {
+    "StorageLastChangeDateTimeUtc": "2022-08-21T21:00:10.138Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.359Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "Announcements": {
+    "StorageLastChangeDateTimeUtc": "2022-09-01T20:09:13.649Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-06-20T11:12:03.223Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": [
+        "8822b105-a46c-441a-a8db-cd6c084d33c8"
+    ]
+  },
+  "Maps": {
+    "StorageLastChangeDateTimeUtc": "2022-08-26T09:56:25.656Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.367Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  }
+}

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Remote Responses/JSON/EF26_DeleteEvent_WithPoster.json
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Remote Responses/JSON/EF26_DeleteEvent_WithPoster.json
@@ -1,0 +1,80 @@
+{
+  "ConventionIdentifier": "EF26",
+  "Since": "2022-09-02T12:04:11.038+00:00",
+  "CurrentDateTimeUtc": "2022-09-02T12:04:20.632Z",
+  "State": "preview",
+  "Events": {
+    "StorageLastChangeDateTimeUtc": "2022-08-28T10:30:05.522Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.266Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": [
+        "46c59831-012e-4e4b-8e15-a6de1aca3ad4"
+    ]
+  },
+  "EventConferenceDays": {
+    "StorageLastChangeDateTimeUtc": "2022-06-23T08:18:09.436Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.334Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "EventConferenceRooms": {
+    "StorageLastChangeDateTimeUtc": "2022-08-27T01:30:05.243Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.339Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "EventConferenceTracks": {
+    "StorageLastChangeDateTimeUtc": "2022-08-21T23:00:05.813Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.343Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "KnowledgeGroups": {
+    "StorageLastChangeDateTimeUtc": "2022-08-26T11:31:36.176Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.347Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "KnowledgeEntries": {
+    "StorageLastChangeDateTimeUtc": "2022-08-31T20:03:51.531Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.351Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "Images": {
+    "StorageLastChangeDateTimeUtc": "2022-09-01T20:09:13.567Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.355Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "Dealers": {
+    "StorageLastChangeDateTimeUtc": "2022-08-21T21:00:10.138Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.359Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "Announcements": {
+    "StorageLastChangeDateTimeUtc": "2022-09-01T20:09:13.649Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-06-20T11:12:03.223Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": [
+        "8822b105-a46c-441a-a8db-cd6c084d33c8"
+    ]
+  },
+  "Maps": {
+    "StorageLastChangeDateTimeUtc": "2022-08-26T09:56:25.656Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.367Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  }
+}

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Remote Responses/JSON/EF26_DeleteEvent_WithSharedPoster.json
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Remote Responses/JSON/EF26_DeleteEvent_WithSharedPoster.json
@@ -1,0 +1,80 @@
+{
+  "ConventionIdentifier": "EF26",
+  "Since": "2022-09-02T12:04:11.038+00:00",
+  "CurrentDateTimeUtc": "2022-09-02T12:04:20.632Z",
+  "State": "preview",
+  "Events": {
+    "StorageLastChangeDateTimeUtc": "2022-08-28T10:30:05.522Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.266Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": [
+        "4a90c95f-dac0-4ca0-9f6d-a7839845ba36"
+    ]
+  },
+  "EventConferenceDays": {
+    "StorageLastChangeDateTimeUtc": "2022-06-23T08:18:09.436Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.334Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "EventConferenceRooms": {
+    "StorageLastChangeDateTimeUtc": "2022-08-27T01:30:05.243Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.339Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "EventConferenceTracks": {
+    "StorageLastChangeDateTimeUtc": "2022-08-21T23:00:05.813Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.343Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "KnowledgeGroups": {
+    "StorageLastChangeDateTimeUtc": "2022-08-26T11:31:36.176Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.347Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "KnowledgeEntries": {
+    "StorageLastChangeDateTimeUtc": "2022-08-31T20:03:51.531Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.351Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "Images": {
+    "StorageLastChangeDateTimeUtc": "2022-09-01T20:09:13.567Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.355Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "Dealers": {
+    "StorageLastChangeDateTimeUtc": "2022-08-21T21:00:10.138Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.359Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "Announcements": {
+    "StorageLastChangeDateTimeUtc": "2022-09-01T20:09:13.649Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-06-20T11:12:03.223Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": [
+        "8822b105-a46c-441a-a8db-cd6c084d33c8"
+    ]
+  },
+  "Maps": {
+    "StorageLastChangeDateTimeUtc": "2022-08-26T09:56:25.656Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.367Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  }
+}

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Remote Responses/JSON/EF26_DeleteKnowledgeGroup.json
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Remote Responses/JSON/EF26_DeleteKnowledgeGroup.json
@@ -1,0 +1,78 @@
+{
+  "ConventionIdentifier": "EF26",
+  "Since": "2022-09-02T12:04:11.038+00:00",
+  "CurrentDateTimeUtc": "2022-09-02T12:04:20.632Z",
+  "State": "preview",
+  "Events": {
+    "StorageLastChangeDateTimeUtc": "2022-08-28T10:30:05.522Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.266Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "EventConferenceDays": {
+    "StorageLastChangeDateTimeUtc": "2022-06-23T08:18:09.436Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.334Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "EventConferenceRooms": {
+    "StorageLastChangeDateTimeUtc": "2022-08-27T01:30:05.243Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.339Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "EventConferenceTracks": {
+    "StorageLastChangeDateTimeUtc": "2022-08-21T23:00:05.813Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.343Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "KnowledgeGroups": {
+    "StorageLastChangeDateTimeUtc": "2022-08-26T11:31:36.176Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.347Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": [
+        "92cdf214-7e9f-6bfa-0370-dfadd5e76493"
+    ]
+  },
+  "KnowledgeEntries": {
+    "StorageLastChangeDateTimeUtc": "2022-08-31T20:03:51.531Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.351Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "Images": {
+    "StorageLastChangeDateTimeUtc": "2022-09-01T20:09:13.567Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.355Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "Dealers": {
+    "StorageLastChangeDateTimeUtc": "2022-08-21T21:00:10.138Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.359Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "Announcements": {
+    "StorageLastChangeDateTimeUtc": "2022-09-01T20:09:13.649Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-06-20T11:12:03.223Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "Maps": {
+    "StorageLastChangeDateTimeUtc": "2022-08-26T09:56:25.656Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.367Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  }
+}

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Remote Responses/JSON/EF26_DeleteRoom.json
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Remote Responses/JSON/EF26_DeleteRoom.json
@@ -1,0 +1,78 @@
+{
+  "ConventionIdentifier": "EF26",
+  "Since": "2022-09-02T12:04:11.038+00:00",
+  "CurrentDateTimeUtc": "2022-09-02T12:04:20.632Z",
+  "State": "preview",
+  "Events": {
+    "StorageLastChangeDateTimeUtc": "2022-08-28T10:30:05.522Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.266Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "EventConferenceDays": {
+    "StorageLastChangeDateTimeUtc": "2022-06-23T08:18:09.436Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.334Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "EventConferenceRooms": {
+    "StorageLastChangeDateTimeUtc": "2022-08-27T01:30:05.243Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.339Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": [
+        "2d5d9a98-aaca-4434-959d-99d20e675d3a"
+    ]
+  },
+  "EventConferenceTracks": {
+    "StorageLastChangeDateTimeUtc": "2022-08-21T23:00:05.813Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.343Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "KnowledgeGroups": {
+    "StorageLastChangeDateTimeUtc": "2022-08-26T11:31:36.176Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.347Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "KnowledgeEntries": {
+    "StorageLastChangeDateTimeUtc": "2022-08-31T20:03:51.531Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.351Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "Images": {
+    "StorageLastChangeDateTimeUtc": "2022-09-01T20:09:13.567Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.355Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "Dealers": {
+    "StorageLastChangeDateTimeUtc": "2022-08-21T21:00:10.138Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.359Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "Announcements": {
+    "StorageLastChangeDateTimeUtc": "2022-09-01T20:09:13.649Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-06-20T11:12:03.223Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "Maps": {
+    "StorageLastChangeDateTimeUtc": "2022-08-26T09:56:25.656Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.367Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  }
+}

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Remote Responses/JSON/EF26_DeleteTrack.json
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Remote Responses/JSON/EF26_DeleteTrack.json
@@ -1,0 +1,78 @@
+{
+  "ConventionIdentifier": "EF26",
+  "Since": "2022-09-02T12:04:11.038+00:00",
+  "CurrentDateTimeUtc": "2022-09-02T12:04:20.632Z",
+  "State": "preview",
+  "Events": {
+    "StorageLastChangeDateTimeUtc": "2022-08-28T10:30:05.522Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.266Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "EventConferenceDays": {
+    "StorageLastChangeDateTimeUtc": "2022-06-23T08:18:09.436Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.334Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "EventConferenceRooms": {
+    "StorageLastChangeDateTimeUtc": "2022-08-27T01:30:05.243Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.339Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "EventConferenceTracks": {
+    "StorageLastChangeDateTimeUtc": "2022-08-21T23:00:05.813Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.343Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": [
+        "f23cc7f6-34c1-48d5-8acb-0ec10c353403"
+    ]
+  },
+  "KnowledgeGroups": {
+    "StorageLastChangeDateTimeUtc": "2022-08-26T11:31:36.176Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.347Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "KnowledgeEntries": {
+    "StorageLastChangeDateTimeUtc": "2022-08-31T20:03:51.531Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.351Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "Images": {
+    "StorageLastChangeDateTimeUtc": "2022-09-01T20:09:13.567Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.355Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "Dealers": {
+    "StorageLastChangeDateTimeUtc": "2022-08-21T21:00:10.138Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.359Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "Announcements": {
+    "StorageLastChangeDateTimeUtc": "2022-09-01T20:09:13.649Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-06-20T11:12:03.223Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  },
+  "Maps": {
+    "StorageLastChangeDateTimeUtc": "2022-08-26T09:56:25.656Z",
+    "StorageDeltaStartChangeDateTimeUtc": "2022-02-23T10:16:35.367Z",
+    "RemoveAllBeforeInsert": false,
+    "ChangedEntities": [],
+    "DeletedEntities": []
+  }
+}

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Remote Responses/SampleResponse.swift
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Remote Responses/SampleResponse.swift
@@ -18,6 +18,7 @@ enum SampleResponse {
     case deletedKnowledgeGroup
     case deletedRoom
     case deletedTrack
+    case deletedDay
     
     private var fileName: String {
         switch self {
@@ -51,6 +52,8 @@ enum SampleResponse {
             return "EF26_DeleteRoom"
         case .deletedTrack:
             return "EF26_DeleteTrack"
+        case .deletedDay:
+            return "EF26_DeleteDay"
         }
     }
     

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Remote Responses/SampleResponse.swift
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Remote Responses/SampleResponse.swift
@@ -16,6 +16,7 @@ enum SampleResponse {
     case deletedDealer
     case deletedDealersWithinFursuitCategory
     case deletedKnowledgeGroup
+    case deletedRoom
     
     private var fileName: String {
         switch self {
@@ -45,6 +46,8 @@ enum SampleResponse {
             return "EF26_DeleteDealers_FursuitCategoryOnly"
         case .deletedKnowledgeGroup:
             return "EF26_DeleteKnowledgeGroup"
+        case .deletedRoom:
+            return "EF26_DeleteRoom"
         }
     }
     

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Remote Responses/SampleResponse.swift
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Remote Responses/SampleResponse.swift
@@ -13,6 +13,7 @@ enum SampleResponse {
     case deletedEventWithPoster
     case deletedEventWithSharedPoster
     case deletedDealer
+    case deletedDealersWithinFursuitCategory
     
     private var fileName: String {
         switch self {
@@ -36,6 +37,8 @@ enum SampleResponse {
             return "EF26_DeleteEvent_WithSharedPoster"
         case .deletedDealer:
             return "EF26_DeleteDealer"
+        case .deletedDealersWithinFursuitCategory:
+            return "EF26_DeleteDealers_FursuitCategoryOnly"
         }
     }
     

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Remote Responses/SampleResponse.swift
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Remote Responses/SampleResponse.swift
@@ -7,6 +7,10 @@ enum SampleResponse {
     case corruptEF26
     case noChanges
     case deletedAnnouncement
+    case deletedEvent
+    case deletedEventWithBanner
+    case deletedEventWithPoster
+    case deletedEventWithSharedPoster
     
     private var fileName: String {
         switch self {
@@ -18,6 +22,14 @@ enum SampleResponse {
             return "NoChanges"
         case .deletedAnnouncement:
             return "EF26_DeleteAnnouncement"
+        case .deletedEvent:
+            return "EF26_DeleteEvent"
+        case .deletedEventWithBanner:
+            return "EF26_DeleteEvent_WithBanner"
+        case .deletedEventWithPoster:
+            return "EF26_DeleteEvent_WithPoster"
+        case .deletedEventWithSharedPoster:
+            return "EF26_DeleteEvent_WithSharedPoster"
         }
     }
     

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Remote Responses/SampleResponse.swift
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Remote Responses/SampleResponse.swift
@@ -12,6 +12,7 @@ enum SampleResponse {
     case deletedEventWithBanner
     case deletedEventWithPoster
     case deletedEventWithSharedPoster
+    case deletedEventHostedByBirdy
     case deletedDealer
     case deletedDealersWithinFursuitCategory
     
@@ -35,6 +36,8 @@ enum SampleResponse {
             return "EF26_DeleteEvent_WithPoster"
         case .deletedEventWithSharedPoster:
             return "EF26_DeleteEvent_WithSharedPoster"
+        case .deletedEventHostedByBirdy:
+            return "EF26_DeleteEventHostedByBirdy"
         case .deletedDealer:
             return "EF26_DeleteDealer"
         case .deletedDealersWithinFursuitCategory:

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Remote Responses/SampleResponse.swift
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Remote Responses/SampleResponse.swift
@@ -6,6 +6,7 @@ enum SampleResponse {
     case ef26
     case corruptEF26
     case noChanges
+    case deletedAnnouncement
     
     private var fileName: String {
         switch self {
@@ -15,6 +16,8 @@ enum SampleResponse {
             return "EF26_Corrupt_Sync_Response"
         case .noChanges:
             return "NoChanges"
+        case .deletedAnnouncement:
+            return "EF26_DeleteAnnouncement"
         }
     }
     

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Remote Responses/SampleResponse.swift
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Remote Responses/SampleResponse.swift
@@ -15,6 +15,7 @@ enum SampleResponse {
     case deletedEventHostedByBirdy
     case deletedDealer
     case deletedDealersWithinFursuitCategory
+    case deletedKnowledgeGroup
     
     private var fileName: String {
         switch self {
@@ -42,6 +43,8 @@ enum SampleResponse {
             return "EF26_DeleteDealer"
         case .deletedDealersWithinFursuitCategory:
             return "EF26_DeleteDealers_FursuitCategoryOnly"
+        case .deletedKnowledgeGroup:
+            return "EF26_DeleteKnowledgeGroup"
         }
     }
     

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Remote Responses/SampleResponse.swift
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Remote Responses/SampleResponse.swift
@@ -3,6 +3,7 @@ import Foundation
 
 enum SampleResponse {
     
+    case deleteAll
     case ef26
     case corruptEF26
     case noChanges
@@ -14,6 +15,8 @@ enum SampleResponse {
     
     private var fileName: String {
         switch self {
+        case .deleteAll:
+            return "DeleteAll"
         case .ef26:
             return "EF26_Full_Sync_Response"
         case .corruptEF26:

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Remote Responses/SampleResponse.swift
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Remote Responses/SampleResponse.swift
@@ -12,6 +12,7 @@ enum SampleResponse {
     case deletedEventWithBanner
     case deletedEventWithPoster
     case deletedEventWithSharedPoster
+    case deletedDealer
     
     private var fileName: String {
         switch self {
@@ -33,6 +34,8 @@ enum SampleResponse {
             return "EF26_DeleteEvent_WithPoster"
         case .deletedEventWithSharedPoster:
             return "EF26_DeleteEvent_WithSharedPoster"
+        case .deletedDealer:
+            return "EF26_DeleteDealer"
         }
     }
     

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Remote Responses/SampleResponse.swift
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Remote Responses/SampleResponse.swift
@@ -17,6 +17,7 @@ enum SampleResponse {
     case deletedDealersWithinFursuitCategory
     case deletedKnowledgeGroup
     case deletedRoom
+    case deletedTrack
     
     private var fileName: String {
         switch self {
@@ -48,6 +49,8 @@ enum SampleResponse {
             return "EF26_DeleteKnowledgeGroup"
         case .deletedRoom:
             return "EF26_DeleteRoom"
+        case .deletedTrack:
+            return "EF26_DeleteTrack"
         }
     }
     

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Test Doubles/FakeModelProperties.swift
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Test Doubles/FakeModelProperties.swift
@@ -7,4 +7,13 @@ class FakeModelProperties: EurofurenceModelProperties {
     var containerDirectoryURL: URL { URL(fileURLWithPath: "file://") }
     var synchronizationChangeToken: SynchronizationPayload.GenerationToken?
     
+    private var removedContainerResources = Set<URL>()
+    func removeContainerResource(at url: URL) throws {
+        removedContainerResources.insert(url)
+    }
+    
+    func removedContainerResource(at url: URL) -> Bool {
+        removedContainerResources.contains(url)
+    }
+    
 }

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/XCTAssertEventuallyThrowsSpecificError.swift
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/XCTAssertEventuallyThrowsSpecificError.swift
@@ -1,5 +1,21 @@
 import XCTest
 
+func XCTAssertThrowsSpecificError<E>(
+    _ expected: E,
+    _ block: () throws -> Void,
+    file: StaticString = #file,
+    line: UInt = #line
+) where E: Error & Equatable {
+    do {
+        try block()
+        XCTFail("Expected to throw an error.", file: file, line: line)
+    } catch let error as E {
+        XCTAssertEqual(expected, error, file: file, line: line)
+    } catch {
+        XCTFail("Unexpected error thrown: \(error)", file: file, line: line)
+    }
+}
+
 func XCTAssertEventuallyThrowsSpecificError<E>(
     _ expected: E,
     _ block: () async throws -> Void,


### PR DESCRIPTION
Support for removing all entities and removing specific entities from the sync response. Cascades deletions where appropriate to maintain invariants (e.g. deleting a room will delete all events in that room).