### PR TITLE
Add basic layout for SwiftUI event view

### DIFF
--- a/Eurofurence.xcodeproj/project.pbxproj
+++ b/Eurofurence.xcodeproj/project.pbxproj
@@ -43,6 +43,8 @@
 		6EA4ECE228C9281D00B20502 /* TopLevelSidebarItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA4ECE128C9281D00B20502 /* TopLevelSidebarItems.swift */; };
 		6EA4ECE428C9285D00B20502 /* DealerSidebarItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA4ECE328C9285D00B20502 /* DealerSidebarItems.swift */; };
 		6EA4ECE628C9288800B20502 /* ScheduleSidebarItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA4ECE528C9288800B20502 /* ScheduleSidebarItems.swift */; };
+		6EB17FEF28D35B30008DB4F1 /* EventView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EB17FEE28D35B30008DB4F1 /* EventView.swift */; };
+		6EB17FF128D37915008DB4F1 /* EventSubtitle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EB17FF028D37915008DB4F1 /* EventSubtitle.swift */; };
 		6EE355A9289079B300F3ACB7 /* LoginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EE355A8289079B300F3ACB7 /* LoginTests.swift */; };
 		6EF82FC128CA3A47006463EA /* AutoPatchSplitViewControllerWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EF82FC028CA3A47006463EA /* AutoPatchSplitViewControllerWindow.swift */; };
 		6EF82FC328CA3B86006463EA /* DealersCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EF82FC228CA3B86006463EA /* DealersCollectionView.swift */; };
@@ -332,6 +334,8 @@
 		6EA4ECE128C9281D00B20502 /* TopLevelSidebarItems.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopLevelSidebarItems.swift; sourceTree = "<group>"; };
 		6EA4ECE328C9285D00B20502 /* DealerSidebarItems.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DealerSidebarItems.swift; sourceTree = "<group>"; };
 		6EA4ECE528C9288800B20502 /* ScheduleSidebarItems.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleSidebarItems.swift; sourceTree = "<group>"; };
+		6EB17FEE28D35B30008DB4F1 /* EventView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventView.swift; sourceTree = "<group>"; };
+		6EB17FF028D37915008DB4F1 /* EventSubtitle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventSubtitle.swift; sourceTree = "<group>"; };
 		6EE355A8289079B300F3ACB7 /* LoginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginTests.swift; sourceTree = "<group>"; };
 		6EE355AA28907BE600F3ACB7 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		6EF82FC028CA3A47006463EA /* AutoPatchSplitViewControllerWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoPatchSplitViewControllerWindow.swift; sourceTree = "<group>"; };
@@ -675,11 +679,12 @@
 		6EA4ECD528C8DC7700B20502 /* Modules */ = {
 			isa = PBXGroup;
 			children = (
-				6EA4ECD228C8DC5B00B20502 /* More */,
-				6EA4ECCF28C8DC4200B20502 /* Information */,
 				6EA4ECCC28C8DC2800B20502 /* Dealers */,
-				6EA4ECC928C8DC0B00B20502 /* Schedule */,
+				6EB17FED28D35B24008DB4F1 /* Event */,
+				6EA4ECCF28C8DC4200B20502 /* Information */,
+				6EA4ECD228C8DC5B00B20502 /* More */,
 				6EA4ECC628C8DBD400B20502 /* News */,
+				6EA4ECC928C8DC0B00B20502 /* Schedule */,
 			);
 			path = Modules;
 			sourceTree = "<group>";
@@ -730,6 +735,15 @@
 				6EA4ECE528C9288800B20502 /* ScheduleSidebarItems.swift */,
 			);
 			path = Sections;
+			sourceTree = "<group>";
+		};
+		6EB17FED28D35B24008DB4F1 /* Event */ = {
+			isa = PBXGroup;
+			children = (
+				6EB17FEE28D35B30008DB4F1 /* EventView.swift */,
+				6EB17FF028D37915008DB4F1 /* EventSubtitle.swift */,
+			);
+			path = Event;
 			sourceTree = "<group>";
 		};
 		6EF82FBF28CA3A2E006463EA /* UIKit */ = {
@@ -1654,6 +1668,7 @@
 				6E79E66F28C9E35B00444A37 /* DealerCategoriesView.swift in Sources */,
 				6EA4ECD128C8DC4900B20502 /* InformationView.swift in Sources */,
 				6E20270128D1FDE2008C61BD /* FontAwesomeText.swift in Sources */,
+				6EB17FEF28D35B30008DB4F1 /* EventView.swift in Sources */,
 				6E08B1AB28CE04EB00512406 /* InformationLabel.swift in Sources */,
 				6EA4ECE228C9281D00B20502 /* TopLevelSidebarItems.swift in Sources */,
 				6E08B1A828CE04AF00512406 /* NewsLabel.swift in Sources */,
@@ -1663,6 +1678,7 @@
 				6E79E66928C9CD0D00444A37 /* ScheduleView.swift in Sources */,
 				6EA4ECE028C9280A00B20502 /* Sidebar.swift in Sources */,
 				6EA4ECE428C9285D00B20502 /* DealerSidebarItems.swift in Sources */,
+				6EB17FF128D37915008DB4F1 /* EventSubtitle.swift in Sources */,
 				CABD9BA528BE08DF00CEFAB3 /* TabExperience.swift in Sources */,
 				6E08B1B128CE06BC00512406 /* AdditionalServicesLabel.swift in Sources */,
 				6EA4ECD428C8DC6000B20502 /* MoreView.swift in Sources */,

--- a/Eurofurence.xcodeproj/project.pbxproj
+++ b/Eurofurence.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		6EA4ECE628C9288800B20502 /* ScheduleSidebarItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA4ECE528C9288800B20502 /* ScheduleSidebarItems.swift */; };
 		6EB17FEF28D35B30008DB4F1 /* EventView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EB17FEE28D35B30008DB4F1 /* EventView.swift */; };
 		6EB17FF128D37915008DB4F1 /* EventSubtitle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EB17FF028D37915008DB4F1 /* EventSubtitle.swift */; };
+		6EE14CBA28D533E600A3A117 /* AlignedLabelContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EE14CB928D533E600A3A117 /* AlignedLabelContainer.swift */; };
 		6EE355A9289079B300F3ACB7 /* LoginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EE355A8289079B300F3ACB7 /* LoginTests.swift */; };
 		6EF82FC128CA3A47006463EA /* AutoPatchSplitViewControllerWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EF82FC028CA3A47006463EA /* AutoPatchSplitViewControllerWindow.swift */; };
 		6EF82FC328CA3B86006463EA /* DealersCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EF82FC228CA3B86006463EA /* DealersCollectionView.swift */; };
@@ -336,6 +337,7 @@
 		6EA4ECE528C9288800B20502 /* ScheduleSidebarItems.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleSidebarItems.swift; sourceTree = "<group>"; };
 		6EB17FEE28D35B30008DB4F1 /* EventView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventView.swift; sourceTree = "<group>"; };
 		6EB17FF028D37915008DB4F1 /* EventSubtitle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventSubtitle.swift; sourceTree = "<group>"; };
+		6EE14CB928D533E600A3A117 /* AlignedLabelContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlignedLabelContainer.swift; sourceTree = "<group>"; };
 		6EE355A8289079B300F3ACB7 /* LoginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginTests.swift; sourceTree = "<group>"; };
 		6EE355AA28907BE600F3ACB7 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		6EF82FC028CA3A47006463EA /* AutoPatchSplitViewControllerWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoPatchSplitViewControllerWindow.swift; sourceTree = "<group>"; };
@@ -757,6 +759,7 @@
 		6EF82FC428CA920A006463EA /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				6EE14CB928D533E600A3A117 /* AlignedLabelContainer.swift */,
 				6E20270028D1FDE2008C61BD /* FontAwesomeText.swift */,
 				6E2026FE28D1C75F008C61BD /* FormattedShortTime.swift */,
 				6E8389D228CF73EA007E14DC /* Lazy.swift */,
@@ -1659,6 +1662,7 @@
 				CA630C0922A069AF00754C27 /* ViewEventIntent+Definition.swift in Sources */,
 				6EF82FC328CA3B86006463EA /* DealersCollectionView.swift in Sources */,
 				6E79E66D28C9CDEC00444A37 /* EventConferenceTracksView.swift in Sources */,
+				6EE14CBA28D533E600A3A117 /* AlignedLabelContainer.swift in Sources */,
 				6E08B1C328CE6E8400512406 /* ScheduleCollectionView.swift in Sources */,
 				6EA4ECCE28C8DC2D00B20502 /* DealersView.swift in Sources */,
 				6E8389D328CF73EA007E14DC /* Lazy.swift in Sources */,

