### PR TITLE
Port favourite events to SwiftUI

### DIFF
--- a/Eurofurence.xcodeproj/project.pbxproj
+++ b/Eurofurence.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		6EB17FEF28D35B30008DB4F1 /* EventView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EB17FEE28D35B30008DB4F1 /* EventView.swift */; };
 		6EB17FF128D37915008DB4F1 /* EventSubtitle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EB17FF028D37915008DB4F1 /* EventSubtitle.swift */; };
 		6EE14CBA28D533E600A3A117 /* AlignedLabelContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EE14CB928D533E600A3A117 /* AlignedLabelContainer.swift */; };
+		6EE14CBC28D5C3D100A3A117 /* ToggleEventFavouriteStateButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EE14CBB28D5C3D100A3A117 /* ToggleEventFavouriteStateButton.swift */; };
 		6EE355A9289079B300F3ACB7 /* LoginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EE355A8289079B300F3ACB7 /* LoginTests.swift */; };
 		6EF82FC128CA3A47006463EA /* AutoPatchSplitViewControllerWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EF82FC028CA3A47006463EA /* AutoPatchSplitViewControllerWindow.swift */; };
 		6EF82FC328CA3B86006463EA /* DealersCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EF82FC228CA3B86006463EA /* DealersCollectionView.swift */; };
@@ -338,6 +339,7 @@
 		6EB17FEE28D35B30008DB4F1 /* EventView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventView.swift; sourceTree = "<group>"; };
 		6EB17FF028D37915008DB4F1 /* EventSubtitle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventSubtitle.swift; sourceTree = "<group>"; };
 		6EE14CB928D533E600A3A117 /* AlignedLabelContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlignedLabelContainer.swift; sourceTree = "<group>"; };
+		6EE14CBB28D5C3D100A3A117 /* ToggleEventFavouriteStateButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToggleEventFavouriteStateButton.swift; sourceTree = "<group>"; };
 		6EE355A8289079B300F3ACB7 /* LoginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginTests.swift; sourceTree = "<group>"; };
 		6EE355AA28907BE600F3ACB7 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		6EF82FC028CA3A47006463EA /* AutoPatchSplitViewControllerWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoPatchSplitViewControllerWindow.swift; sourceTree = "<group>"; };
@@ -744,6 +746,7 @@
 			children = (
 				6EB17FEE28D35B30008DB4F1 /* EventView.swift */,
 				6EB17FF028D37915008DB4F1 /* EventSubtitle.swift */,
+				6EE14CBB28D5C3D100A3A117 /* ToggleEventFavouriteStateButton.swift */,
 			);
 			path = Event;
 			sourceTree = "<group>";
@@ -1685,6 +1688,7 @@
 				6EB17FF128D37915008DB4F1 /* EventSubtitle.swift in Sources */,
 				CABD9BA528BE08DF00CEFAB3 /* TabExperience.swift in Sources */,
 				6E08B1B128CE06BC00512406 /* AdditionalServicesLabel.swift in Sources */,
+				6EE14CBC28D5C3D100A3A117 /* ToggleEventFavouriteStateButton.swift in Sources */,
 				6EA4ECD428C8DC6000B20502 /* MoreView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Eurofurence.xcodeproj/project.pbxproj
+++ b/Eurofurence.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		6EB17FF128D37915008DB4F1 /* EventSubtitle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EB17FF028D37915008DB4F1 /* EventSubtitle.swift */; };
 		6EE14CBA28D533E600A3A117 /* AlignedLabelContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EE14CB928D533E600A3A117 /* AlignedLabelContainer.swift */; };
 		6EE14CBC28D5C3D100A3A117 /* ToggleEventFavouriteStateButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EE14CBB28D5C3D100A3A117 /* ToggleEventFavouriteStateButton.swift */; };
+		6EE14CBE28D5C5B200A3A117 /* FavouriteEventsNavigationLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EE14CBD28D5C5B200A3A117 /* FavouriteEventsNavigationLink.swift */; };
 		6EE355A9289079B300F3ACB7 /* LoginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EE355A8289079B300F3ACB7 /* LoginTests.swift */; };
 		6EF82FC128CA3A47006463EA /* AutoPatchSplitViewControllerWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EF82FC028CA3A47006463EA /* AutoPatchSplitViewControllerWindow.swift */; };
 		6EF82FC328CA3B86006463EA /* DealersCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EF82FC228CA3B86006463EA /* DealersCollectionView.swift */; };
@@ -340,6 +341,7 @@
 		6EB17FF028D37915008DB4F1 /* EventSubtitle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventSubtitle.swift; sourceTree = "<group>"; };
 		6EE14CB928D533E600A3A117 /* AlignedLabelContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlignedLabelContainer.swift; sourceTree = "<group>"; };
 		6EE14CBB28D5C3D100A3A117 /* ToggleEventFavouriteStateButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToggleEventFavouriteStateButton.swift; sourceTree = "<group>"; };
+		6EE14CBD28D5C5B200A3A117 /* FavouriteEventsNavigationLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavouriteEventsNavigationLink.swift; sourceTree = "<group>"; };
 		6EE355A8289079B300F3ACB7 /* LoginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginTests.swift; sourceTree = "<group>"; };
 		6EE355AA28907BE600F3ACB7 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		6EF82FC028CA3A47006463EA /* AutoPatchSplitViewControllerWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoPatchSplitViewControllerWindow.swift; sourceTree = "<group>"; };
@@ -645,6 +647,7 @@
 			isa = PBXGroup;
 			children = (
 				6E79E66828C9CD0D00444A37 /* ScheduleView.swift */,
