### PR TITLE
Bugfix/ef27 dealer weekdays

### DIFF
--- a/Packages/EurofurenceComponents/Sources/DealerComponent/View Model/DefaultDealerDetailViewModel.swift
+++ b/Packages/EurofurenceComponents/Sources/DealerComponent/View Model/DefaultDealerDetailViewModel.swift
@@ -193,28 +193,27 @@ struct DefaultDealerDetailViewModel: DealerDetailViewModel {
         
         var days = [String]()
 
-        if !data.isAttendingOnThursday {
-            days = ["Friday", "Saturday"]
+        // TODO: Improve model (and backend API) to support arbitrary weekdays
+        /*
+         EF27 starts on Sunday instead of Wednesday, thus DD is open Monday to Wednesday instead of Thursday to Saturday:
+         Thursday -> Monday
+         Friday   -> Tuesday
+         Saturday -> Wednesday
+         */
+        if data.isAttendingOnThursday {
+            // TODO: EF27 weekdays
+            // days.append("Thursday")
+            days.append("Monday")
         }
-
-        if !data.isAttendingOnFriday {
-            days = ["Thursday", "Saturday"]
+        if data.isAttendingOnFriday {
+            // TODO: EF27 weekdays
+            // days.append("Friday")
+            days.append("Tuesday")
         }
-
-        if !data.isAttendingOnSaturday {
-            days = ["Thursday", "Friday"]
-        }
-
-        if !data.isAttendingOnFriday && !data.isAttendingOnSaturday {
-            days = ["Thursday"]
-        }
-
-        if !data.isAttendingOnThursday && !data.isAttendingOnSaturday {
-            days = ["Friday"]
-        }
-
-        if !data.isAttendingOnThursday && !data.isAttendingOnFriday {
-            days = ["Saturday"]
+        if data.isAttendingOnSaturday {
+            // TODO: EF27 weekdays
+            // days.append("Saturday")
+            days.append("Wednesday")
         }
 
         if days.isEmpty {

--- a/Packages/EurofurenceComponents/Sources/DealerComponent/View Model/DefaultDealerDetailViewModel.swift
+++ b/Packages/EurofurenceComponents/Sources/DealerComponent/View Model/DefaultDealerDetailViewModel.swift
@@ -191,6 +191,10 @@ struct DefaultDealerDetailViewModel: DealerDetailViewModel {
             comment: "Text displayed with the days during the convention a dealer is present for, e.g. 'Thursday'"
         )
         
+        if data.isAttendingOnThursday && data.isAttendingOnFriday && data.isAttendingOnSaturday {
+            return nil
+        }
+        
         var days = [String]()
 
         // TODO: Improve model (and backend API) to support arbitrary weekdays

--- a/Packages/EurofurenceComponents/Sources/DealersComponent/View Model/DefaultDealersViewModelFactory.swift
+++ b/Packages/EurofurenceComponents/Sources/DealersComponent/View Model/DefaultDealersViewModelFactory.swift
@@ -212,9 +212,11 @@ public struct DefaultDealersViewModelFactory: DealersViewModelFactory, DealersIn
 
             title = dealer.preferredName
             subtitle = dealer.alternateName
-            isPresentForAllDays = dealer.isAttendingOnThursday &&
+            isPresentForAllDays = (dealer.isAttendingOnThursday &&
                                   dealer.isAttendingOnFriday &&
-                                  dealer.isAttendingOnSaturday
+                                  dealer.isAttendingOnSaturday) || (!dealer.isAttendingOnThursday &&
+                                                                   !dealer.isAttendingOnFriday &&
+                                                                   !dealer.isAttendingOnSaturday)
             isAfterDarkContentPresent = dealer.isAfterDark
         }
 

--- a/Packages/EurofurenceComponents/Tests/DealerComponentTests/View Model Tests/WhenProducingDealerViewModel_HappyPath_DealerDetailViewModelFactoryShould.swift
+++ b/Packages/EurofurenceComponents/Tests/DealerComponentTests/View Model Tests/WhenProducingDealerViewModel_HappyPath_DealerDetailViewModelFactoryShould.swift
@@ -61,7 +61,9 @@ class WhenProducingDealerViewModel_HappyPath_DealerDetailViewModelFactoryShould:
         extendedDealerData.isAttendingOnSaturday = true
         extendedDealerData.isAfterDark = false
         
-        let limitedAvailabilityWarning = makeExpectedLimitedAvailabilityWarning(["Friday", "Saturday"])
+        // TODO: EF27 weekdays
+        // let limitedAvailabilityWarning = makeExpectedLimitedAvailabilityWarning(["Friday", "Saturday"])
+        let limitedAvailabilityWarning = makeExpectedLimitedAvailabilityWarning(["Tueday", "Wednesday"])
         assertDealerData(
             extendedDealerData,
             produces: DealerDetailLocationAndAvailabilityViewModel(
@@ -80,7 +82,9 @@ class WhenProducingDealerViewModel_HappyPath_DealerDetailViewModelFactoryShould:
         extendedDealerData.isAttendingOnSaturday = true
         extendedDealerData.isAfterDark = false
         
-        let limitedAvailabilityWarning = makeExpectedLimitedAvailabilityWarning(["Thursday", "Saturday"])
+        // TODO: EF27 weekdays
+        // let limitedAvailabilityWarning = makeExpectedLimitedAvailabilityWarning(["Thursday", "Saturday"])
+        let limitedAvailabilityWarning = makeExpectedLimitedAvailabilityWarning(["Monday", "Wednesday"])
         assertDealerData(
             extendedDealerData,
             produces: DealerDetailLocationAndAvailabilityViewModel(
@@ -99,7 +103,9 @@ class WhenProducingDealerViewModel_HappyPath_DealerDetailViewModelFactoryShould:
         extendedDealerData.isAttendingOnSaturday = false
         extendedDealerData.isAfterDark = false
         
-        let limitedAvailabilityWarning = makeExpectedLimitedAvailabilityWarning(["Thursday", "Friday"])
+        // TODO: EF27 weekdays
+        // let limitedAvailabilityWarning = makeExpectedLimitedAvailabilityWarning(["Thursday", "Friday"])
+        let limitedAvailabilityWarning = makeExpectedLimitedAvailabilityWarning(["Monday", "Tuesday"])
         assertDealerData(
             extendedDealerData,
             produces: DealerDetailLocationAndAvailabilityViewModel(
@@ -118,7 +124,9 @@ class WhenProducingDealerViewModel_HappyPath_DealerDetailViewModelFactoryShould:
         extendedDealerData.isAttendingOnSaturday = false
         extendedDealerData.isAfterDark = false
         
-        let limitedAvailabilityWarning = makeExpectedLimitedAvailabilityWarning(["Thursday"])
+        // TODO: EF27 weekdays
+        // let limitedAvailabilityWarning = makeExpectedLimitedAvailabilityWarning(["Thursday"])
+        let limitedAvailabilityWarning = makeExpectedLimitedAvailabilityWarning(["Monday"])
         assertDealerData(
             extendedDealerData,
             produces: DealerDetailLocationAndAvailabilityViewModel(
@@ -137,7 +145,9 @@ class WhenProducingDealerViewModel_HappyPath_DealerDetailViewModelFactoryShould:
         extendedDealerData.isAttendingOnSaturday = false
         extendedDealerData.isAfterDark = false
         
-        let limitedAvailabilityWarning = makeExpectedLimitedAvailabilityWarning(["Friday"])
+        // TODO: EF27 weekdays
+        // let limitedAvailabilityWarning = makeExpectedLimitedAvailabilityWarning(["Friday"])
+        let limitedAvailabilityWarning = makeExpectedLimitedAvailabilityWarning(["Tuesday"])
         assertDealerData(
             extendedDealerData,
             produces: DealerDetailLocationAndAvailabilityViewModel(
@@ -156,7 +166,9 @@ class WhenProducingDealerViewModel_HappyPath_DealerDetailViewModelFactoryShould:
         extendedDealerData.isAttendingOnSaturday = true
         extendedDealerData.isAfterDark = false
         
-        let limitedAvailabilityWarning = makeExpectedLimitedAvailabilityWarning(["Saturday"])
+        // TODO: EF27 weekdays
+        // let limitedAvailabilityWarning = makeExpectedLimitedAvailabilityWarning(["Saturday"])
+        let limitedAvailabilityWarning = makeExpectedLimitedAvailabilityWarning(["Wednesday"])
         assertDealerData(
             extendedDealerData,
             produces: DealerDetailLocationAndAvailabilityViewModel(

--- a/Packages/EurofurenceComponents/Tests/DealerComponentTests/View Model Tests/WhenProducingDealerViewModel_HappyPath_DealerDetailViewModelFactoryShould.swift
+++ b/Packages/EurofurenceComponents/Tests/DealerComponentTests/View Model Tests/WhenProducingDealerViewModel_HappyPath_DealerDetailViewModelFactoryShould.swift
@@ -81,7 +81,7 @@ class WhenProducingDealerViewModel_HappyPath_DealerDetailViewModelFactoryShould:
         
         // TODO: EF27 weekdays
         // let limitedAvailabilityWarning = makeExpectedLimitedAvailabilityWarning(["Friday", "Saturday"])
-        let limitedAvailabilityWarning = makeExpectedLimitedAvailabilityWarning(["Tueday", "Wednesday"])
+        let limitedAvailabilityWarning = makeExpectedLimitedAvailabilityWarning(["Tuesday", "Wednesday"])
         assertDealerData(
             extendedDealerData,
             produces: DealerDetailLocationAndAvailabilityViewModel(

--- a/Packages/EurofurenceComponents/Tests/DealerComponentTests/View Model Tests/WhenProducingDealerViewModel_HappyPath_DealerDetailViewModelFactoryShould.swift
+++ b/Packages/EurofurenceComponents/Tests/DealerComponentTests/View Model Tests/WhenProducingDealerViewModel_HappyPath_DealerDetailViewModelFactoryShould.swift
@@ -53,7 +53,25 @@ class WhenProducingDealerViewModel_HappyPath_DealerDetailViewModelFactoryShould:
             )
         )
     }
-
+    
+    func testProduceExpectedLocationAndAvailability_WhenNotAvailableOnAnyDay_AndNotInAfterDarkDen_AtIndexOne() {
+        var extendedDealerData = ExtendedDealerData.random
+        extendedDealerData.isAttendingOnThursday = false
+        extendedDealerData.isAttendingOnFriday = false
+        extendedDealerData.isAttendingOnSaturday = false
+        extendedDealerData.isAfterDark = false
+        
+        assertDealerData(
+            extendedDealerData,
+            produces: DealerDetailLocationAndAvailabilityViewModel(
+                title: "Location and Availability",
+                mapPNGGraphicData: extendedDealerData.dealersDenMapLocationGraphicPNGData,
+                limitedAvailabilityWarning: nil,
+                locatedInAfterDarkDealersDenMessage: nil
+            )
+        )
+    }
+    
     func testProduceExpectedLocationAndAvailability_WhenNotAvailableOnThursday_AndNotInAfterDarkDen_AtIndexOne() {
         var extendedDealerData = ExtendedDealerData.random
         extendedDealerData.isAttendingOnThursday = false

--- a/Packages/EurofurenceComponents/Tests/DealersComponentTests/View Model Tests/WhenResolvingDealerAvailability_DealersViewModelFactoryShould.swift
+++ b/Packages/EurofurenceComponents/Tests/DealersComponentTests/View Model Tests/WhenResolvingDealerAvailability_DealersViewModelFactoryShould.swift
@@ -14,6 +14,13 @@ class WhenResolvingDealerAvailability_DealersViewModelFactoryShould: XCTestCase 
         )
         
         assertIsPresentForAllDays(
+            true,
+            isAttendingOnThursday: false,
+            isAttendingOnFriday: false,
+            isAttendingOnSaturday: false
+        )
+        
+        assertIsPresentForAllDays(
             false,
             isAttendingOnThursday: false,
             isAttendingOnFriday: true,


### PR DESCRIPTION
Fix issues introduced to the Dealers views by the API model with fixed weekdays and EF27 taking place on different weekdays than previous EFs (i.e. Dealers' Den on Monday, Tuesday, Wednesday instead of Wednesday, Friday, Saturday).