--- a/Eurofurence/SwiftUI/Modules/Event/EventSubtitle.swift
+++ b/Eurofurence/SwiftUI/Modules/Event/EventSubtitle.swift
@@ -1,0 +1,40 @@
+import EurofurenceKit
+import SwiftUI
+
+struct EventSubtitle: View {
+    
+    @ObservedObject private var event: Event
+    
+    init(_ event: Event) {
+        self.event = event
+    }
+    
+    var body: some View {
+        if event.subtitle.isEmpty {
+            if let abstract = event.abstract {
+                MarkdownContent(abstract)
+            }
+        } else {
+            MarkdownContent(event.subtitle)
+        }
+    }
+    
+}
+
+struct EventSubtitle_Previews: PreviewProvider {
+    
+    static var previews: some View {
+        EurofurenceModel.preview { model in
+            let registration = model.event(for: .registration)
+            EventSubtitle(registration)
+                .previewDisplayName(registration.title)
+                .previewLayout(.sizeThatFits)
+            
+            let bootyBounce = model.event(for: .bootyBounce)
+            EventSubtitle(bootyBounce)
+                .previewDisplayName(bootyBounce.title)
+                .previewLayout(.sizeThatFits)
+        }
+    }
+    
+}

--- a/Eurofurence/SwiftUI/Modules/Event/EventView.swift
+++ b/Eurofurence/SwiftUI/Modules/Event/EventView.swift
@@ -65,13 +65,15 @@ struct EventView: View {
             }
             
             ToolbarItem(placement: .bottomBar) {
-                Button {
-                    // TODO: Leave feedback!
-                } label: {
-                    Label {
-                        Text("Leave Feedback")
-                    } icon: {
-                        Image(systemName: "square.and.pencil")
+                if event.acceptingFeedback {
+                    Button {
+                        // TODO: Leave feedback!
+                    } label: {
+                        Label {
+                            Text("Leave Feedback")
+                        } icon: {
+                            Image(systemName: "square.and.pencil")
+                        }
                     }
                 }
             }
@@ -146,7 +148,7 @@ struct EventView: View {
         
         var body: some View {
             if event.canonicalTags.isEmpty == false {
-                VStack(alignment: .leading) {
+                AlignedLabelContainer {
                     ForEach(event.canonicalTags) { tag in
                         HStack {
                             CanonicalTagLabel(tag)
@@ -187,6 +189,12 @@ struct EventView_Previews: PreviewProvider {
                 EventView(event: deadDog)
             }
             .previewDisplayName(deadDog.title)
+            
+            let dealersDen = model.event(for: .dealersDen)
+            NavigationView {
+                EventView(event: dealersDen)
+            }
+            .previewDisplayName(dealersDen.title)
         }
     }
     

--- a/Eurofurence/SwiftUI/Modules/Event/EventView.swift
+++ b/Eurofurence/SwiftUI/Modules/Event/EventView.swift
@@ -1,0 +1,189 @@
+import EurofurenceKit
+import SwiftUI
+
+struct EventView: View {
+    
+    var event: Event
+    @State private var isAboutExpanded = true
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @ScaledMetric(relativeTo: .body) private var intersectionSpacing: CGFloat = 7
+    
+    var body: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading) {
+                EventHeading(event: event)
+                    .padding(.bottom, intersectionSpacing)
+                
+                Divider()
+                    .padding(.bottom, intersectionSpacing)
+                
+                EventTags(event: event)
+                    .padding(.bottom, intersectionSpacing)
+            }
+            .padding()
+        }
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .bottomBar) {
+                Button {
+                    // TODO: Add to/remove from calendar!
+                } label: {
+                    Label {
+                        Text("Add to Calendar")
+                    } icon: {
+                        Image(systemName: "calendar.circle")
+                    }
+                }
+            }
+            
+            ToolbarItem(placement: .bottomBar) {
+                Button {
+                    // TODO: Favourite/unfavourite!
+                } label: {
+                    Label {
+                        Text("Leave Feedback")
+                    } icon: {
+                        Image(systemName: "square.and.pencil.circle")
+                    }
+                }
+            }
+            
+            ToolbarItem(placement: .bottomBar) {
+                Button {
+                    // TODO: Favourite/unfavourite!
+                } label: {
+                    Label {
+                        Text("Faourite")
+                    } icon: {
+                        Image(systemName: "heart.circle")
+                    }
+                }
+            }
+            
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    // TODO: Share!
+                } label: {
+                    Label {
+                        Text("Share")
+                    } icon: {
+                        Image(systemName: "square.and.arrow.up")
+                    }
+                }
+            }
+        }
+    }
+    
+    private struct EventHeading: View {
+        
+        @ObservedObject var event: Event
+        @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+        @ScaledMetric(relativeTo: .body) private var eventTimesToSubtitleSpacing: CGFloat = 10
+        
+        var body: some View {
+            VStack(alignment: .leading) {
+                if let poster = event.poster {
+                    EurofurenceKitImage(image: poster)
+                }
+                
+                trackIndicator
+                    .foregroundColor(.secondary)
+                    .padding(5)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 7)
+                            .stroke(Color.secondary, lineWidth: 1)
+                    )
+                
+                VStack(alignment: .leading, spacing: eventTimesToSubtitleSpacing) {
+                    VStack(alignment: .leading) {
+                        Text(event.title)
+                            .font(.largeTitle.bold())
+                        
+                        if dynamicTypeSize > .xxxLarge {
+                            VStack(alignment: .leading) {
+                                startAndEndTimes
+                            }
+                            .foregroundColor(.secondary)
+                        } else {
+                            HStack {
+                                startAndEndTimes
+                            }
+                            .foregroundColor(.secondary)
+                        }
+                        
+                        Text(event.room.name)
+                            .foregroundColor(.secondary)
+                    }
+                    
+                    EventSubtitle(event)
+                }
+            }
+        }
+        
+        @ViewBuilder private var trackIndicator: some View {
+            if dynamicTypeSize > .xxxLarge {
+                TrackText(event.track)
+            } else {
+                TrackLabel(event.track)
+            }
+        }
+        
+        @ViewBuilder private var startAndEndTimes: some View {
+            Text(event.startDate, format: .dateTime.weekday(.wide))
+            Text((event.startDate...event.endDate))
+        }
+        
+    }
+    
+    private struct EventTags: View {
+        
+        @ObservedObject var event: Event
+        @ScaledMetric(relativeTo: .body) private var interTagSpacing: CGFloat = 7
+        
+        var body: some View {
+            if event.canonicalTags.isEmpty == false {
+                VStack(alignment: .leading) {
+                    ForEach(event.canonicalTags) { tag in
+                        HStack {
+                            CanonicalTagLabel(tag)
+                                .foregroundColor(.pantone330U)
+                            
+                            Spacer()
+                        }
+                        .padding(.bottom, interTagSpacing)
+                        
+                        Divider()
+                    }
+                }
+            }
+        }
+        
+    }
+    
+}
+
+struct EventView_Previews: PreviewProvider {
+    
+    static var previews: some View {
+        EurofurenceModel.preview { model in
+            let registration = model.event(for: .registration)
+            NavigationView {
+                EventView(event: registration)
+            }
+            .previewDisplayName(registration.title)
+            
+            let bootyBounce = model.event(for: .bootyBounce)
+            NavigationView {
+                EventView(event: bootyBounce)
+            }
+            .previewDisplayName(bootyBounce.title)
+            
+            let deadDog = model.event(for: .deadDog)
+            NavigationView {
+                EventView(event: deadDog)
+            }
+            .previewDisplayName(deadDog.title)
+        }
+    }
+    
+}