+				6EE14CBD28D5C5B200A3A117 /* FavouriteEventsNavigationLink.swift */,
 				6E08B1C228CE6E8400512406 /* ScheduleCollectionView.swift */,
 				6E20270228D26CDD008C61BD /* ScheduleEventsList.swift */,
 				6E2026FC28D1C0C1008C61BD /* EventListRow.swift */,
@@ -1689,6 +1692,7 @@
 				CABD9BA528BE08DF00CEFAB3 /* TabExperience.swift in Sources */,
 				6E08B1B128CE06BC00512406 /* AdditionalServicesLabel.swift in Sources */,
 				6EE14CBC28D5C3D100A3A117 /* ToggleEventFavouriteStateButton.swift in Sources */,
+				6EE14CBE28D5C5B200A3A117 /* FavouriteEventsNavigationLink.swift in Sources */,
 				6EA4ECD428C8DC6000B20502 /* MoreView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Eurofurence.xcodeproj/project.pbxproj
+++ b/Eurofurence.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		6EE14CBA28D533E600A3A117 /* AlignedLabelContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EE14CB928D533E600A3A117 /* AlignedLabelContainer.swift */; };
 		6EE14CBC28D5C3D100A3A117 /* ToggleEventFavouriteStateButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EE14CBB28D5C3D100A3A117 /* ToggleEventFavouriteStateButton.swift */; };
 		6EE14CBE28D5C5B200A3A117 /* FavouriteEventsNavigationLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EE14CBD28D5C5B200A3A117 /* FavouriteEventsNavigationLink.swift */; };
+		6EE14CC028D5C87400A3A117 /* View+ShowScheduleFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EE14CBF28D5C87400A3A117 /* View+ShowScheduleFilter.swift */; };
 		6EE355A9289079B300F3ACB7 /* LoginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EE355A8289079B300F3ACB7 /* LoginTests.swift */; };
 		6EF82FC128CA3A47006463EA /* AutoPatchSplitViewControllerWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EF82FC028CA3A47006463EA /* AutoPatchSplitViewControllerWindow.swift */; };
 		6EF82FC328CA3B86006463EA /* DealersCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EF82FC228CA3B86006463EA /* DealersCollectionView.swift */; };
