### PR TITLE
Prepare Screenshots for EF27

### DIFF
--- a/EurofurenceUITests/UI Automation/AutomationController.swift
+++ b/EurofurenceUITests/UI Automation/AutomationController.swift
@@ -45,9 +45,16 @@ extension AutomationController {
         } while waitingForTabItemToAppear && totalWaitTimeSeconds < threeMinutes
     }
     
-    func transitionToKnownEvent() throws {
+    func prepareFavouriteEvents() throws {
+        tapTab(.schedule)
         app.buttons["Tue 5"].tap()
-        try waitForCellWithText("Furry Tails Theater")
+        try swipeLeftCellWithText("Furry Tails Theater")
+        app.buttons["Favourite"].tap()
+        app.buttons["Tue 5"].tap()
+    }
+    
+    func tapKnownFavouriteEvent() throws {
+        try tapCellWithText("Furry Tails Theater")
     }
     
     func tapKnownEvent() throws {
@@ -59,10 +66,6 @@ extension AutomationController {
     
     func tapKnownDealer() throws {
         try tapCellWithText("Eurofurence Convention Store")
-    }
-    
-    func transitionToKnownDealer() throws {
-        try waitForCellWithText("Eurofurence Convention Store")
     }
     
     func tapKnownKnowledgeGroup() throws {
@@ -118,6 +121,7 @@ extension AutomationController {
     
     enum Tab {
         
+        case news
         case schedule
         case dealers
         case information
@@ -129,6 +133,8 @@ extension AutomationController {
         
         private var identifier: String {
             switch self {
+            case .news:
+                return "News"
             case .schedule:
                 return "Schedule"
             case .dealers:
@@ -179,13 +185,18 @@ extension AutomationController {
         textElement.tap()
     }
     
+    func swipeLeftCellWithText(_ text: String) throws {
+        let textElement = try waitForCellWithText(text)
+        textElement.swipeLeft(velocity: XCUIGestureVelocity(integerLiteral: 400))
+    }
+    
     private var verticalSwipeVelocity: XCUIGestureVelocity {
         switch XCUIDevice.shared.orientation {
         case .landscapeLeft, .landscapeRight:
-            return 250
+            return 400
             
         default:
-            return 450
+            return 500
         }
     }
     

--- a/EurofurenceUITests/UI Automation/AutomationController.swift
+++ b/EurofurenceUITests/UI Automation/AutomationController.swift
@@ -45,6 +45,11 @@ extension AutomationController {
         } while waitingForTabItemToAppear && totalWaitTimeSeconds < threeMinutes
     }
     
+    func transitionToKnownEvent() throws {
+        app.buttons["Tue 5"].tap()
+        try waitForCellWithText("Furry Tails Theater")
+    }
+    
     func tapKnownEvent() throws {
         // We know this event has a good amount of text for most devices for testing (bar a larger iPad).
         // This may need to change as more event info pops through for EF26.
@@ -53,9 +58,11 @@ extension AutomationController {
     }
     
     func tapKnownDealer() throws {
-        try XCTSkipIf(true, "The API does not yield dealers at the moment. Dealer based UI tests are disabled.")
-        
-        try tapCellWithText("Eurofurence Shop")
+        try tapCellWithText("Eurofurence Convention Store")
+    }
+    
+    func transitionToKnownDealer() throws {
+        try waitForCellWithText("Eurofurence Convention Store")
     }
     
     func tapKnownKnowledgeGroup() throws {
@@ -63,6 +70,9 @@ extension AutomationController {
         try tapCellWithText("Eurofurence on Social Media")
     }
     
+    func tapKnownMap() throws {
+        app.staticTexts["CCH & Radisson Venue"].tap()
+    }
 }
 
 // MARK: - Finding Elements
@@ -111,6 +121,7 @@ extension AutomationController {
         case schedule
         case dealers
         case information
+        case maps
         
         fileprivate func tap(in application: XCUIApplication) {
             application.tabBars.buttons[identifier].tap()
@@ -124,6 +135,8 @@ extension AutomationController {
                 return "Dealers"
             case .information:
                 return "Information"
+            case .maps:
+                return "Maps"
             }
         }
         
@@ -172,7 +185,7 @@ extension AutomationController {
             return 250
             
         default:
-            return 400
+            return 450
         }
     }
     

--- a/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/News/Component/CompositionalNewsComponentDefaultWidgetsBuilder.swift
+++ b/Packages/EurofurenceApplication/Sources/EurofurenceApplication/Application/Components/News/Component/CompositionalNewsComponentDefaultWidgetsBuilder.swift
@@ -19,8 +19,8 @@ struct CompositionalNewsComponentDefaultWidgetsBuilder {
         addCountdownWidget()
         addAnnouncementsWidget()
         addUpcomingEventsWidget()
-        addRunningEventsWidget()
         addTodaysFavouriteEventsWidget()
+        addRunningEventsWidget()
         
         return builder.build()
     }

--- a/Screenshots/ScreenshotGenerator.swift
+++ b/Screenshots/ScreenshotGenerator.swift
@@ -36,12 +36,16 @@ class ScreenshotGenerator: XCTestCase {
     }
     
     private func takePhoneScreenshots() throws {
+        // Force refresh to ensure updated data if app was already installed on simulator
         app.tables.cells.firstMatch.press(forDuration: TimeInterval(integerLiteral: 1),
                                           thenDragTo: app.tabBars.firstMatch)
+        try automationController.prepareFavouriteEvents()
+        
+        automationController.tapTab(.news)
         snapshot("01_News")
 
         automationController.tapTab(.schedule)
-        try automationController.transitionToKnownEvent()
+        app.tables.firstMatch.swipeDown()
         
         snapshot("02_Schedule")
         
@@ -50,7 +54,7 @@ class ScreenshotGenerator: XCTestCase {
         snapshot("03_EventDetail")
         
         automationController.tapTab(.dealers)
-        try automationController.transitionToKnownDealer()
+        app.tables.firstMatch.swipeDown()
         
         snapshot("04_Dealers")
         
@@ -74,6 +78,9 @@ class ScreenshotGenerator: XCTestCase {
     private func takeTabletScreenshots() throws {
         app.tables.cells.firstMatch.press(forDuration: TimeInterval(integerLiteral: 1),
                                           thenDragTo: app.tabBars.firstMatch)
+        try automationController.prepareFavouriteEvents()
+        try automationController.tapKnownFavouriteEvent()
+        
         snapshot("01_News")
 
         automationController.tapTab(.schedule)
@@ -82,7 +89,6 @@ class ScreenshotGenerator: XCTestCase {
         snapshot("02_Schedule")
         
         automationController.tapTab(.dealers)
-        try automationController.transitionToKnownDealer()
         try automationController.tapKnownDealer()
         
         snapshot("03_Dealers")

--- a/Screenshots/ScreenshotGenerator.swift
+++ b/Screenshots/ScreenshotGenerator.swift
@@ -36,11 +36,12 @@ class ScreenshotGenerator: XCTestCase {
     }
     
     private func takePhoneScreenshots() throws {
+        app.tables.cells.firstMatch.press(forDuration: TimeInterval(integerLiteral: 1),
+                                          thenDragTo: app.tabBars.firstMatch)
         snapshot("01_News")
 
         automationController.tapTab(.schedule)
-        
-        app.tables.firstMatch.swipeDown()
+        try automationController.transitionToKnownEvent()
         
         snapshot("02_Schedule")
         
@@ -49,7 +50,7 @@ class ScreenshotGenerator: XCTestCase {
         snapshot("03_EventDetail")
         
         automationController.tapTab(.dealers)
-        app.tables.firstMatch.swipeDown()
+        try automationController.transitionToKnownDealer()
         
         snapshot("04_Dealers")
         
@@ -64,30 +65,37 @@ class ScreenshotGenerator: XCTestCase {
         try automationController.tapKnownKnowledgeGroup()
         
         snapshot("07_SocialMedia")
+        
+        automationController.tapTab(.maps)
+        
+        snapshot("08_Maps")
     }
     
     private func takeTabletScreenshots() throws {
+        app.tables.cells.firstMatch.press(forDuration: TimeInterval(integerLiteral: 1),
+                                          thenDragTo: app.tabBars.firstMatch)
         snapshot("01_News")
 
         automationController.tapTab(.schedule)
-        
-        app.tables.firstMatch.swipeDown()
-        
         try automationController.tapKnownEvent()
         
         snapshot("02_Schedule")
         
         automationController.tapTab(.dealers)
-        
+        try automationController.transitionToKnownDealer()
         try automationController.tapKnownDealer()
         
         snapshot("03_Dealers")
         
         automationController.tapTab(.information)
-        
         try automationController.tapKnownKnowledgeGroup()
         
         snapshot("04_Information")
+        
+        automationController.tapTab(.maps)
+        try automationController.tapKnownMap()
+        
+        snapshot("05_Maps")
     }
 
 }

--- a/Screenshots/SnapshotHelper.swift
+++ b/Screenshots/SnapshotHelper.swift
@@ -181,7 +181,7 @@ open class Snapshot: NSObject {
 
                 let path = screenshotsDir.appendingPathComponent("\(simulator)-\(name).png")
                 #if swift(<5.0)
-                    UIImagePNGRepresentation(image)?.write(to: path, options: .atomic)
+                    try UIImagePNGRepresentation(image)?.write(to: path, options: .atomic)
                 #else
                     try image.pngData()?.write(to: path, options: .atomic)
                 #endif
@@ -306,4 +306,4 @@ private extension CGFloat {
 
 // Please don't remove the lines below
 // They are used to detect outdated configuration files
-// SnapshotHelperVersion [1.28]
+// SnapshotHelperVersion [1.29]

--- a/fastlane/Snapfile
+++ b/fastlane/Snapfile
@@ -1,21 +1,17 @@
 devices([
    "iPhone SE (3rd generation)",
-   "iPhone 8",
-   "iPhone 8 Plus",
-   "iPhone 13",
-   "iPhone 13 Pro Max",
+   "iPhone 14",
+   "iPhone 14 Pro Max",
 
-   "iPad Pro (9.7-inch)",
-   "iPad Pro (11-inch) (3rd generation)",
-   "iPad Pro (12.9-inch) (2nd generation)",
-   "iPad Pro (12.9-inch) (5th generation)"
+   "iPad Pro (11-inch) (4th generation)",
+   "iPad Pro (12.9-inch) (6th generation)"
 ])
 
 languages([
   "en-US"
 ])
 
-workspace("Eurofurence.xcworkspace")
+project("Eurofurence.xcodeproj")
 scheme("Eurofurence")
 testplan("Screenshots")
 output_directory("./screenshots")

--- a/fastlane/Snapfile
+++ b/fastlane/Snapfile
@@ -1,9 +1,10 @@
 devices([
-   "iPhone SE (3rd generation)",
+   "iPhone 8 Plus",
    "iPhone 14",
    "iPhone 14 Pro Max",
 
    "iPad Pro (11-inch) (4th generation)",
+   "iPad Pro (12.9-inch) (4th generation)",
    "iPad Pro (12.9-inch) (6th generation)"
 ])
 
@@ -16,6 +17,9 @@ scheme("Eurofurence")
 testplan("Screenshots")
 output_directory("./screenshots")
 clear_previous_screenshots(true) 
+reinstall_app(true)
+erase_simulator(true)
+app_identifier("org.eurofurence")
 override_status_bar(true)
-
+concurrent_simulators(3)
 


### PR DESCRIPTION
- Changed the logic by which screenshots are generated slightly to showcase some different things.
- Updated the device list for screenshots.
- Moved the list showing the users' favourite events of the current day above the list of currently running events to make favourites more visible on the news tab.