--- a/Eurofurence/SwiftUI/Modules/Event/EventView.swift
+++ b/Eurofurence/SwiftUI/Modules/Event/EventView.swift
@@ -83,7 +83,7 @@ struct EventView: View {
         var body: some View {
             VStack(alignment: .leading) {
                 if let poster = event.poster {
-                    EurofurenceKitImage(image: poster)
+                    EurofurenceKitImage(image: poster, permitsFullscreenInteraction: true)
                 }
                 
                 trackIndicator

--- a/Eurofurence/SwiftUI/Modules/Event/EventView.swift
+++ b/Eurofurence/SwiftUI/Modules/Event/EventView.swift
@@ -14,48 +14,28 @@ struct EventView: View {
                 EventHeading(event: event)
                     .padding(.bottom, intersectionSpacing)
                 
-                Divider()
-                    .padding(.bottom, intersectionSpacing)
-                
-                EventTags(event: event)
-                    .padding(.bottom, intersectionSpacing)
+                if (event.tags.isEmpty || event.eventDescription.isEmpty) == false {
+                    Divider()
+                        .padding(.bottom, intersectionSpacing)
+                    
+                    EventTags(event: event)
+                        .padding(.bottom, intersectionSpacing)
+                    
+                    MarkdownContent(event.eventDescription)
+                }
             }
             .padding()
         }
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
-            ToolbarItem(placement: .bottomBar) {
-                Button {
-                    // TODO: Add to/remove from calendar!
-                } label: {
-                    Label {
-                        Text("Add to Calendar")
-                    } icon: {
-                        Image(systemName: "calendar.circle")
-                    }
-                }
-            }
-            
-            ToolbarItem(placement: .bottomBar) {
+            ToolbarItem {
                 Button {
                     // TODO: Favourite/unfavourite!
                 } label: {
                     Label {
-                        Text("Leave Feedback")
+                        Text("Favourite")
                     } icon: {
-                        Image(systemName: "square.and.pencil.circle")
-                    }
-                }
-            }
-            
-            ToolbarItem(placement: .bottomBar) {
-                Button {
-                    // TODO: Favourite/unfavourite!
-                } label: {
-                    Label {
-                        Text("Faourite")
-                    } icon: {
-                        Image(systemName: "heart.circle")
+                        Image(systemName: "heart")
                     }
                 }
             }
@@ -68,6 +48,30 @@ struct EventView: View {
                         Text("Share")
                     } icon: {
                         Image(systemName: "square.and.arrow.up")
+                    }
+                }
+            }
+            
+            ToolbarItem(placement: .bottomBar) {
+                Button {
+                    // TODO: Add to/remove from calendar!
+                } label: {
+                    Label {
+                        Text("Add to Calendar")
+                    } icon: {
+                        Image(systemName: "calendar.badge.plus")
+                    }
+                }
+            }
+            
+            ToolbarItem(placement: .bottomBar) {
+                Button {
+                    // TODO: Leave feedback!
+                } label: {
+                    Label {
+                        Text("Leave Feedback")
+                    } icon: {
+                        Image(systemName: "square.and.pencil")
                     }
                 }
             }

--- a/Eurofurence/SwiftUI/Modules/Event/EventView.swift
+++ b/Eurofurence/SwiftUI/Modules/Event/EventView.swift
@@ -19,7 +19,6 @@ struct EventView: View {
                         .padding(.bottom, intersectionSpacing)
                     
                     EventTags(event: event)
-                        .padding(.bottom, intersectionSpacing)
                     
                     MarkdownContent(event.eventDescription)
                 }
@@ -159,6 +158,7 @@ struct EventView: View {
                         .padding(.bottom, interTagSpacing)
                         
                         Divider()
+                            .padding(.bottom, interTagSpacing)
                     }
                 }
             }