@@ -342,6 +343,7 @@
 		6EE14CB928D533E600A3A117 /* AlignedLabelContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlignedLabelContainer.swift; sourceTree = "<group>"; };
 		6EE14CBB28D5C3D100A3A117 /* ToggleEventFavouriteStateButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToggleEventFavouriteStateButton.swift; sourceTree = "<group>"; };
 		6EE14CBD28D5C5B200A3A117 /* FavouriteEventsNavigationLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavouriteEventsNavigationLink.swift; sourceTree = "<group>"; };
+		6EE14CBF28D5C87400A3A117 /* View+ShowScheduleFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+ShowScheduleFilter.swift"; sourceTree = "<group>"; };
 		6EE355A8289079B300F3ACB7 /* LoginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginTests.swift; sourceTree = "<group>"; };
 		6EE355AA28907BE600F3ACB7 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		6EF82FC028CA3A47006463EA /* AutoPatchSplitViewControllerWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoPatchSplitViewControllerWindow.swift; sourceTree = "<group>"; };
@@ -646,13 +648,14 @@
 		6EA4ECC928C8DC0B00B20502 /* Schedule */ = {
 			isa = PBXGroup;
 			children = (
-				6E79E66828C9CD0D00444A37 /* ScheduleView.swift */,
+				6E79E66A28C9CDCE00444A37 /* EventConferenceDaysView.swift */,
+				6E79E66C28C9CDEC00444A37 /* EventConferenceTracksView.swift */,
+				6E2026FC28D1C0C1008C61BD /* EventListRow.swift */,
 				6EE14CBD28D5C5B200A3A117 /* FavouriteEventsNavigationLink.swift */,
 				6E08B1C228CE6E8400512406 /* ScheduleCollectionView.swift */,
 				6E20270228D26CDD008C61BD /* ScheduleEventsList.swift */,
-				6E2026FC28D1C0C1008C61BD /* EventListRow.swift */,
-				6E79E66A28C9CDCE00444A37 /* EventConferenceDaysView.swift */,
-				6E79E66C28C9CDEC00444A37 /* EventConferenceTracksView.swift */,
+				6E79E66828C9CD0D00444A37 /* ScheduleView.swift */,
+				6EE14CBF28D5C87400A3A117 /* View+ShowScheduleFilter.swift */,
 			);
 			path = Schedule;
 			sourceTree = "<group>";
@@ -1637,6 +1640,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6EE14CC028D5C87400A3A117 /* View+ShowScheduleFilter.swift in Sources */,
 				CA85154625FF744900860631 /* DebugTableViewController.swift in Sources */,
 				6EA4ECC828C8DBF100B20502 /* NewsView.swift in Sources */,
 				CA630BEE229F16F400754C27 /* DonateFromAppEventIntentDonor.swift in Sources */,

--- a/Eurofurence/SwiftUI/Design Language/Labels/FavouriteEventsLabel.swift
+++ b/Eurofurence/SwiftUI/Design Language/Labels/FavouriteEventsLabel.swift
@@ -1,3 +1,4 @@
+import EurofurenceKit
 import SwiftUI
 
 struct FavouriteEventsLabel: View {
@@ -12,16 +13,7 @@ struct FavouriteEventsLabel: View {
         Label {
             Text("Schedule")
         } icon: {
-            icon
-                .foregroundColor(.red)
-        }
-    }
-    
-    @ViewBuilder private var icon: some View {
-        if isSelected {
-            Image(systemName: "heart.fill")
-        } else {
-            Image(systemName: "heart")
+            FavouriteIcon(filled: true)
         }
     }
     

--- a/Eurofurence/SwiftUI/Experiences/Split View/Sidebar/Sections/ScheduleSidebarItems.swift
+++ b/Eurofurence/SwiftUI/Experiences/Split View/Sidebar/Sections/ScheduleSidebarItems.swift
@@ -19,11 +19,7 @@ struct ScheduleSidebarItems: View {
                 AllEventsLabel()
             }
             
-            NavigationLink {
-                Text("Favourite Events")
-            } label: {
-                FavouriteEventsLabel()
-            }
+            FavouriteEventsNavigationLink()
             
             Divider()
             

--- a/Eurofurence/SwiftUI/Modules/Event/EventView.swift
+++ b/Eurofurence/SwiftUI/Modules/Event/EventView.swift
@@ -40,8 +40,7 @@ struct EventView: View {
                     Label {
                         Text(event.isFavourite ? "Unfavourite" : "Favourite")
                     } icon: {
-                        Image(systemName: event.isFavourite ? "heart.fill" : "heart")
-                            .foregroundColor(.red)
+                        FavouriteIcon(filled: event.isFavourite)
                     }
                 }
             }

--- a/Eurofurence/SwiftUI/Modules/Event/EventView.swift
+++ b/Eurofurence/SwiftUI/Modules/Event/EventView.swift
@@ -28,20 +28,8 @@ struct EventView: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem {
-                Button {
-                    Task { @MainActor in
-                        if event.isFavourite {
-                            await event.unfavourite()
-                        } else {
-                            await event.favourite()
-                        }
-                    }
-                } label: {
-                    Label {
-                        Text(event.isFavourite ? "Unfavourite" : "Favourite")
-                    } icon: {
-                        FavouriteIcon(filled: event.isFavourite)
-                    }
+                ToggleEventFavouriteStateButton(event: event) {
+                    FavouriteIcon(filled: event.isFavourite)
                 }
             }
             

--- a/Eurofurence/SwiftUI/Modules/Event/EventView.swift
+++ b/Eurofurence/SwiftUI/Modules/Event/EventView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 struct EventView: View {
     
-    var event: Event
+    @ObservedObject var event: Event
     @State private var isAboutExpanded = true
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @ScaledMetric(relativeTo: .body) private var intersectionSpacing: CGFloat = 7
@@ -29,12 +29,19 @@ struct EventView: View {
         .toolbar {
             ToolbarItem {
                 Button {
-                    // TODO: Favourite/unfavourite!
+                    Task { @MainActor in
+                        if event.isFavourite {
+                            await event.unfavourite()
+                        } else {
+                            await event.favourite()
+                        }
+                    }
                 } label: {
                     Label {
-                        Text("Favourite")
+                        Text(event.isFavourite ? "Unfavourite" : "Favourite")
                     } icon: {
-                        Image(systemName: "heart")
+                        Image(systemName: event.isFavourite ? "heart.fill" : "heart")
+                            .foregroundColor(.red)
                     }
                 }
             }

--- a/Eurofurence/SwiftUI/Modules/Event/ToggleEventFavouriteStateButton.swift
+++ b/Eurofurence/SwiftUI/Modules/Event/ToggleEventFavouriteStateButton.swift
@@ -1,0 +1,32 @@
+import EurofurenceKit
+import SwiftUI
+
+struct ToggleEventFavouriteStateButton<Icon>: View where Icon: View {
+    
+    @ObservedObject private var event: Event
+    private let icon: () -> Icon
+    
+    init(event: Event, @ViewBuilder _ icon: @escaping () -> Icon) {
+        self.event = event
+        self.icon = icon
+    }
+    
+    var body: some View {
+        Button {
+            Task {
+                if event.isFavourite {
+                    await event.unfavourite()
+                } else {
+                    await event.favourite()
+                }
+            }
+        } label: {
+            Label {
+                Text(event.isFavourite ? "Unfavourite" : "Favourite")
+            } icon: {
+                icon()
+            }
+        }
+    }
+    
+}

--- a/Eurofurence/SwiftUI/Modules/Schedule/EventListRow.swift
+++ b/Eurofurence/SwiftUI/Modules/Schedule/EventListRow.swift
@@ -117,8 +117,7 @@ struct EventListRow: View {
         
         @ViewBuilder private var eventTags: some View {
             if event.isFavourite {
-                Image(systemName: "heart.fill")
-                    .foregroundColor(.red)
+                FavouriteIcon(filled: true)
             }
             
             ForEach(event.canonicalTags) { tag in

--- a/Eurofurence/SwiftUI/Modules/Schedule/EventListRow.swift
+++ b/Eurofurence/SwiftUI/Modules/Schedule/EventListRow.swift
@@ -41,7 +41,7 @@ struct EventListRow: View {
     
     private struct Heading: View {
         
-        var event: Event
+        @ObservedObject var event: Event
         var configuration: Configuration
         @Environment(\.dynamicTypeSize) private var dynamicTypeSize: DynamicTypeSize
         
@@ -71,6 +71,7 @@ struct EventListRow: View {
                 if dynamicTypeSize >= .xLarge {
                     HStack {
                         startTime
+                            .padding(.bottom, 3)
                         
                         if dynamicTypeSize >= .xxxLarge && dynamicTypeSize < .accessibility3 {
                             Spacer()
@@ -115,6 +116,11 @@ struct EventListRow: View {
         }
         
         @ViewBuilder private var eventTags: some View {
+            if event.isFavourite {
+                Image(systemName: "heart.fill")
+                    .foregroundColor(.red)
+            }
+            
             ForEach(event.canonicalTags) { tag in
                 CanonicalTagIcon(tag)
             }

--- a/Eurofurence/SwiftUI/Modules/Schedule/EventListRow.swift
+++ b/Eurofurence/SwiftUI/Modules/Schedule/EventListRow.swift
@@ -21,6 +21,12 @@ struct EventListRow: View {
             }
         }
         .frame(minHeight: rowHeight)
+        .swipeActions {
+            ToggleEventFavouriteStateButton(event: event) {
+                Image(systemName: event.isFavourite ? "heart.slash" : "heart.fill")
+            }
+            .tint(.blue)
+        }
     }
     
     private struct EventSummary: View {

--- a/Eurofurence/SwiftUI/Modules/Schedule/FavouriteEventsNavigationLink.swift
+++ b/Eurofurence/SwiftUI/Modules/Schedule/FavouriteEventsNavigationLink.swift
@@ -9,6 +9,7 @@ struct FavouriteEventsNavigationLink: View {
         NavigationLink {
             let favouritesOnly = EurofurenceModel.ScheduleConfiguration(favouritesOnly: true)
             ScheduleCollectionView(schedule: model.makeSchedule(configuration: favouritesOnly))
+                .showScheduleFilter(false)
                 .navigationTitle("Favourited Events")
         } label: {
             Label {

--- a/Eurofurence/SwiftUI/Modules/Schedule/FavouriteEventsNavigationLink.swift
+++ b/Eurofurence/SwiftUI/Modules/Schedule/FavouriteEventsNavigationLink.swift
@@ -1,0 +1,22 @@
+import EurofurenceKit
+import SwiftUI
+
+struct FavouriteEventsNavigationLink: View {
+    
+    @EnvironmentObject private var model: EurofurenceModel
+    
+    var body: some View {
+        NavigationLink {
+            let favouritesOnly = EurofurenceModel.ScheduleConfiguration(favouritesOnly: true)
+            ScheduleCollectionView(schedule: model.makeSchedule(configuration: favouritesOnly))
+                .navigationTitle("Favourited Events")
+        } label: {
+            Label {
+                Text("Favourite Events")
+            } icon: {
+                FavouriteIcon(filled: true)
+            }
+        }
+    }
+    
+}

--- a/Eurofurence/SwiftUI/Modules/Schedule/ScheduleCollectionView.swift
+++ b/Eurofurence/SwiftUI/Modules/Schedule/ScheduleCollectionView.swift
@@ -76,7 +76,16 @@ private struct ScheduleFilterView: View {
     @Environment(\.dismiss) private var dismiss
     
     var body: some View {
-        List {
+        Form {
+            Toggle(isOn: $schedule.favouritesOnly.animation()) {
+                Label {
+                    Text("Favourites Only")
+                } icon: {
+                    Image(systemName: "heart.fill")
+                        .foregroundColor(.red)
+                }
+            }
+            
             if schedule.availableDays.isEmpty == false {
                 Section {
                     ScheduleDayPicker(schedule: schedule)

--- a/Eurofurence/SwiftUI/Modules/Schedule/ScheduleCollectionView.swift
+++ b/Eurofurence/SwiftUI/Modules/Schedule/ScheduleCollectionView.swift
@@ -81,8 +81,7 @@ private struct ScheduleFilterView: View {
                 Label {
                     Text("Favourites Only")
                 } icon: {
-                    Image(systemName: "heart.fill")
-                        .foregroundColor(.red)
+                    FavouriteIcon(filled: true)
                 }
             }
             

--- a/Eurofurence/SwiftUI/Modules/Schedule/ScheduleCollectionView.swift
+++ b/Eurofurence/SwiftUI/Modules/Schedule/ScheduleCollectionView.swift
@@ -5,6 +5,7 @@ struct ScheduleCollectionView: View {
     
     @EnvironmentObject var model: EurofurenceModel
     @ObservedObject var schedule: Schedule
+    @Environment(\.showScheduleFilterButton) private var showScheduleFilter
     @State private var isPresentingFilter = false
     @State private var selectedEvent: Event?
     
@@ -17,7 +18,9 @@ struct ScheduleCollectionView: View {
                 }
                 
                 ToolbarItem(placement: .bottomBar) {
-                    ScheduleFilterButton(isPresentingFilter: $isPresentingFilter, schedule: schedule)
+                    if showScheduleFilter {
+                        ScheduleFilterButton(isPresentingFilter: $isPresentingFilter, schedule: schedule)
+                    }
                 }
             }
     }

--- a/Eurofurence/SwiftUI/Modules/Schedule/ScheduleView.swift
+++ b/Eurofurence/SwiftUI/Modules/Schedule/ScheduleView.swift
@@ -31,8 +31,7 @@ struct ScheduleView: View {
                     Label {
                         Text("Favourite Events")
                     } icon: {
-                        Image(systemName: "heart")
-                            .foregroundColor(.red)
+                        FavouriteIcon(filled: true)
                     }
                 }
                 

--- a/Eurofurence/SwiftUI/Modules/Schedule/ScheduleView.swift
+++ b/Eurofurence/SwiftUI/Modules/Schedule/ScheduleView.swift
@@ -25,15 +25,7 @@ struct ScheduleView: View {
     @ViewBuilder private var scheduleRoot: some View {
         List {
             if schedule.query.isEmpty {
-                NavigationLink {
-                    Text("Favourite Events")
-                } label: {
-                    Label {
-                        Text("Favourite Events")
-                    } icon: {
-                        FavouriteIcon(filled: true)
-                    }
-                }
+                FavouriteEventsNavigationLink()
                 
                 Section {
                     EventConferenceDaysView(selectedDay: $selectedDay)

--- a/Eurofurence/SwiftUI/Modules/Schedule/View+ShowScheduleFilter.swift
+++ b/Eurofurence/SwiftUI/Modules/Schedule/View+ShowScheduleFilter.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+extension View {
+    
+    func showScheduleFilter(_ show: Bool) -> some View {
+        self
+            .environment(\.showScheduleFilterButton, show)
+    }
+    
+}
+
+extension EnvironmentValues {
+    
+    var showScheduleFilterButton: Bool {
+        get {
+            self[ShowScheduleFilterButtonEnvironmentKey.self]
+        }
+        set {
+            self[ShowScheduleFilterButtonEnvironmentKey.self] = newValue
+        }
+    }
+    
+    private struct ShowScheduleFilterButtonEnvironmentKey: EnvironmentKey {
+        
+        typealias Value = Bool
+        
+        static var defaultValue = true
+        
+    }
+    
+}

--- a/Packages/EurofurenceKit/Sources/EurofurenceKit/Controllers/Schedule.swift
+++ b/Packages/EurofurenceKit/Sources/EurofurenceKit/Controllers/Schedule.swift
@@ -117,6 +117,7 @@ public class Schedule: NSObject, ObservableObject {
         self.configuration = configuration
         self.managedObjectContext = managedObjectContext
         self.clock = clock
+        self.favouritesOnly = configuration.favouritesOnly
         
         super.init()
         

--- a/Packages/EurofurenceKit/Sources/EurofurenceKit/Controllers/Schedule.swift
+++ b/Packages/EurofurenceKit/Sources/EurofurenceKit/Controllers/Schedule.swift
@@ -59,6 +59,13 @@ public class Schedule: NSObject, ObservableObject {
     /// A localized description of the filter.
     @Published public private(set) var localizedFilterDescription: String?
     
+    /// A flag to designate whether the schedule should only contain events the user has favourited.
+    @Published public var favouritesOnly: Bool = false {
+        didSet {
+            refetchEvents()
+        }
+    }
+    
     /// A textual query to apply for filtering against this schedule.
     @Published public var query: String = "" {
         didSet {
@@ -208,6 +215,10 @@ public class Schedule: NSObject, ObservableObject {
     
     private func makeFetchingPredicate() -> NSPredicate {
         var predicates = [NSPredicate]()
+        
+        if favouritesOnly {
+            predicates.append(NSPredicate(format: "isFavourite == YES"))
+        }
         
         if query.isEmpty == false {
             predicates.append(Event.predicateForTextualSearch(query: query))

--- a/Packages/EurofurenceKit/Sources/EurofurenceKit/Entities/Event.swift
+++ b/Packages/EurofurenceKit/Sources/EurofurenceKit/Entities/Event.swift
@@ -28,6 +28,7 @@ public class Event: Entity {
     @NSManaged public var track: Track
     @NSManaged public var tags: Set<Tag>
     
+    /// Indicates whether the receiver has been included in the user's collection of favourite events.
     @NSManaged public internal(set) var isFavourite: Bool
     
     /// Adds the receiver to the user's collection of favourited events.

--- a/Packages/EurofurenceKit/Sources/EurofurenceKit/Entities/Event.swift
+++ b/Packages/EurofurenceKit/Sources/EurofurenceKit/Entities/Event.swift
@@ -54,7 +54,8 @@ public class Event: Entity {
         
         do {
             try await writingContext.performAsync { [writingContext] in
-                let writableEvent = writingContext.object(with: eventID) as! Event
+                guard let writableEvent = writingContext.object(with: eventID) as? Event else { return }
+                
                 writableEvent.isFavourite = newState
                 try writingContext.save()
             }

--- a/Packages/EurofurenceKit/Sources/EurofurenceKit/EurofurenceModel+Schedule.swift
+++ b/Packages/EurofurenceKit/Sources/EurofurenceKit/EurofurenceModel+Schedule.swift
@@ -10,15 +10,18 @@ extension EurofurenceModel {
         let day: Day?
         let track: Track?
         let room: Room?
+        let favouritesOnly: Bool
         
         public init(
             day: Day? = nil,
             track: Track? = nil,
-            room: Room? = nil
+            room: Room? = nil,
+            favouritesOnly: Bool = false
         ) {
             self.day = day
             self.track = track
             self.room = room
+            self.favouritesOnly = favouritesOnly
         }
         
     }

--- a/Packages/EurofurenceKit/Sources/EurofurenceKit/Model.xcdatamodeld/Model.xcdatamodel/contents
+++ b/Packages/EurofurenceKit/Sources/EurofurenceKit/Model.xcdatamodeld/Model.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21279" systemVersion="21G83" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21279" systemVersion="21G115" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Announcement" representedClassName="Announcement" parentEntity="Entity" syncable="YES">
         <attribute name="area" attributeType="String"/>
         <attribute name="author" attributeType="String"/>
@@ -69,6 +69,7 @@
         <attribute name="deviatingFromConbook" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="endDate" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="eventDescription" attributeType="String"/>
+        <attribute name="isFavourite" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="slug" attributeType="String"/>
         <attribute name="startDate" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="subtitle" attributeType="String"/>

--- a/Packages/EurofurenceKit/Sources/EurofurenceKit/SwiftUI/Views/EurofurenceKitImage.swift
+++ b/Packages/EurofurenceKit/Sources/EurofurenceKit/SwiftUI/Views/EurofurenceKitImage.swift
@@ -18,6 +18,7 @@ public struct EurofurenceKitImage: View {
                 .resizable()
                 .aspectRatio(contentMode: .fit)
                 .cornerRadius(7)
+                .allowsHitTesting(permitsFullscreenInteraction)
                 .onTapGesture {
                     if permitsFullscreenInteraction {
                         isShowingFullScreen = true

--- a/Packages/EurofurenceKit/Sources/EurofurenceKit/SwiftUI/Views/FavouriteIcon.swift
+++ b/Packages/EurofurenceKit/Sources/EurofurenceKit/SwiftUI/Views/FavouriteIcon.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+/// An icon used to denote favourites, and infer favourite state.
+public struct FavouriteIcon: View {
+    
+    private let filled: Bool
+    
+    public init(filled: Bool) {
+        self.filled = filled
+    }
+    
+    public var body: some View {
+        SwiftUI.Image(systemName: filled ? "heart.fill" : "heart")
+            .foregroundColor(.red)
+    }
+    
+}
+
+struct FavouriteIcon_Previews: PreviewProvider {
+    
+    static var previews: some View {
+        FavouriteIcon(filled: false)
+            .previewDisplayName("Unfilled")
+            .previewLayout(.sizeThatFits)
+        
+        FavouriteIcon(filled: true)
+            .previewDisplayName("Filled")
+            .previewLayout(.sizeThatFits)
+    }
+    
+}

--- a/Packages/EurofurenceKit/Sources/EurofurenceKit/SwiftUI/Views/Modal Image/PannableFullScreenImage.swift
+++ b/Packages/EurofurenceKit/Sources/EurofurenceKit/SwiftUI/Views/Modal Image/PannableFullScreenImage.swift
@@ -8,7 +8,7 @@ struct PannableFullScreenImage<Content>: View where Content: View {
     @Binding var isPresented: Bool
     @State private var isSourceForMatchedGeometricTransition = false
     
-    private let magnificationScaleLimit: CGFloat = 3
+    private let magnificationLimit: CGFloat = 3
     @State private var currentImageViewSize: CGSize = .zero
     
     @State private var magnification = 1.0
@@ -56,7 +56,7 @@ struct PannableFullScreenImage<Content>: View where Content: View {
                             }
                             .onEnded { scale in
                                 withAnimation {
-                                    let totalMagnificiation = max(min(magnificationScaleLimit, magnification * scale), 1)
+                                    let totalMagnificiation = max(min(magnificationLimit, magnification * scale), 1)
                                     magnification = totalMagnificiation
                                     inProgressMagnification = 1
                                 }

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Model Ingestion/Event/EventTests.swift
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Model Ingestion/Event/EventTests.swift
@@ -12,9 +12,9 @@ class EventTests: EurofurenceKitTestCase {
         let dealersDen = try scenario.model.event(identifiedBy: dealersDenID)
         XCTAssertFalse(dealersDen.isFavourite, "Events should not default to be in the user's favourites")
         
-        var changed = false
+        let changedExpectation = expectation(description: "Expected object to notify it has changed")
         let eventWillChangeSubscription = dealersDen.objectWillChange.sink { _ in
-            changed = true
+            changedExpectation.fulfill()
         }
         
         addTeardownBlock {
@@ -24,7 +24,7 @@ class EventTests: EurofurenceKitTestCase {
         await dealersDen.favourite()
         
         XCTAssertTrue(dealersDen.isFavourite, "Event should be marked as favourite after actioning the favourite")
-        XCTAssertTrue(changed, "Favouriting an event should trigger an update notification")
+        waitForExpectations(timeout: 0.5)
     }
     
     func testFavouritingAnAlreadyFavouritedEventDoesNotPostUpdateNotification() async throws {
@@ -33,13 +33,12 @@ class EventTests: EurofurenceKitTestCase {
         
         let dealersDenID = "18ab1606-506e-4b7c-b1db-4d3dad0e7c20"
         let dealersDen = try scenario.model.event(identifiedBy: dealersDenID)
-        XCTAssertFalse(dealersDen.isFavourite, "Events should not default to be in the user's favourites")
-        
         await dealersDen.favourite()
         
-        var changed = false
+        let changedExpectation = expectation(description: "Did not expect object to notify it has changed")
+        changedExpectation.isInverted = true
         let eventWillChangeSubscription = dealersDen.objectWillChange.sink { _ in
-            changed = true
+            changedExpectation.fulfill()
         }
         
         addTeardownBlock {
@@ -48,10 +47,52 @@ class EventTests: EurofurenceKitTestCase {
         
         await dealersDen.favourite()
         
-        XCTAssertFalse(
-            changed,
-            "Favouriting an event that is already a favourite should not post a change notification"
-        )
+        waitForExpectations(timeout: 0.5)
+    }
+    
+    func testUnfavouritingEventRemovesFavouriteMarkerAndPostsUpdateNotification() async throws {
+        let scenario = await EurofurenceModelTestBuilder().build()
+        try await scenario.updateLocalStore(using: .ef26)
+        
+        let dealersDenID = "18ab1606-506e-4b7c-b1db-4d3dad0e7c20"
+        let dealersDen = try scenario.model.event(identifiedBy: dealersDenID)
+        await dealersDen.favourite()
+        
+        let changedExpectation = expectation(description: "Expected object to notify it has changed")
+        let eventWillChangeSubscription = dealersDen.objectWillChange.sink { _ in
+            changedExpectation.fulfill()
+        }
+        
+        addTeardownBlock {
+            eventWillChangeSubscription.cancel()
+        }
+        
+        await dealersDen.unfavourite()
+        
+        XCTAssertFalse(dealersDen.isFavourite, "Unfavouriting an event should not maintain the favourite marker")
+        waitForExpectations(timeout: 0.5)
+    }
+    
+    func testUnfavouritingEventThatIsNotFavouritedDoesNotPostUpdateNotification() async throws {
+        let scenario = await EurofurenceModelTestBuilder().build()
+        try await scenario.updateLocalStore(using: .ef26)
+        
+        let dealersDenID = "18ab1606-506e-4b7c-b1db-4d3dad0e7c20"
+        let dealersDen = try scenario.model.event(identifiedBy: dealersDenID)
+        
+        let changedExpectation = expectation(description: "Did not expect object to notify it has changed")
+        changedExpectation.isInverted = true
+        let eventWillChangeSubscription = dealersDen.objectWillChange.sink { _ in
+            changedExpectation.fulfill()
+        }
+        
+        addTeardownBlock {
+            eventWillChangeSubscription.cancel()
+        }
+        
+        await dealersDen.unfavourite()
+        
+        waitForExpectations(timeout: 0.5)
     }
 
 }

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Model Ingestion/Event/EventTests.swift
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Model Ingestion/Event/EventTests.swift
@@ -1,0 +1,57 @@
+@testable import EurofurenceKit
+import EurofurenceWebAPI
+import XCTest
+
+class EventTests: EurofurenceKitTestCase {
+    
+    func testFavouritingEventMarksEventAsFavouriteWithObjectWillChangeEvent() async throws {
+        let scenario = await EurofurenceModelTestBuilder().build()
+        try await scenario.updateLocalStore(using: .ef26)
+        
+        let dealersDenID = "18ab1606-506e-4b7c-b1db-4d3dad0e7c20"
+        let dealersDen = try scenario.model.event(identifiedBy: dealersDenID)
+        XCTAssertFalse(dealersDen.isFavourite, "Events should not default to be in the user's favourites")
+        
+        var changed = false
+        let eventWillChangeSubscription = dealersDen.objectWillChange.sink { _ in
+            changed = true
+        }
+        
+        addTeardownBlock {
+            eventWillChangeSubscription.cancel()
+        }
+        
+        await dealersDen.favourite()
+        
+        XCTAssertTrue(dealersDen.isFavourite, "Event should be marked as favourite after actioning the favourite")
+        XCTAssertTrue(changed, "Favouriting an event should trigger an update notification")
+    }
+    
+    func testFavouritingAnAlreadyFavouritedEventDoesNotPostUpdateNotification() async throws {
+        let scenario = await EurofurenceModelTestBuilder().build()
+        try await scenario.updateLocalStore(using: .ef26)
+        
+        let dealersDenID = "18ab1606-506e-4b7c-b1db-4d3dad0e7c20"
+        let dealersDen = try scenario.model.event(identifiedBy: dealersDenID)
+        XCTAssertFalse(dealersDen.isFavourite, "Events should not default to be in the user's favourites")
+        
+        await dealersDen.favourite()
+        
+        var changed = false
+        let eventWillChangeSubscription = dealersDen.objectWillChange.sink { _ in
+            changed = true
+        }
+        
+        addTeardownBlock {
+            eventWillChangeSubscription.cancel()
+        }
+        
+        await dealersDen.favourite()
+        
+        XCTAssertFalse(
+            changed,
+            "Favouriting an event that is already a favourite should not post a change notification"
+        )
+    }
+
+}

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Model Ingestion/Schedule/ScheduleTests.swift
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Model Ingestion/Schedule/ScheduleTests.swift
@@ -436,6 +436,28 @@ class ScheduleTests: EurofurenceKitTestCase {
         assertContainsEventsGroupedByDay(schedule: schedule)
     }
     
+    func testFilteringToFavouritesRemovesNonFavouritedEvents() async throws {
+        let scenario = await EurofurenceModelTestBuilder().build()
+        try await scenario.updateLocalStore(using: .ef26)
+        let schedule = scenario.model.makeSchedule()
+        
+        let firstFurryConventionID = "ff714ae4-a165-4cbd-a0e1-74773620203a"
+        let firstFurryConvention = try scenario.model.event(identifiedBy: firstFurryConventionID)
+        await firstFurryConvention.favourite()
+        schedule.favouritesOnly = true
+        
+        if let group = schedule.eventGroups.first {
+            XCTAssertEqual(1, group.elements.count, "Expected one result matching the search")
+            XCTAssertEqual(
+                "ff714ae4-a165-4cbd-a0e1-74773620203a",
+                group.elements.first?.identifier,
+                "Expected to match the specific favourited event only"
+            )
+        }
+        
+        assertContainsEventsGroupedByDay(schedule: schedule)
+    }
+    
     private func assertContainsEventsGroupedByDay(
         schedule: Schedule,
         room: EurofurenceKit.Room? = nil,

--- a/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Model Ingestion/Schedule/ScheduleTests.swift
+++ b/Packages/EurofurenceKit/Tests/EurofurenceKitTests/Model Ingestion/Schedule/ScheduleTests.swift
@@ -436,6 +436,29 @@ class ScheduleTests: EurofurenceKitTestCase {
         assertContainsEventsGroupedByDay(schedule: schedule)
     }
     
+    func testScheduleConfiguredOnlyForFavouritesOnlyShowsFavouritedEvent() async throws {
+        let scenario = await EurofurenceModelTestBuilder().build()
+        try await scenario.updateLocalStore(using: .ef26)
+        
+        let firstFurryConventionID = "ff714ae4-a165-4cbd-a0e1-74773620203a"
+        let firstFurryConvention = try scenario.model.event(identifiedBy: firstFurryConventionID)
+        await firstFurryConvention.favourite()
+        
+        let favouritesOnlyConfiguration = EurofurenceModel.ScheduleConfiguration(favouritesOnly: true)
+        let schedule = scenario.model.makeSchedule(configuration: favouritesOnlyConfiguration)
+        
+        if let group = schedule.eventGroups.first {
+            XCTAssertEqual(1, group.elements.count, "Expected one result matching the search")
+            XCTAssertEqual(
+                "ff714ae4-a165-4cbd-a0e1-74773620203a",
+                group.elements.first?.identifier,
+                "Expected to match the specific favourited event only"
+            )
+        }
+        
+        assertContainsEventsGroupedByDay(schedule: schedule)
+    }
+    
     func testFilteringToFavouritesRemovesNonFavouritedEvents() async throws {
         let scenario = await EurofurenceModelTestBuilder().build()
         try await scenario.updateLocalStore(using: .ef26)


### PR DESCRIPTION
Enables toggling of favourite state from listing or detail view, and disclosure of favourites-specific listing.