--- a/Eurofurence/SwiftUI/Modules/Schedule/EventListRow.swift
+++ b/Eurofurence/SwiftUI/Modules/Schedule/EventListRow.swift
@@ -132,8 +132,8 @@ struct EventListRow: View {
                 Text(event.title)
                     .font(.headline)
                 
-                if let abstract = event.abstract, dynamicTypeSize < .accessibility1 {
-                    MarkdownContent(abstract)
+                if dynamicTypeSize < .accessibility1 {
+                    EventSubtitle(event)
                         .font(.subheadline)
                         .foregroundColor(.secondary)
                         .lineLimit(2)

--- a/Eurofurence/SwiftUI/Modules/Schedule/ScheduleEventsList.swift
+++ b/Eurofurence/SwiftUI/Modules/Schedule/ScheduleEventsList.swift
@@ -40,7 +40,7 @@ struct ScheduleEventsList: View {
         ForEach(group.elements) { (event) in
             NavigationLink(tag: event, selection: $selectedEvent) {
                 Lazy {
-                    Text(event.title)
+                    EventView(event: event)
                 }
             } label: {
                 EventListRow(

--- a/Eurofurence/SwiftUI/Views/AlignedLabelContainer.swift
+++ b/Eurofurence/SwiftUI/Views/AlignedLabelContainer.swift
@@ -1,0 +1,95 @@
+import SwiftUI
+
+struct AlignedLabelContainer<Content>: View where Content: View {
+    
+    private let content: () -> Content
+    @State private var preferredIconWidth: CGFloat = 0
+    
+    init(@ViewBuilder _ content: @escaping () -> Content) {
+        self.content = content
+    }
+    
+    var body: some View {
+        VStack(alignment: .leading) {
+            content()
+                .environment(\.preferredIconWidth, preferredIconWidth)
+                .onPreferenceChange(IconWidthPreferenceKey.self) { newValue in
+                    preferredIconWidth = newValue ?? 0
+                }
+                .labelStyle(EqualIconWidthLabelStyle())
+        }
+    }
+    
+}
+
+private struct IconWidthPreferenceKey: PreferenceKey {
+    
+    typealias Value = CGFloat?
+    
+    static var defaultValue: CGFloat?
+    
+    static func reduce(value: inout CGFloat?, nextValue: () -> CGFloat?) {
+        if let next = nextValue() {
+            if let currentValue = value {
+                value = max(currentValue, next)
+            } else {
+                value = next
+            }
+        }
+    }
+    
+}
+
+private extension EnvironmentValues {
+    
+    var preferredIconWidth: CGFloat {
+        get {
+            self[PreferredIconWidthEnvironmentKey.self]
+        }
+        set {
+            self[PreferredIconWidthEnvironmentKey.self] = newValue
+        }
+    }
+    
+    struct PreferredIconWidthEnvironmentKey: EnvironmentKey {
+        
+        typealias Value = CGFloat
+        
+        static var defaultValue: CGFloat = 0
+        
+    }
+    
+}
+
+private struct EqualIconWidthViewModifier: ViewModifier {
+    
+    @Environment(\.preferredIconWidth) private var preferredIconWidth
+    
+    func body(content: Content) -> some View {
+        content
+            .background(
+                GeometryReader { proxy in
+                    Color
+                        .clear
+                        .preference(key: IconWidthPreferenceKey.self, value: proxy.size.width)
+                }
+            )
+            .frame(width: preferredIconWidth)
+    }
+    
+}
+
+private struct EqualIconWidthLabelStyle: LabelStyle {
+    
+    func makeBody(configuration: Configuration) -> some View {
+        HStack {
+            configuration
+                .icon
+                .modifier(EqualIconWidthViewModifier())
+            
+            configuration
+                .title
+        }
+    }
+    
+}

--- a/Eurofurence/UIKit/PrincipalSwiftUIWindowSceneDelegate.swift
+++ b/Eurofurence/UIKit/PrincipalSwiftUIWindowSceneDelegate.swift
@@ -1,3 +1,4 @@
+import EurofurenceKit
 import SwiftUI
 import UIKit
 
@@ -21,8 +22,10 @@ class PrincipalSwiftUIWindowSceneDelegate: UIResponder, UIWindowSceneDelegate {
             await model.prepareForPresentation()
         }
         
-        let rootView = HandheldExperience()
-            .environmentModel(model)
+        let rootView = ModalImageContainer {
+            HandheldExperience()
+                .environmentModel(model)
+        }
         
         let rootViewController = UIHostingController(rootView: rootView)
         window.rootViewController = rootViewController

--- a/Packages/EurofurenceKit/Sources/EurofurenceKit/Entities/CanonicalTag.swift
+++ b/Packages/EurofurenceKit/Sources/EurofurenceKit/Entities/CanonicalTag.swift
@@ -1,7 +1,11 @@
 import Foundation
 
 /// Describes the feature of a well-known tag within the model.
-public enum CanonicalTag: CaseIterable, CustomStringConvertible, Hashable, Identifiable {
+public enum CanonicalTag: CaseIterable, Comparable, CustomStringConvertible, Hashable, Identifiable {
+    
+    public static func > (lhs: CanonicalTag, rhs: CanonicalTag) -> Bool {
+        lhs.description > rhs.description
+    }
     
     public var id: some Hashable {
         hashValue

--- a/Packages/EurofurenceKit/Sources/EurofurenceKit/Entities/CanonicalTag.swift
+++ b/Packages/EurofurenceKit/Sources/EurofurenceKit/Entities/CanonicalTag.swift
@@ -60,9 +60,54 @@ public enum CanonicalTag: CaseIterable, CustomStringConvertible, Hashable, Ident
             
         case .faceMaskRequired:
             return NSLocalizedString(
-                "Fake Mask Required",
+                "Face Mask Required",
                 bundle: .module,
                 comment: "Description used to denote an event where a face mask is required to enter"
+            )
+            
+        }
+    }
+    
+    public var localizedDescription: String {
+        switch self {
+        case .sponsorOnly:
+            return NSLocalizedString(
+                "Admittance for Sponsors and Super-Sponsors only",
+                bundle: .module,
+                comment: "Detailed description used to denote an event where only sponsors may attend"
+            )
+            
+        case .superSponsorOnly:
+            return NSLocalizedString(
+                "Admittance for Super-Sponsors only",
+                bundle: .module,
+                comment: "Detailed description used to denote an event where only super sponsors may attend"
+            )
+            
+        case .artShow:
+            return description
+            
+        case .kage:
+            return NSLocalizedString(
+                "May contain traces of cockroach and wine",
+                bundle: .module,
+                comment: "Detailed description used to denote an event Kage is running or a featured panelist"
+            )
+            
+        case .dealersDen:
+            return description
+            
+        case .mainStage:
+            return description
+            
+        case .photoshoot:
+            return description
+            
+        case .faceMaskRequired:
+            return NSLocalizedString(
+                "Face masks are mandatory for this event",
+                bundle: .module,
+                comment: "Detailed description used to denote an event where a face mask is required to enter"
             )
             
         }

--- a/Packages/EurofurenceKit/Sources/EurofurenceKit/Entities/Event.swift
+++ b/Packages/EurofurenceKit/Sources/EurofurenceKit/Entities/Event.swift
@@ -38,7 +38,7 @@ extension Event {
             tags.append(tag)
         }
         
-        return tags
+        return tags.sorted()
     }
     
 }

--- a/Packages/EurofurenceKit/Sources/EurofurenceKit/Previewing/EurofurenceModel+Previewing.swift
+++ b/Packages/EurofurenceKit/Sources/EurofurenceKit/Previewing/EurofurenceModel+Previewing.swift
@@ -281,6 +281,7 @@ extension EurofurenceModel {
     public enum PreviewEvent {
         case registration
         case bootyBounce
+        case deadDog
         
         fileprivate var identifier: String {
             switch self {
@@ -289,6 +290,9 @@ extension EurofurenceModel {
                 
             case .bootyBounce:
                 return "0d7817c3-03c4-48a7-bcf9-5cd690e86368"
+                
+            case .deadDog:
+                return "d3e5252b-8521-42ab-bd1a-d67f58c0f10f"
             }
         }
     }

--- a/Packages/EurofurenceKit/Sources/EurofurenceKit/Previewing/EurofurenceModel+Previewing.swift
+++ b/Packages/EurofurenceKit/Sources/EurofurenceKit/Previewing/EurofurenceModel+Previewing.swift
@@ -282,6 +282,7 @@ extension EurofurenceModel {
         case registration
         case bootyBounce
         case deadDog
+        case dealersDen
         
         fileprivate var identifier: String {
             switch self {
@@ -293,6 +294,9 @@ extension EurofurenceModel {
                 
             case .deadDog:
                 return "d3e5252b-8521-42ab-bd1a-d67f58c0f10f"
+                
+            case .dealersDen:
+                return "db4a2537-5e9b-41c0-9c2c-3a1cfc513b5c"
             }
         }
     }

--- a/Packages/EurofurenceKit/Sources/EurofurenceKit/Resources/Localizable.strings
+++ b/Packages/EurofurenceKit/Sources/EurofurenceKit/Resources/Localizable.strings
@@ -32,4 +32,8 @@
 "Dealers Den" = "Dealers Den";
 "Main Stage" = "Main Stage";
 "Photoshoot" = "Photoshoot";
-"Fake Mask Required" = "Fake Mask Required";
+"Face Mask Required" = "Face Mask Required";
+"Admittance for Sponsors and Super-Sponsors only" = "Admittance for Sponsors and Super-Sponsors only";
+"Admittance for Super-Sponsors only" = "Admittance for Super-Sponsors only";
+"May contain traces of cockroach and wine" = "May contain traces of cockroach and wine";
+"Face masks are mandatory for this event" = "Face masks are mandatory for this event";

--- a/Packages/EurofurenceKit/Sources/EurofurenceKit/SwiftUI/Modifiers/View+Measure.swift
+++ b/Packages/EurofurenceKit/Sources/EurofurenceKit/SwiftUI/Modifiers/View+Measure.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+extension View {
+    
+    /// Installs a modifier that invokes the given closure whenever the size of the view changes.
+    /// - Parameter onChange: A closure that will be invkoed when the size of the view is known. The size parameter
+    ///                       represents the size of the view.
+    /// - Returns: A modified `View` with auto-measurements enabled.
+    public func measure(onChange: @escaping (CGSize) -> Void) -> some View {
+        ModifiedContent(content: self, modifier: MeasuredViewModifier(onChange: onChange))
+            .onPreferenceChange(SizePreferenceKey.self) { newValue in
+                onChange(newValue)
+            }
+    }
+    
+}
+
+// MARK: - Modifier
+
+private struct MeasuredViewModifier: ViewModifier {
+    
+    let onChange: (CGSize) -> Void
+    @State private var size: CGSize = .zero
+    
+    func body(content: Content) -> some View {
+        content
+            .background(
+                GeometryReader { proxy in
+                    Color
+                        .clear
+                        .preference(key: SizePreferenceKey.self, value: proxy.size)
+                }
+            )
+    }
+    
+}
+
+// MARK: - Preference
+
+private struct SizePreferenceKey: PreferenceKey {
+    
+    typealias Value = CGSize
+    
+    static let defaultValue: CGSize = .zero
+    
+    static func reduce(value: inout CGSize, nextValue: () -> CGSize) {
+        value = nextValue()
+    }
+    
+}

--- a/Packages/EurofurenceKit/Sources/EurofurenceKit/SwiftUI/Views/EurofurenceKitImage.swift
+++ b/Packages/EurofurenceKit/Sources/EurofurenceKit/SwiftUI/Views/EurofurenceKitImage.swift
@@ -4,6 +4,7 @@ import SwiftUI
 public struct EurofurenceKitImage: View {
     
     @ObservedObject private var image: EurofurenceKit.Image
+    @State private var isShowingFullScreen = false
     
     public init(image: EurofurenceKit.Image) {
         self.image = image
@@ -13,6 +14,12 @@ public struct EurofurenceKitImage: View {
         swiftUIImage
             .aspectRatio(contentMode: .fit)
             .cornerRadius(7)
+            .onTapGesture {
+                isShowingFullScreen = true
+            }
+            .fullScreenCover(isPresented: $isShowingFullScreen) {
+                PannableFullScreenImage(image: swiftUIImage, isPresented: $isShowingFullScreen)
+            }
     }
     
     @ViewBuilder
@@ -30,6 +37,223 @@ public struct EurofurenceKitImage: View {
             }
 #endif
         }
+    }
+    
+    private struct PannableFullScreenImage<Content>: View where Content: View {
+        
+        var image: Content
+        @Binding var isPresented: Bool
+        
+        private let magnificationScaleLimit: CGFloat = 3
+        @State private var currentImageViewSize: CGSize = .zero
+        
+        @State private var magnification = 1.0
+        @State private var inProgressMagnification = 1.0
+        
+        @State private var translationFromIdentity = CGSize.zero
+        @State private var inProgressDrag: DragGesture.Value?
+        
+        var body: some View {
+            GeometryReader { geometry in
+                ZStack {
+                    image
+                        .measure { newValue in
+                            currentImageViewSize = newValue
+                        }
+                        .aspectRatio(contentMode: .fit)
+                        .scaleEffect(currentGestureMagnification)
+                        .offset(currentGestureTranslation)
+                        .onChange(of: magnification) { _ in
+                            withAnimation {
+                                translationFromIdentity = finalDragTranslation(
+                                    proposedTranslation: .zero,
+                                    geometry: geometry
+                                )
+                            }
+                        }
+                        .gesture(TapGesture(count: 2)
+                            .onEnded { _ in
+                                withAnimation {
+                                    if fabsf(Float(magnification)) > 1 {
+                                        magnification = 1
+                                    } else {
+                                        magnification = 2
+                                    }
+                                    
+                                    translationFromIdentity = .zero
+                                }
+                            })
+                        .gesture(MagnificationGesture()
+                            .onChanged { scale in
+                                inProgressMagnification = scale
+                            }
+                            .onEnded { scale in
+                                withAnimation {
+                                    let totalMagnificiation = max(min(magnificationScaleLimit, magnification * scale), 1)
+                                    magnification = totalMagnificiation
+                                    inProgressMagnification = 1
+                                }
+                            })
+                        .simultaneousGesture(DragGesture()
+                            .onChanged { value in
+                                inProgressDrag = value
+                            }
+                            .onEnded { value in
+                                let translation = finalDragTranslation(
+                                    proposedTranslation: value.predictedEndTranslation,
+                                    geometry: geometry
+                                )
+                                
+                                withAnimation(.easeOut) {
+                                    inProgressDrag = nil
+                                    translationFromIdentity = translation
+                                }
+                            })
+                        .edgesIgnoringSafeArea(.all)
+                    
+                    HStack {
+                        Spacer()
+                        
+                        VStack {
+                            Button {
+                                isPresented.toggle()
+                            } label: {
+                                SwiftUI.Image(systemName: "xmark")
+                                    .resizable()
+                                    .aspectRatio(contentMode: .fit)
+                                    .foregroundColor(.secondary)
+                                    .frame(width: 18, height: 18)
+                                    .padding()
+                                    .background(.thinMaterial)
+                                    .clipShape(Circle())
+                            }
+                            
+                            Spacer()
+                        }
+                    }
+                    .padding()
+                }
+            }
+        }
+        
+        private var currentGestureMagnification: CGFloat {
+            magnification * inProgressMagnification
+        }
+        
+        private var currentGestureTranslation: CGSize {
+            guard let inProgressTranslation = inProgressDrag else { return translationFromIdentity }
+            
+            var translation = translationFromIdentity
+            translation.width += inProgressTranslation.translation.width
+            translation.height += inProgressTranslation.translation.height
+            
+            return translation
+        }
+        
+        private func finalDragTranslation(proposedTranslation: CGSize, geometry: GeometryProxy) -> CGSize {
+            var finalTranslation = translationFromIdentity
+            finalTranslation.width += proposedTranslation.width
+            finalTranslation.height += proposedTranslation.height
+            
+            let viewSize = CGSize(
+                width: currentImageViewSize.width * magnification,
+                height: currentImageViewSize.height * magnification
+            )
+            
+            adjustHorizontalComponent(proposedTranslation: &finalTranslation, viewSize: viewSize, geometry: geometry)
+            adjustVerticalComponent(proposedTranslation: &finalTranslation, viewSize: viewSize, geometry: geometry)
+            
+            return finalTranslation
+        }
+        
+        private func adjustHorizontalComponent(
+            proposedTranslation: inout CGSize,
+            viewSize: CGSize,
+            geometry: GeometryProxy
+        ) {
+            let w_i = viewSize.width
+            let w_v = geometry.size.width
+            
+            if w_i <= w_v {
+                // Image is smaller than the viewport - return to the identity translation.
+                proposedTranslation.width = .zero
+                return
+            }
+            
+            // The translation represents the vector from the identity position to a new central position.
+            // We want to ensure that if the image has been magnified, its leading and trailing edges are outside or
+            // flush with the edges of the container view (based on its input geometry).
+            // We can calculate this by solving for the new central position of the view based on the drag, and shunting
+            // either the horizonal or vertical components of the vector to compensate for any misalignment.
+            
+            let horizontalCenter = geometry.size.width / 2
+            
+            let newHorizontalCenter = horizontalCenter + proposedTranslation.width
+            let left = newHorizontalCenter - (w_i / 2)
+            let right = newHorizontalCenter + (w_i / 2)
+            
+            if left <= 0 && right >= w_v {
+                // Image is zoomed in beyond the viewport - permit the translation.
+                return
+            }
+            
+            if left > 0 {
+                // Image is zoomed in, but shunted outside the leading bounds. Return to the leading edge.
+                proposedTranslation.width -= left
+                return
+            }
+            
+            if right < w_v {
+                // Image is zoomed in, but shunted inside the trailing bounds. Return to the trailing edge.
+                proposedTranslation.width += (w_v - right)
+                return
+            }
+        }
+        
+        private func adjustVerticalComponent(
+            proposedTranslation: inout CGSize,
+            viewSize: CGSize,
+            geometry: GeometryProxy
+        ) {
+            let h_i = viewSize.height
+            let h_v = geometry.size.height
+            
+            if h_i <= h_v {
+                // Image is smaller than the viewport - return to the identity translation.
+                proposedTranslation.height = .zero
+                return
+            }
+            
+            // The translation represents the vector from the identity position to a new central position.
+            // We want to ensure that if the image has been magnified, its leading and trailing edges are outside or
+            // flush with the edges of the container view (based on its input geometry).
+            // We can calculate this by solving for the new central position of the view based on the drag, and shunting
+            // either the horizonal or vertical components of the vector to compensate for any misalignment.
+            
+            let verticalCenter = geometry.size.height / 2
+            
+            let newVerticalCenter = verticalCenter + proposedTranslation.height
+            let top = newVerticalCenter - (h_i / 2)
+            let bottom = newVerticalCenter + (h_i / 2)
+            
+            if top <= 0 && bottom >= h_v {
+                // Image is zoomed in beyond the viewport - permit the translation.
+                return
+            }
+            
+            if top > 0 {
+                // Image is zoomed in, but shunted outside the top bounds. Return to the top edge.
+                proposedTranslation.height -= top
+                return
+            }
+            
+            if bottom < h_v {
+                // Image is zoomed in, but shunted inside the bottom bounds. Return to the bottom edge.
+                proposedTranslation.height += (h_v - bottom)
+                return
+            }
+        }
+        
     }
     
 }

--- a/Packages/EurofurenceKit/Sources/EurofurenceKit/SwiftUI/Views/EurofurenceKitImage.swift
+++ b/Packages/EurofurenceKit/Sources/EurofurenceKit/SwiftUI/Views/EurofurenceKitImage.swift
@@ -5,255 +5,42 @@ public struct EurofurenceKitImage: View {
     
     @ObservedObject private var image: EurofurenceKit.Image
     @State private var isShowingFullScreen = false
+    private let permitsFullscreenInteraction: Bool
     
-    public init(image: EurofurenceKit.Image) {
+    public init(image: EurofurenceKit.Image, permitsFullscreenInteraction: Bool = false) {
         self.image = image
+        self.permitsFullscreenInteraction = permitsFullscreenInteraction
     }
     
     public var body: some View {
-        swiftUIImage
-            .aspectRatio(contentMode: .fit)
-            .cornerRadius(7)
-            .onTapGesture {
-                isShowingFullScreen = true
-            }
-            .fullScreenCover(isPresented: $isShowingFullScreen) {
-                PannableFullScreenImage(image: swiftUIImage, isPresented: $isShowingFullScreen)
-            }
+        if let swiftUIImage = swiftUIImage {
+            swiftUIImage
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .cornerRadius(7)
+                .onTapGesture {
+                    if permitsFullscreenInteraction {
+                        isShowingFullScreen = true
+                    }
+                }
+                .modalImage(id: image.id, isPresented: $isShowingFullScreen, image: swiftUIImage.resizable())
+        }
     }
     
-    @ViewBuilder
-    private var swiftUIImage: some View {
+    private var swiftUIImage: SwiftUI.Image? {
         if let url = image.cachedImageURL {
 #if os(iOS)
             if let uiImage = UIImage(contentsOfFile: url.path) {
-                SwiftUI.Image(uiImage: uiImage)
-                    .resizable()
+                return SwiftUI.Image(uiImage: uiImage)
             }
 #elseif os(macOS)
             if let nsImage = NSImage(contentsOf: url) {
-                SwiftUI.Image(nsImage: nsImage)
-                    .resizable()
+                return SwiftUI.Image(nsImage: nsImage)
             }
 #endif
         }
-    }
-    
-    private struct PannableFullScreenImage<Content>: View where Content: View {
         
-        var image: Content
-        @Binding var isPresented: Bool
-        
-        private let magnificationScaleLimit: CGFloat = 3
-        @State private var currentImageViewSize: CGSize = .zero
-        
-        @State private var magnification = 1.0
-        @State private var inProgressMagnification = 1.0
-        
-        @State private var translationFromIdentity = CGSize.zero
-        @State private var inProgressDrag: DragGesture.Value?
-        
-        var body: some View {
-            GeometryReader { geometry in
-                ZStack {
-                    image
-                        .measure { newValue in
-                            currentImageViewSize = newValue
-                        }
-                        .aspectRatio(contentMode: .fit)
-                        .scaleEffect(currentGestureMagnification)
-                        .offset(currentGestureTranslation)
-                        .onChange(of: magnification) { _ in
-                            withAnimation {
-                                translationFromIdentity = finalDragTranslation(
-                                    proposedTranslation: .zero,
-                                    geometry: geometry
-                                )
-                            }
-                        }
-                        .gesture(TapGesture(count: 2)
-                            .onEnded { _ in
-                                withAnimation {
-                                    if fabsf(Float(magnification)) > 1 {
-                                        magnification = 1
-                                    } else {
-                                        magnification = 2
-                                    }
-                                    
-                                    translationFromIdentity = .zero
-                                }
-                            })
-                        .gesture(MagnificationGesture()
-                            .onChanged { scale in
-                                inProgressMagnification = scale
-                            }
-                            .onEnded { scale in
-                                withAnimation {
-                                    let totalMagnificiation = max(min(magnificationScaleLimit, magnification * scale), 1)
-                                    magnification = totalMagnificiation
-                                    inProgressMagnification = 1
-                                }
-                            })
-                        .simultaneousGesture(DragGesture()
-                            .onChanged { value in
-                                inProgressDrag = value
-                            }
-                            .onEnded { value in
-                                let translation = finalDragTranslation(
-                                    proposedTranslation: value.predictedEndTranslation,
-                                    geometry: geometry
-                                )
-                                
-                                withAnimation(.easeOut) {
-                                    inProgressDrag = nil
-                                    translationFromIdentity = translation
-                                }
-                            })
-                        .edgesIgnoringSafeArea(.all)
-                    
-                    HStack {
-                        Spacer()
-                        
-                        VStack {
-                            Button {
-                                isPresented.toggle()
-                            } label: {
-                                SwiftUI.Image(systemName: "xmark")
-                                    .resizable()
-                                    .aspectRatio(contentMode: .fit)
-                                    .foregroundColor(.secondary)
-                                    .frame(width: 18, height: 18)
-                                    .padding()
-                                    .background(.thinMaterial)
-                                    .clipShape(Circle())
-                            }
-                            
-                            Spacer()
-                        }
-                    }
-                    .padding()
-                }
-            }
-        }
-        
-        private var currentGestureMagnification: CGFloat {
-            magnification * inProgressMagnification
-        }
-        
-        private var currentGestureTranslation: CGSize {
-            guard let inProgressTranslation = inProgressDrag else { return translationFromIdentity }
-            
-            var translation = translationFromIdentity
-            translation.width += inProgressTranslation.translation.width
-            translation.height += inProgressTranslation.translation.height
-            
-            return translation
-        }
-        
-        private func finalDragTranslation(proposedTranslation: CGSize, geometry: GeometryProxy) -> CGSize {
-            var finalTranslation = translationFromIdentity
-            finalTranslation.width += proposedTranslation.width
-            finalTranslation.height += proposedTranslation.height
-            
-            let viewSize = CGSize(
-                width: currentImageViewSize.width * magnification,
-                height: currentImageViewSize.height * magnification
-            )
-            
-            adjustHorizontalComponent(proposedTranslation: &finalTranslation, viewSize: viewSize, geometry: geometry)
-            adjustVerticalComponent(proposedTranslation: &finalTranslation, viewSize: viewSize, geometry: geometry)
-            
-            return finalTranslation
-        }
-        
-        private func adjustHorizontalComponent(
-            proposedTranslation: inout CGSize,
-            viewSize: CGSize,
-            geometry: GeometryProxy
-        ) {
-            let w_i = viewSize.width
-            let w_v = geometry.size.width
-            
-            if w_i <= w_v {
-                // Image is smaller than the viewport - return to the identity translation.
-                proposedTranslation.width = .zero
-                return
-            }
-            
-            // The translation represents the vector from the identity position to a new central position.
-            // We want to ensure that if the image has been magnified, its leading and trailing edges are outside or
-            // flush with the edges of the container view (based on its input geometry).
-            // We can calculate this by solving for the new central position of the view based on the drag, and shunting
-            // either the horizonal or vertical components of the vector to compensate for any misalignment.
-            
-            let horizontalCenter = geometry.size.width / 2
-            
-            let newHorizontalCenter = horizontalCenter + proposedTranslation.width
-            let left = newHorizontalCenter - (w_i / 2)
-            let right = newHorizontalCenter + (w_i / 2)
-            
-            if left <= 0 && right >= w_v {
-                // Image is zoomed in beyond the viewport - permit the translation.
-                return
-            }
-            
-            if left > 0 {
-                // Image is zoomed in, but shunted outside the leading bounds. Return to the leading edge.
-                proposedTranslation.width -= left
-                return
-            }
-            
-            if right < w_v {
-                // Image is zoomed in, but shunted inside the trailing bounds. Return to the trailing edge.
-                proposedTranslation.width += (w_v - right)
-                return
-            }
-        }
-        
-        private func adjustVerticalComponent(
-            proposedTranslation: inout CGSize,
-            viewSize: CGSize,
-            geometry: GeometryProxy
-        ) {
-            let h_i = viewSize.height
-            let h_v = geometry.size.height
-            
-            if h_i <= h_v {
-                // Image is smaller than the viewport - return to the identity translation.
-                proposedTranslation.height = .zero
-                return
-            }
-            
-            // The translation represents the vector from the identity position to a new central position.
-            // We want to ensure that if the image has been magnified, its leading and trailing edges are outside or
-            // flush with the edges of the container view (based on its input geometry).
-            // We can calculate this by solving for the new central position of the view based on the drag, and shunting
-            // either the horizonal or vertical components of the vector to compensate for any misalignment.
-            
-            let verticalCenter = geometry.size.height / 2
-            
-            let newVerticalCenter = verticalCenter + proposedTranslation.height
-            let top = newVerticalCenter - (h_i / 2)
-            let bottom = newVerticalCenter + (h_i / 2)
-            
-            if top <= 0 && bottom >= h_v {
-                // Image is zoomed in beyond the viewport - permit the translation.
-                return
-            }
-            
-            if top > 0 {
-                // Image is zoomed in, but shunted outside the top bounds. Return to the top edge.
-                proposedTranslation.height -= top
-                return
-            }
-            
-            if bottom < h_v {
-                // Image is zoomed in, but shunted inside the bottom bounds. Return to the bottom edge.
-                proposedTranslation.height += (h_v - bottom)
-                return
-            }
-        }
-        
+        return nil
     }
     
 }

--- a/Packages/EurofurenceKit/Sources/EurofurenceKit/SwiftUI/Views/Modal Image/ModalImageContainer.swift
+++ b/Packages/EurofurenceKit/Sources/EurofurenceKit/SwiftUI/Views/Modal Image/ModalImageContainer.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+/// A root view for managing the presentation of images with a modal transition.
+///
+/// This view should occur at or near the root of the app's view hiearchy in order for child views to publish images
+/// that need modal transition via the ``modalImage(id:isPresented:image:)`` view modifier.
+public struct ModalImageContainer<Content>: View where Content: View {
+    
+    private let content: () -> Content
+    @State private var presentedImage: ModallyPresentedImage?
+    
+    public init(@ViewBuilder _ content: @escaping () -> Content) {
+        self.content = content
+    }
+    
+    public var body: some View {
+        ZStack {
+            content()
+                .onChangeOfModallyPresentedImage { newValue in
+                    withAnimation {
+                        presentedImage = newValue
+                    }
+                }
+            
+            pannableImage
+        }
+    }
+    
+    @ViewBuilder private var pannableImage: some View {
+        if let presentedImage = presentedImage {
+            PannableFullScreenImage(image: presentedImage.image, isPresented: presentedImage.isPresented)
+                .background(.ultraThinMaterial)
+                .accessibilityAddTraits(.isModal)
+        }
+    }
+    
+}
+
+

--- a/Packages/EurofurenceKit/Sources/EurofurenceKit/SwiftUI/Views/Modal Image/ModalImagePreferenceKey.swift
+++ b/Packages/EurofurenceKit/Sources/EurofurenceKit/SwiftUI/Views/Modal Image/ModalImagePreferenceKey.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+extension View {
+    
+    /// Requests the presentation, or dismissal, of a modally presented image.
+    ///
+    /// - Parameter image: The modally presented image to present, or `nil` if a previously presented image should be
+    ///                    dismissed.
+    /// - Returns: A modified `View` that will modally present or dismiss an image.
+    func modallyPresentedImage(_ image: ModallyPresentedImage?) -> some View {
+        self
+            .preference(key: ModalImagePreferenceKey.self, value: image)
+    }
+    
+    /// Adds an action to perform when an image is to be modally presented or dismissed.
+    ///
+    /// - Parameter onChange: The action to perform when a request to present or dismiss an image occurs.
+    /// - Returns: A view that triggers the provided closure when an image is to be presented or dismissed.
+    func onChangeOfModallyPresentedImage(_ onChange: @escaping (ModallyPresentedImage?) -> Void) -> some View {
+        self
+            .onPreferenceChange(ModalImagePreferenceKey.self, perform: onChange)
+    }
+    
+}
+
+private struct ModalImagePreferenceKey: PreferenceKey {
+    
+    typealias Value = ModallyPresentedImage?
+    
+    static func reduce(value: inout ModallyPresentedImage?, nextValue: () -> ModallyPresentedImage?) {
+        if let next = nextValue() {
+            value = next
+        }
+    }
+    
+}

--- a/Packages/EurofurenceKit/Sources/EurofurenceKit/SwiftUI/Views/Modal Image/ModallyPresentedImage.swift
+++ b/Packages/EurofurenceKit/Sources/EurofurenceKit/SwiftUI/Views/Modal Image/ModallyPresentedImage.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+struct ModallyPresentedImage: Equatable {
+    
+    static func == (lhs: ModallyPresentedImage, rhs: ModallyPresentedImage) -> Bool {
+        lhs.id == rhs.id
+    }
+    
+    var id: AnyHashable
+    var isPresented: Binding<Bool>
+    var image: SwiftUI.Image
+    
+}

--- a/Packages/EurofurenceKit/Sources/EurofurenceKit/SwiftUI/Views/Modal Image/PannableFullScreenImage.swift
+++ b/Packages/EurofurenceKit/Sources/EurofurenceKit/SwiftUI/Views/Modal Image/PannableFullScreenImage.swift
@@ -1,0 +1,219 @@
+import SwiftUI
+
+struct PannableFullScreenImage<Content>: View where Content: View {
+    
+    var image: Content
+    @Binding var isPresented: Bool
+    
+    private let magnificationScaleLimit: CGFloat = 3
+    @State private var currentImageViewSize: CGSize = .zero
+    
+    @State private var magnification = 1.0
+    @State private var inProgressMagnification = 1.0
+    
+    @State private var translationFromIdentity = CGSize.zero
+    @State private var inProgressDrag: DragGesture.Value?
+    
+    var body: some View {
+        GeometryReader { geometry in
+            ZStack {
+                image
+                    .aspectRatio(contentMode: .fit)
+                    .measure { newValue in
+                        currentImageViewSize = newValue
+                    }
+                    .scaleEffect(currentGestureMagnification)
+                    .offset(currentGestureTranslation)
+                    .onChange(of: magnification) { _ in
+                        withAnimation {
+                            translationFromIdentity = finalDragTranslation(
+                                proposedTranslation: .zero,
+                                geometry: geometry
+                            )
+                        }
+                    }
+                    .gesture(TapGesture(count: 2)
+                        .onEnded { _ in
+                            withAnimation {
+                                if fabsf(Float(magnification)) > 1 {
+                                    magnification = 1
+                                } else {
+                                    magnification = 2
+                                }
+                                
+                                translationFromIdentity = .zero
+                            }
+                        })
+                    .gesture(MagnificationGesture()
+                        .onChanged { scale in
+                            inProgressMagnification = scale
+                        }
+                        .onEnded { scale in
+                            withAnimation {
+                                let totalMagnificiation = max(min(magnificationScaleLimit, magnification * scale), 1)
+                                magnification = totalMagnificiation
+                                inProgressMagnification = 1
+                            }
+                        })
+                    .simultaneousGesture(DragGesture()
+                        .onChanged { value in
+                            inProgressDrag = value
+                        }
+                        .onEnded { value in
+                            let translation = finalDragTranslation(
+                                proposedTranslation: value.predictedEndTranslation,
+                                geometry: geometry
+                            )
+                            
+                            withAnimation(.easeOut) {
+                                inProgressDrag = nil
+                                translationFromIdentity = translation
+                            }
+                        })
+                    .edgesIgnoringSafeArea(.all)
+                
+                HStack {
+                    Spacer()
+                    
+                    VStack {
+                        Button {
+                            isPresented.toggle()
+                        } label: {
+                            SwiftUI.Image(systemName: "xmark")
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                                .foregroundColor(.secondary)
+                                .frame(width: 18, height: 18)
+                                .padding()
+                                .background(.thinMaterial)
+                                .clipShape(Circle())
+                        }
+                        
+                        Spacer()
+                    }
+                }
+                .padding()
+            }
+        }
+        .transition(.opacity)
+    }
+    
+    private var currentGestureMagnification: CGFloat {
+        magnification * inProgressMagnification
+    }
+    
+    private var currentGestureTranslation: CGSize {
+        guard let inProgressTranslation = inProgressDrag else { return translationFromIdentity }
+        
+        var translation = translationFromIdentity
+        translation.width += inProgressTranslation.translation.width
+        translation.height += inProgressTranslation.translation.height
+        
+        return translation
+    }
+    
+    private func finalDragTranslation(proposedTranslation: CGSize, geometry: GeometryProxy) -> CGSize {
+        var finalTranslation = translationFromIdentity
+        finalTranslation.width += proposedTranslation.width
+        finalTranslation.height += proposedTranslation.height
+        
+        let viewSize = CGSize(
+            width: currentImageViewSize.width * magnification,
+            height: currentImageViewSize.height * magnification
+        )
+        
+        adjustHorizontalComponent(proposedTranslation: &finalTranslation, viewSize: viewSize, geometry: geometry)
+        adjustVerticalComponent(proposedTranslation: &finalTranslation, viewSize: viewSize, geometry: geometry)
+        
+        return finalTranslation
+    }
+    
+    private func adjustHorizontalComponent(
+        proposedTranslation: inout CGSize,
+        viewSize: CGSize,
+        geometry: GeometryProxy
+    ) {
+        let w_i = viewSize.width
+        let w_v = geometry.size.width
+        
+        if w_i <= w_v {
+            // Image is smaller than the viewport - return to the identity translation.
+            proposedTranslation.width = .zero
+            return
+        }
+        
+        // The translation represents the vector from the identity position to a new central position.
+        // We want to ensure that if the image has been magnified, its leading and trailing edges are outside or
+        // flush with the edges of the container view (based on its input geometry).
+        // We can calculate this by solving for the new central position of the view based on the drag, and shunting
+        // either the horizonal or vertical components of the vector to compensate for any misalignment.
+        
+        let horizontalCenter = geometry.size.width / 2
+        
+        let newHorizontalCenter = horizontalCenter + proposedTranslation.width
+        let left = newHorizontalCenter - (w_i / 2)
+        let right = newHorizontalCenter + (w_i / 2)
+        
+        if left <= 0 && right >= w_v {
+            // Image is zoomed in beyond the viewport - permit the translation.
+            return
+        }
+        
+        if left > 0 {
+            // Image is zoomed in, but shunted outside the leading bounds. Return to the leading edge.
+            proposedTranslation.width -= left
+            return
+        }
+        
+        if right < w_v {
+            // Image is zoomed in, but shunted inside the trailing bounds. Return to the trailing edge.
+            proposedTranslation.width += (w_v - right)
+            return
+        }
+    }
+    
+    private func adjustVerticalComponent(
+        proposedTranslation: inout CGSize,
+        viewSize: CGSize,
+        geometry: GeometryProxy
+    ) {
+        let h_i = viewSize.height
+        let h_v = geometry.size.height
+        
+        if h_i <= h_v {
+            // Image is smaller than the viewport - return to the identity translation.
+            proposedTranslation.height = .zero
+            return
+        }
+        
+        // The translation represents the vector from the identity position to a new central position.
+        // We want to ensure that if the image has been magnified, its leading and trailing edges are outside or
+        // flush with the edges of the container view (based on its input geometry).
+        // We can calculate this by solving for the new central position of the view based on the drag, and shunting
+        // either the horizonal or vertical components of the vector to compensate for any misalignment.
+        
+        let verticalCenter = geometry.size.height / 2
+        
+        let newVerticalCenter = verticalCenter + proposedTranslation.height
+        let top = newVerticalCenter - (h_i / 2)
+        let bottom = newVerticalCenter + (h_i / 2)
+        
+        if top <= 0 && bottom >= h_v {
+            // Image is zoomed in beyond the viewport - permit the translation.
+            return
+        }
+        
+        if top > 0 {
+            // Image is zoomed in, but shunted outside the top bounds. Return to the top edge.
+            proposedTranslation.height -= top
+            return
+        }
+        
+        if bottom < h_v {
+            // Image is zoomed in, but shunted inside the bottom bounds. Return to the bottom edge.
+            proposedTranslation.height += (h_v - bottom)
+            return
+        }
+    }
+    
+}

--- a/Packages/EurofurenceKit/Sources/EurofurenceKit/SwiftUI/Views/Modal Image/View+ModalImage.swift
+++ b/Packages/EurofurenceKit/Sources/EurofurenceKit/SwiftUI/Views/Modal Image/View+ModalImage.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+extension View {
+    
+    /// A modifier that enables the receiver `View` to present an image in a modal context.
+    ///
+    /// The image parameter will be presented on top of all other views within the current environment, with an
+    /// appropriate backdrop to occlude the UI, allowing the user to pan and zoom the image to review details.
+    ///
+    /// - Parameters:
+    ///   - id: A unique identity to associate with the presented image, for presentation-tracking purposes.
+    ///   - isPresented: A binding to infer whether the image is currently being presented modally.
+    ///   - image: The SwiftUI `Image` to present modally, atop the current scene.
+    /// - Returns: A modified `View` that presents the provided image modally when `isPresented` is `true`.
+    public func modalImage<ID>(
+        id: ID,
+        isPresented: Binding<Bool>,
+        image: SwiftUI.Image
+    ) -> some View where ID: Hashable {
+        ModifiedContent(
+            content: self,
+            modifier: ModalImageViewModifier(
+                isPresented: isPresented,
+                configuration: ModallyPresentedImage(id: id, isPresented: isPresented, image: image)
+            )
+        )
+    }
+    
+}
+
+private struct ModalImageViewModifier: ViewModifier {
+    
+    @Binding var isPresented: Bool
+    let configuration: ModallyPresentedImage
+    
+    func body(content: Content) -> some View {
+        content
+            .modallyPresentedImage(isPresented ? configuration : nil)
+    }
+    
+}

--- a/Packages/EurofurenceKit/Sources/EurofurenceKit/SwiftUI/Views/Modal Image/View+ModalImage.swift
+++ b/Packages/EurofurenceKit/Sources/EurofurenceKit/SwiftUI/Views/Modal Image/View+ModalImage.swift
@@ -32,10 +32,29 @@ private struct ModalImageViewModifier: ViewModifier {
     
     @Binding var isPresented: Bool
     let configuration: ModallyPresentedImage
+    @Environment(\.modalImageNamespace) private var modalImageNamespace
+    @State private var contentSize: CGSize = .zero
     
     func body(content: Content) -> some View {
-        content
-            .modallyPresentedImage(isPresented ? configuration : nil)
+        ZStack {
+            if isPresented {
+                content
+                    .matchedGeometryEffect(
+                        id: configuration.id,
+                        in: modalImageNamespace!,
+                        isSource: false
+                    )
+                    .transition(.offset())
+            } else {
+                content
+                    .matchedGeometryEffect(
+                        id: configuration.id,
+                        in: modalImageNamespace!
+                    )
+                    .transition(.offset())
+            }
+        }
+        .modallyPresentedImage(isPresented ? configuration : nil)
     }
     
 }

--- a/Packages/EurofurenceKit/Sources/EurofurenceKit/SwiftUI/Views/Modal Image/View+ModalImage.swift
+++ b/Packages/EurofurenceKit/Sources/EurofurenceKit/SwiftUI/Views/Modal Image/View+ModalImage.swift
@@ -36,25 +36,29 @@ private struct ModalImageViewModifier: ViewModifier {
     @State private var contentSize: CGSize = .zero
     
     func body(content: Content) -> some View {
-        ZStack {
-            if isPresented {
-                content
-                    .matchedGeometryEffect(
-                        id: configuration.id,
-                        in: modalImageNamespace!,
-                        isSource: false
-                    )
-                    .transition(.offset())
-            } else {
-                content
-                    .matchedGeometryEffect(
-                        id: configuration.id,
-                        in: modalImageNamespace!
-                    )
-                    .transition(.offset())
+        if let modalImageNamespace = modalImageNamespace {
+            ZStack {
+                if isPresented {
+                    content
+                        .matchedGeometryEffect(
+                            id: configuration.id,
+                            in: modalImageNamespace,
+                            isSource: false
+                        )
+                        .transition(.offset())
+                } else {
+                    content
+                        .matchedGeometryEffect(
+                            id: configuration.id,
+                            in: modalImageNamespace
+                        )
+                        .transition(.offset())
+                }
             }
+            .modallyPresentedImage(isPresented ? configuration : nil)
+        } else {
+            content
         }
-        .modallyPresentedImage(isPresented ? configuration : nil)
     }
     
 }

--- a/Packages/EurofurenceKit/Sources/EurofurenceKit/SwiftUI/Views/Tag/CanonicalTagIcon.swift
+++ b/Packages/EurofurenceKit/Sources/EurofurenceKit/SwiftUI/Views/Tag/CanonicalTagIcon.swift
@@ -17,13 +17,13 @@ public struct CanonicalTagIcon: View {
     
     private static let tagToSFSymbolNames: [CanonicalTag: String] = [
         .sponsorOnly: "star.circle",
-            .superSponsorOnly: "star.circle.fill",
-            .artShow: "photo.artframe",
-            .kage: "ant.fill",
-            .dealersDen: "cart.fill",
-            .mainStage: "asterisk.circle.fill",
-            .photoshoot: "camera.fill",
-            .faceMaskRequired: "facemask.fill"
+        .superSponsorOnly: "star.circle.fill",
+        .artShow: "photo.artframe",
+        .kage: "ant.fill",
+        .dealersDen: "cart.fill",
+        .mainStage: "asterisk.circle.fill",
+        .photoshoot: "camera.fill",
+        .faceMaskRequired: "facemask.fill"
     ]
     
 }

--- a/Packages/EurofurenceKit/Sources/EurofurenceKit/SwiftUI/Views/Tag/CanonicalTagLabel.swift
+++ b/Packages/EurofurenceKit/Sources/EurofurenceKit/SwiftUI/Views/Tag/CanonicalTagLabel.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+/// A descriptive label for well-known tags.
+public struct CanonicalTagLabel: View {
+    
+    private let tag: CanonicalTag
+    
+    public init(_ tag: CanonicalTag) {
+        self.tag = tag
+    }
+    
+    public var body: some View {
+        Label {
+            CanonicalTagText(tag)
+        } icon: {
+            CanonicalTagIcon(tag)
+        }
+    }
+    
+}
+
+struct CanonicalTagLabel_Previews: PreviewProvider {
+    
+    static var previews: some View {
+        ForEach(CanonicalTag.allCases) { tag in
+            CanonicalTagLabel(tag)
+                .previewLayout(.sizeThatFits)
+                .previewDisplayName(tag.description)
+        }
+    }
+    
+}

--- a/Packages/EurofurenceKit/Sources/EurofurenceKit/SwiftUI/Views/Tag/CanonicalTagText.swift
+++ b/Packages/EurofurenceKit/Sources/EurofurenceKit/SwiftUI/Views/Tag/CanonicalTagText.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+/// A descriptive summary for well-known tags.
+public struct CanonicalTagText: View {
+    
+    private let tag: CanonicalTag
+    
+    public init(_ tag: CanonicalTag) {
+        self.tag = tag
+    }
+    
+    public var body: some View {
+        Text(verbatim: tag.localizedDescription)
+    }
+    
+}
+
+struct CanonicalTagText_Previews: PreviewProvider {
+    
+    static var previews: some View {
+        ForEach(CanonicalTag.allCases) { tag in
+            CanonicalTagText(tag)
+                .previewLayout(.sizeThatFits)
+                .previewDisplayName(tag.description)
+        }
+    }
+    
+}

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Model Ingestion/WellKnownTagTests.swift
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Model Ingestion/WellKnownTagTests.swift
@@ -68,6 +68,16 @@ class WellKnownTagTests: EurofurenceKitTestCase {
         XCTAssertTrue(eventWithTag.canonicalTags.contains(.faceMaskRequired))
     }
     
+    func testTagsReturnedInAlphabeticalOrder() async throws {
+        let scenario = await EurofurenceModelTestBuilder().build()
+        try await scenario.updateLocalStore(using: .ef26)
+        let dealersDenID = "18ab1606-506e-4b7c-b1db-4d3dad0e7c20"
+        let dealersDen = try scenario.model.event(identifiedBy: dealersDenID)
+        
+        let expected: [CanonicalTag] = [.sponsorOnly, .superSponsorOnly, .faceMaskRequired]
+        XCTAssertEqual(expected, dealersDen.canonicalTags, "Expected tags to be ordered alphabetically")
+    }
+    
     private func eventWithTag(named name: String, in managedObjectContext: NSManagedObjectContext) throws -> Event {
         let fetchRequest: NSFetchRequest<Event> = Event.fetchRequest()
         fetchRequest.predicate = NSPredicate(format: "SELF.tags.name CONTAINS %@", name)


### PR DESCRIPTION
Includes most pertinent information mostly following the existing layout, with a few new quick win visual bumps - including panning of posters.